### PR TITLE
Revert static analysis changes to AStarNode

### DIFF
--- a/src/AStarNode.cpp
+++ b/src/AStarNode.cpp
@@ -19,39 +19,31 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "AStarNode.h"
 
 AStarNode::AStarNode()
- : x(0)
- , y(0)
- , g(0)
- , h(0)
- , parent(Point())
-{}
+{
+	this->x = 0;
+	this->y = 0;
+}
 
 AStarNode::AStarNode(const int a, const int b)
- : x(a)
- , y(b)
- , g(0)
- , h(0)
- , parent(Point())
-{}
-
-AStarNode::AStarNode(const Point &p)
- : x(0)
- , y(0)
- , g(0)
- , h(0)
- , parent(Point())
 {
-	parent.x = p.x;
-	parent.y = p.y;
+	this->x = a;
+	this->y = b;
+}
+
+AStarNode::AStarNode(const Point p)
+{
+	this->x = p.x;
+	this->y = p.y;
 }
 
 AStarNode::AStarNode(const AStarNode& copy)
- : x(copy.x)
- , y(copy.y)
- , g(copy.g)
- , h(copy.h)
- , parent(Point(copy.parent))
-{}
+{
+	x = copy.x;
+	y = copy.y;
+	g = copy.g;
+	h = copy.h;
+	parent = copy.parent;
+}
 
 int AStarNode::getX() const
 {
@@ -61,6 +53,12 @@ int AStarNode::getX() const
 int AStarNode::getY() const
 {
 	return y;
+}
+
+Point AStarNode::getCoordinate() const
+{
+	Point coord = {x,y};
+	return coord;
 }
 
 Point AStarNode::getParent() const
@@ -138,6 +136,11 @@ float AStarNode::getActualCost() const
 void AStarNode::setActualCost(const float G)
 {
 	g = G;
+}
+
+float AStarNode::getEstimatedCost() const
+{
+	return h;
 }
 
 void AStarNode::setEstimatedCost(const float H)

--- a/src/AStarNode.h
+++ b/src/AStarNode.h
@@ -47,7 +47,7 @@ protected:
 public:
 	AStarNode();
 	AStarNode(const int a, const int b);
-	AStarNode(const Point &p);
+	AStarNode(const Point p);
 	AStarNode(const AStarNode& copy);
 
 	int getX() const;


### PR DESCRIPTION
Closes #59

Simply reverting these files fixes A\* pathfinding. We can re-implement these changes in the future when we have time to test them more.
