### PR TITLE
Translate resist string when displayed instead of when loaded

### DIFF
--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -395,7 +395,7 @@ void MenuCharacter::refreshStats() {
 	if (show_stat[13]) {
 		for (unsigned int j=0; j<stats->vulnerable.size(); j++) {
 			ss.str("");
-			ss << ELEMENTS[j].resist << ": " << (100 - stats->vulnerable[j]) << "%";
+			ss << msg->get(ELEMENTS[j].resist) << ": " << (100 - stats->vulnerable[j]) << "%";
 			statList->set(visible_stats++, ss.str(),"");
 		}
 	}

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -402,7 +402,7 @@ void loadMiscSettings() {
 		ELEMENTS.clear();
 		while (infile.next()) {
 			if (infile.key == "name") e.name = infile.val;
-			else if (infile.key == "resist") e.resist = msg->get(infile.val);
+			else if (infile.key == "resist") e.resist = infile.val;
 
 			if (e.name != "" && e.resist != "") {
 				ELEMENTS.push_back(e);


### PR DESCRIPTION
As suggested by igorko, this is more consistent with the other list entries in MenuCharacter.
