### PR TITLE
Fix drawing order of equipment sheets on Avatar.

### DIFF
--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -97,7 +97,8 @@ public:
 
 	void init();
 	void loadLayerDefinitions();
-	std::vector<std::vector<std::string> > layer_def;
+	std::vector<std::string> layer_reference_order;
+	std::vector<std::vector<unsigned> > layer_def;
 	void loadGraphics(std::vector<Layer_gfx> _img_gfx);
 	void loadSounds();
 	void loadStepFX(const std::string& stepname);

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -336,28 +336,26 @@ void GameStatePlay::checkEquipmentChange() {
 
 		vector<Layer_gfx> img_gfx;
 		// load only displayable layers
-		const vector<string> &player_layers = pc->layer_def[pc->stats.direction];
-		for (unsigned int j=0; j<player_layers.size(); j++) {
+		for (unsigned int j=0; j<pc->layer_reference_order.size(); j++) {
+			Layer_gfx gfx;
+			gfx.gfx = "";
+			gfx.type = "";
 			for (int i=0; i<menu->inv->inventory[EQUIPMENT].getSlotNumber(); i++) {
-				if (player_layers[j] == menu->inv->inventory[EQUIPMENT].slot_type[i]) {
-					Layer_gfx gfx;
+				if (pc->layer_reference_order[j] == menu->inv->inventory[EQUIPMENT].slot_type[i]) {
 					gfx.gfx = menu->items->items[menu->inv->inventory[EQUIPMENT][i].item].gfx;
 					gfx.type = menu->inv->inventory[EQUIPMENT].slot_type[i];
-					img_gfx.push_back(gfx);
-					break;
 				}
 			}
-			if (player_layers[j] == "head") {
-				Layer_gfx gfx;
+			if (pc->layer_reference_order[j] == "head") {
 				gfx.gfx = pc->stats.head;
 				gfx.type = "head";
-				img_gfx.push_back(gfx);
-				continue;
 			}
-			if (player_layers[j] == "body" && img_gfx.back().gfx == "") {
-				img_gfx.back().gfx = "clothes";
+			if (pc->layer_reference_order[j] == "body" && gfx.gfx == "") {
+				gfx.gfx = "clothes";
 			}
+			img_gfx.push_back(gfx);
 		}
+		assert(pc->layer_reference_order.size()==img_gfx.size());
 		pc->loadGraphics(img_gfx);
 
 		pc->loadStepFX(menu->items->items[menu->inv->inventory[EQUIPMENT][1].item].stepfx);


### PR DESCRIPTION
This pull introduces Null pointers in the animsets and anims of the Avatar class again, but this brings the advantage that all items are at fixed positions, see the new Avatar::layer_reference_order variable.
That variable defines in which order the items are passed from GameStatePlay::checkEquipmentChange into the Avatar class.
The Avatar class also aligns animsets and anims to the layer_reference_order.
This brings the advantage that on Avatar::addRenders() no search must be performed, but only the correct index depending on direction must be looked up.
