### PR TITLE
Add example engine config files to default mod

### DIFF
--- a/mods/default/engine/combat.txt
+++ b/mods/default/engine/combat.txt
@@ -1,0 +1,5 @@
+#max_absorb_percent=90
+#max_resist_percent=90
+#max_block_percent=100
+#max_avoidance_percent=99
+

--- a/mods/default/engine/elements.txt
+++ b/mods/default/engine/elements.txt
@@ -1,0 +1,5 @@
+# elemental effects and their display names
+
+#[element]
+#name=fire
+#resist=Fire Resistance

--- a/mods/default/engine/misc.txt
+++ b/mods/default/engine/misc.txt
@@ -1,0 +1,5 @@
+# Miscellaneous engine settings
+
+#save_hpmp=0
+#default_name=
+

--- a/mods/default/engine/tileset_config.txt
+++ b/mods/default/engine/tileset_config.txt
@@ -1,0 +1,10 @@
+# Tileset Settings
+
+#orientation=isometric
+
+# units_per_tile MUST be a power of 2
+# and divisible by both tile dimensions
+#units_per_tile=64
+
+# tile_size: width, height
+#tile_size=64,32


### PR DESCRIPTION
These files are looked for right when the engine starts, so this removes some warning messages that appear when running the game with no mods.
