### PR TITLE
Close menus upon death

### DIFF
--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -634,6 +634,8 @@ void MenuManager::logic() {
 		else if (drag_src == DRAG_SRC_INVENTORY) inv->itemReturn(drag_stack);
 		else if (drag_src == DRAG_SRC_ACTIONBAR) act->actionReturn(drag_power);
 		drag_src = -1;
+		dragging = false;
+		closeAll(true);
 	}
 
 	// handle equipment changes affecting hero stats


### PR DESCRIPTION
Prevents the player from increasing stats when dead, which would refill their HP/MP.
