### PR TITLE
Fix segfault caused by loading shared resources out of order

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,13 +65,13 @@ static void init() {
 
 	// Shared Resources set-up
 
-	anim = new AnimationManager();
-	comb = new CombatText;
-	font = new FontEngine();
-	imag = new ImageManager();
-	inpt = new InputState();
 	mods = new ModManager();
 	msg = new MessageEngine();
+	font = new FontEngine();
+	anim = new AnimationManager();
+	comb = new CombatText();
+	imag = new ImageManager();
+	inpt = new InputState();
 
 
 	// Load tileset options (must be after ModManager is initialized)


### PR DESCRIPTION
Order matters here. These resources depend on other resources. For example, CombatText requires an instance of FontEngine to work. This problem is also present in flare-game.
