### PR TITLE
Don't translate internal names for elements

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -401,7 +401,7 @@ void loadMiscSettings() {
 		Element e;
 		ELEMENTS.clear();
 		while (infile.next()) {
-			if (infile.key == "name") e.name = msg->get(infile.val);
+			if (infile.key == "name") e.name = infile.val;
 			else if (infile.key == "resist") e.resist = msg->get(infile.val);
 
 			if (e.name != "" && e.resist != "") {


### PR DESCRIPTION
Fixes resistances not being set correctly when using non-English languages.
