### PR TITLE
Fix Avatar sliding.

### DIFF
--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -212,3 +212,11 @@ void Animation::reset() {
 	times_played = 0;
 	additional_data = 1;
 }
+
+void Animation::syncTo(Animation *other) {
+	cur_frame = other->cur_frame;
+	cur_frame_duration = other->cur_frame_duration;
+	cur_frame_index = other->cur_frame_index;
+	times_played = other->times_played;
+	additional_data = other->additional_data;
+}

--- a/src/Animation.h
+++ b/src/Animation.h
@@ -93,6 +93,9 @@ public:
 	// advance the animation one frame
 	void advanceFrame();
 
+	// sets the frame counters to the same values as the given Animation.
+	void syncTo(Animation *other);
+
 	// return the Renderable of the current frame
 	Renderable getCurrentFrame(int direction);
 

--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -188,6 +188,7 @@ void Avatar::loadGraphics(std::vector<Layer_gfx> _img_gfx) {
 			AnimationManager::instance()->increaseCount(name);
 			animsets.push_back(AnimationManager::instance()->getAnimationSet(name));
 			anims.push_back(animsets.back()->getAnimation(activeAnimation->getName()));
+			anims.back()->syncTo(activeAnimation);
 		} else {
 			animsets.push_back(NULL);
 			anims.push_back(NULL);


### PR DESCRIPTION
When equipping new items, the avatar animation was reset to the default
animations (so in flare-game 'stance')

But when running, you probably want to have the run animation set again.
