### PR TITLE
Clean up some Power settings and refactor joystick aiming

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -291,7 +291,10 @@ void Avatar::handlePower(int actionbar_power) {
 		const Power &power = powers->getPower(actionbar_power);
 		Point target;
 		if (MOUSE_AIM) {
-			target = screen_to_map(inpt->mouse.x,  inpt->mouse.y + power.aim_assist, stats.pos.x, stats.pos.y);
+			if (power.aim_assist)
+				target = screen_to_map(inpt->mouse.x,  inpt->mouse.y + AIM_ASSIST, stats.pos.x, stats.pos.y);
+			else
+				target = screen_to_map(inpt->mouse.x,  inpt->mouse.y, stats.pos.x, stats.pos.y);
 		} else {
 			FPoint ftarget = calcVector(stats.pos, stats.direction, stats.melee_range);
 			target.x = static_cast<int>(ftarget.x);

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -178,7 +178,7 @@ void PowerManager::loadPowers(const std::string& filename) {
 		else if (infile.key == "visual_option")
 			powers[input_id].visual_option = toInt(infile.val);
 		else if (infile.key == "aim_assist")
-			powers[input_id].aim_assist = toInt(infile.val);
+			powers[input_id].aim_assist = toBool(infile.val);
 		else if (infile.key == "speed")
 			powers[input_id].speed = toInt(infile.val);
 		else if (infile.key == "lifespan")

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -106,7 +106,7 @@ public:
 	bool directional; // sprite sheet contains options for 8 directions, one per row
 	int visual_random; // sprite sheet contains rows of random options
 	int visual_option; // sprite sheet contains rows of similar effects.  use a specific option
-	int aim_assist;
+	bool aim_assist;
 	int speed; // for missile hazards, map units per frame
 	int lifespan; // how long the hazard/animation lasts
 	bool floor; // the hazard is drawn between the background and object layers
@@ -197,7 +197,7 @@ public:
 		, directional(false)
 		, visual_random(0)
 		, visual_option(0)
-		, aim_assist(0)
+		, aim_assist(false)
 		, speed(0)
 		, lifespan(0)
 		, floor(false)

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -159,6 +159,7 @@ bool ENABLE_PLAYGAME = false;
 bool SHOW_FPS = false;
 int CORPSE_TIMEOUT = 1800;
 bool SELL_WITHOUT_VENDOR = true;
+int AIM_ASSIST = 0;
 
 
 /**
@@ -351,6 +352,8 @@ void loadMiscSettings() {
 				CORPSE_TIMEOUT = toInt(infile.val);
 			} else if (infile.key == "sell_without_vendor") {
 				SELL_WITHOUT_VENDOR = toInt(infile.val);
+			} else if (infile.key == "aim_assist") {
+				AIM_ASSIST = toInt(infile.val);
 			}
 		}
 		infile.close();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -111,6 +111,7 @@ extern bool ENABLE_PLAYGAME;
 extern bool SHOW_FPS;
 extern int CORPSE_TIMEOUT;
 extern bool SELL_WITHOUT_VENDOR;
+extern int AIM_ASSIST;
 
 // Tile Settings
 extern unsigned short UNITS_PER_TILE;


### PR DESCRIPTION
- Removes unused animation variables from powers (animation files replace them)
- Makes aim_assist an engine setting, as mentioned in #158
- Use calcVector and melee_range for aiming with MOUSE_AIM turned off
