### PR TITLE
Fix cases where dying enemies would attempt to move

### DIFF
--- a/src/BehaviorStandard.cpp
+++ b/src/BehaviorStandard.cpp
@@ -256,6 +256,9 @@ void BehaviorStandard::checkPower() {
  */
 void BehaviorStandard::checkMove() {
 
+	// dying enemies can't move
+	if (e->stats.cur_state == ENEMY_DEAD || e->stats.cur_state == ENEMY_CRITDEAD) return;
+
 	// stunned enemies can't act
 	if (e->stats.stun_duration) return;
 


### PR DESCRIPTION
This fixes patrolling enemies leaving blocked tiles after they die. Here's what was happening:
1. Enemy is killed. Its collision area is unblocked in Enemy::takeHit()
2. In BehaviorStandard, the state would switch to ENEMY_DEAD or ENEMY_CRITDEAD
3. Enemy logic continues to run until the enemy is a corpse (last frame of the dying animation)
4. That logic would "move" the enemy and block a new tile, which would never be unblocked
