### PR TITLE
Loading animations: introduce 2d settings render_size and render_offset.

### DIFF
--- a/src/AnimationSet.cpp
+++ b/src/AnimationSet.cpp
@@ -112,14 +112,12 @@ void AnimationSet::load() {
 		}
 		else if (parser.key == "type")
 			type = parser.val;
-		else if (parser.key == "render_size_x")
-			render_size.x = toInt(parser.val);
-		else if (parser.key == "render_size_y")
-			render_size.y = toInt(parser.val);
-		else if (parser.key == "render_offset_x")
-			render_offset.x = toInt(parser.val);
-		else if (parser.key == "render_offset_y")
-			render_offset.y = toInt(parser.val);
+		else if (parser.key == "render_size")
+			render_size.x = toInt(parser.nextValue());
+			render_size.y = toInt(parser.nextValue());
+		else if (parser.key == "render_offset")
+			render_offset.x = toInt(parser.nextValue());
+			render_offset.y = toInt(parser.nextValue());
 		else if (parser.key == "active_frame")
 			cout << "active frames in entities not supported" << endl;
 		else if (parser.key == "frame") {


### PR DESCRIPTION
Before we had:
render_size_x=32
render_size_y=64
render_offset_x=14
render_offset_y=56

Now it should be:
render_size=32,64
render_offset=14,56

In flare-game there are no files containing "render_offset_" as of now because all of them are packed.
