### PR TITLE
Remove warnings from static code analysis.

### DIFF
--- a/src/AStarNode.cpp
+++ b/src/AStarNode.cpp
@@ -19,31 +19,39 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "AStarNode.h"
 
 AStarNode::AStarNode()
-{
-	this->x = 0;
-	this->y = 0;
-}
+ : x(0)
+ , y(0)
+ , g(0)
+ , h(0)
+ , parent(Point())
+{}
 
 AStarNode::AStarNode(const int a, const int b)
-{
-	this->x = a;
-	this->y = b;
-}
+ : x(a)
+ , y(b)
+ , g(0)
+ , h(0)
+ , parent(Point())
+{}
 
 AStarNode::AStarNode(const Point &p)
+ : x(0)
+ , y(0)
+ , g(0)
+ , h(0)
+ , parent(Point())
 {
-	this->x = p.x;
-	this->y = p.y;
+	parent.x = p.x;
+	parent.y = p.y;
 }
 
 AStarNode::AStarNode(const AStarNode& copy)
-{
-	x = copy.x;
-	y = copy.y;
-	g = copy.g;
-	h = copy.h;
-	parent = copy.parent;
-}
+ : x(copy.x)
+ , y(copy.y)
+ , g(copy.g)
+ , h(copy.h)
+ , parent(Point(copy.parent))
+{}
 
 int AStarNode::getX() const
 {
@@ -53,12 +61,6 @@ int AStarNode::getX() const
 int AStarNode::getY() const
 {
 	return y;
-}
-
-Point AStarNode::getCoordinate() const
-{
-	Point coord = {x,y};
-	return coord;
 }
 
 Point AStarNode::getParent() const
@@ -136,11 +138,6 @@ float AStarNode::getActualCost() const
 void AStarNode::setActualCost(const float G)
 {
 	g = G;
-}
-
-float AStarNode::getEstimatedCost() const
-{
-	return h;
 }
 
 void AStarNode::setEstimatedCost(const float H)

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -20,14 +20,18 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 
 using namespace std;
+	bool new_section;
+	std::string section;
+	std::string key;
+	std::string val;
 
-
-FileParser::FileParser() {
-	line = "";
-	section = "";
-	key = "";
-	val = "";
-}
+FileParser::FileParser()
+	: line("")
+	, new_section(false)
+	, section("")
+	, key("")
+	, val("")
+{}
 
 bool FileParser::open(const string& filename) {
 	infile.open(filename.c_str(), ios::in);

--- a/src/GameStatePlay.h
+++ b/src/GameStatePlay.h
@@ -51,7 +51,6 @@ private:
 
 	MapRenderer *map;
 	Enemy *enemy;
-	int renderableCount;
 	HazardManager *hazards;
 	EnemyManager *enemies;
 	MenuManager *menu;

--- a/src/MenuLog.cpp
+++ b/src/MenuLog.cpp
@@ -39,7 +39,6 @@ MenuLog::MenuLog() {
 
 	// Load config settings
 	FileParser infile;
-	std::string val;
 	if(infile.open(mods->locate("menus/log.txt"))) {
 		while(infile.next()) {
 			infile.val = infile.val + ',';


### PR DESCRIPTION
no changes to functionality nor translating strings.
