### PR TITLE
Added multiline-keys support to Flare’s GNU Gettext implementation.

### DIFF
--- a/src/GetText.cpp
+++ b/src/GetText.cpp
@@ -69,6 +69,19 @@ bool GetText::next() {
 
 			if (key != "")
 				continue;
+			else {  // Might be a multi-line key.
+				line = getLine(infile);
+				while(line.find("\"") == 0)
+				{
+					// We remove the double quotes.
+					key += line.substr(1, line.length()-2);
+					line = getLine(infile);
+				}
+				if(key != "") // It was a multi-line value indeed.
+				{
+					continue;
+				}
+			}
 		}
 
 		// this is a value


### PR DESCRIPTION
As promised in #18 — and requested by myself @ https://github.com/clintbellanger/flare/issues/597 — here is the support for multiline keys in PO files.

I had previously added support for multiline values, so I just had to reuse that code a couple of lines higher, and change “val” by “key”.

I have to say that, while I could check it did not broke single-line translation, I could not ensure this actually works: http://opengameart.org/forumtopic/packaging-flare-after-the-gameengine-split
