### PR TITLE
Don't activate hotspots where there's no line-of-sight

### DIFF
--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -561,7 +561,7 @@ void GameStatePlay::logic() {
 		checkLoot();
 		checkEnemyFocus();
 		checkNPCInteraction();
-		map->checkHotspots();
+		map->checkHotspots(pc->stats.pos);
 
 		pc->logic(menu->act->checkAction(inpt->mouse), restrictPowerUse());
 

--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -997,7 +997,7 @@ void MapRenderer::checkEvents(Point loc) {
  * This function checks valid mouse clicks against all clickable events, and
  * executes
  */
-void MapRenderer::checkHotspots() {
+void MapRenderer::checkHotspots(Point hero_pos) {
 	show_tooltip = false;
 
 	vector<Map_Event>::iterator it;
@@ -1076,7 +1076,8 @@ void MapRenderer::checkHotspots() {
 					}
 
 					if ((abs(cam.x - (*it).location.x * UNITS_PER_TILE) < CLICK_RANGE)
-						&& (abs(cam.y - (*it).location.y * UNITS_PER_TILE) < CLICK_RANGE)) {
+						&& (abs(cam.y - (*it).location.y * UNITS_PER_TILE) < CLICK_RANGE)
+						&& collider.line_of_sight((*it).location.x * UNITS_PER_TILE, (*it).location.y * UNITS_PER_TILE, hero_pos.x, hero_pos.y)) {
 
 						// only check events if the player is clicking
 						// and allowed to click

--- a/src/MapRenderer.h
+++ b/src/MapRenderer.h
@@ -257,7 +257,7 @@ public:
 
 	void clearEvents();
 	void checkEvents(Point loc);
-	void checkHotspots();
+	void checkHotspots(Point hero_pos);
 	void checkTooltip();
 
 	// vars


### PR DESCRIPTION
Closes #85

I've tested this in the Averguard Complex. The switch to lower the walls no longer can be clicked from the other side. Other hotspots such as doors and barrels/chests still work.
