### PR TITLE
Fixed my faulty implementation of Gettext multi-line key support.

### DIFF
--- a/src/GetText.cpp
+++ b/src/GetText.cpp
@@ -69,17 +69,15 @@ bool GetText::next() {
 
 			if (key != "")
 				continue;
-			else {  // Might be a multi-line key.
+			else {
+				// It is a multi-line value, unless it is the first msgid, in which case it will be empty
+				// and it will be ignored when finding the matching msgstr, so no big deal.
 				line = getLine(infile);
 				while(line.find("\"") == 0)
 				{
 					// We remove the double quotes.
 					key += line.substr(1, line.length()-2);
 					line = getLine(infile);
-				}
-				if(key != "") // It was a multi-line value indeed.
-				{
-					continue;
 				}
 			}
 		}


### PR DESCRIPTION
I did wrong assuming I got it right the first time without testing it. When parsing the multi-line key, the msgstr line right after was read before continuing the loop, and then a new line was read, resulting in the msgstr line after the multi-line msgid being skipped.

Now, when a multi-line key is matched, instead of continuing the while loop, we do nothing, so the flow enters the msgstr if statement right after.

I did test this patch, and it works like a charm :) Again, sorry for not doing the same with my original attempt.
