### PR TITLE
Create addText for tooltips

### DIFF
--- a/src/WidgetButton.cpp
+++ b/src/WidgetButton.cpp
@@ -186,7 +186,7 @@ TooltipData WidgetButton::checkTooltip(Point mouse) {
 	TooltipData _tip;
 
 	if (isWithin(pos, mouse) && tooltip != "") {
-		_tip.lines[_tip.num_lines++] = tooltip;
+		_tip.addText(tooltip);
 	}
 
 	return _tip;

--- a/src/WidgetListBox.cpp
+++ b/src/WidgetListBox.cpp
@@ -196,7 +196,7 @@ TooltipData WidgetListBox::checkTooltip(Point mouse) {
 	for(int i=0; i<list_height; i++) {
 		if (i<list_amount) {
 			if (isWithin(rows[i], mouse) && tooltips[i+cursor] != "") {
-				_tip.lines[_tip.num_lines++] = tooltips[i+cursor];
+				_tip.addText(tooltips[i+cursor]);
 				break;
 			}
 		}

--- a/src/WidgetTooltip.h
+++ b/src/WidgetTooltip.h
@@ -114,6 +114,30 @@ public:
 
 	}
 
+	// add text with support for new lines
+	void addText(std::string text, SDL_Color color) {
+		for (int i=0; i<TOOLTIP_MAX_LINES; i++) {
+			if (lines[i] == "") {
+				int cur = i;
+				colors[cur] = color;
+				for (unsigned j=0; j<text.length(); j++) {
+					if (text[j] == '\n') {
+						num_lines++;
+						colors[cur+num_lines] = color;
+					} else if (cur+num_lines<TOOLTIP_MAX_LINES) {
+						lines[cur+num_lines] += text[j];
+					}
+				}
+				num_lines++;
+				break;
+			}
+		}
+	}
+
+	void addText(std::string text) {
+		addText(text,font->getColor("widget_normal"));
+	}
+
 };
 
 class WidgetTooltip {


### PR DESCRIPTION
The purpose of this function is to prevent the need to manually increment lines when adding text to a tooltip. Plus it will make refactoring tooltips to use vectors internally easier. It supports new lines, so `tip.addText("Hello\nWorld")` will make a tooltip that looks like:

```
Hello
World
```

There's also an optional second parameter for defining the color of the text. So for doing item tooltips we can do something like:

```
tip.addText(item.name, color_quality);
tip.addText("Level: " + item.level +"\n" + item.type, color_normal);
etc...
```

In this pull request, I've used it in WidgetListBox and WidgetButton tooltips, which is also a great use of this function. Both those widgets only supported single-line tooltips before.
