### PR TITLE
Finish implementing HP/MP over time effects

### DIFF
--- a/src/EffectManager.h
+++ b/src/EffectManager.h
@@ -43,9 +43,8 @@ struct Effect{
 	int ticks;
 	int duration;
 	std::string type;
-	int shield_hp;
-	int shield_maxhp;
 	int magnitude;
+	int magnitude_max;
 	std::string animation_name;
 	Animation* animation;
 
@@ -55,9 +54,8 @@ struct Effect{
 		ticks = 0;
 		duration = -1;
 		type = "";
-		shield_hp = 0;
-		shield_maxhp = 0;
 		magnitude = 0;
+		magnitude_max = 0;
 		animation_name = "";
 		animation = NULL;
 	}
@@ -77,7 +75,7 @@ public:
 	EffectManager();
 	~EffectManager();
 	void logic();
-	void addEffect(int _id, int _icon, int _duration, int _shield_hp, int _magnitude, std::string _type, std::string _animation);
+	void addEffect(int _id, int _icon, int _duration, int _magnitude, std::string _type, std::string _animation);
 	void removeEffectType(std::string _type);
 	void clearEffects();
 	void clearNegativeEffects();
@@ -87,6 +85,7 @@ public:
 
 	int bleed_dmg;
 	int hpot;
+	int mpot;
 	int forced_speed;
 	bool immunity;
 	bool slow;

--- a/src/MenuActiveEffects.cpp
+++ b/src/MenuActiveEffects.cpp
@@ -116,11 +116,11 @@ void MenuActiveEffects::render() {
 		int icon = stats->effects.effect_list[i].icon;
 		int ticks = stats->effects.effect_list[i].ticks;
 		int duration = stats->effects.effect_list[i].duration;
-		int shield_hp = stats->effects.effect_list[i].shield_hp;
-		int shield_maxhp = stats->effects.effect_list[i].shield_maxhp;
+		int magnitude = stats->effects.effect_list[i].magnitude;
+		int magnitude_max = stats->effects.effect_list[i].magnitude_max;
 
 		if (type == "shield")
-			renderIcon(icon,i,shield_hp,shield_maxhp);
+			renderIcon(icon,i,magnitude,magnitude_max);
 		else if (type == "block")
 			renderIcon(icon,i,0,0);
 		else if (ticks > 0 && duration > 0)

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -146,8 +146,6 @@ public:
 	bool buff;
 	bool buff_heal;
 	bool buff_teleport;
-	int buff_restore_hp;
-	int buff_restore_mp;
 
 	int post_effect;
 	int effect_duration;
@@ -226,8 +224,6 @@ public:
 		, buff(false)
 		, buff_heal(false)
 		, buff_teleport(false)
-		, buff_restore_hp(0)
-		, buff_restore_mp(0)
 
 		, post_effect(0)
 		, effect_duration(0)

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -425,8 +425,14 @@ void StatBlock::logic() {
 
 	// apply healing over time
 	if (effects.hpot > 0) {
+		comb->addMessage(msg->get("+%d HP",effects.hpot), pos, COMBAT_MESSAGE_BUFF, hero);
 		hp += effects.hpot;
 		if (hp > maxhp) hp = maxhp;
+	}
+	if (effects.mpot > 0) {
+		comb->addMessage(msg->get("+%d MP",effects.mpot), pos, COMBAT_MESSAGE_BUFF, hero);
+		mp += effects.mpot;
+		if (mp > maxmp) mp = maxmp;
 	}
 
 	// handle effect timers


### PR DESCRIPTION
Removed buff_restore_hp and buff_restore_mp.
Potions should now use HP/MP over time effects.

For example, an instant potion uses:
`effect_duration=1` and `effect_magnitude=25`
but to heal the same amount over time, we use:
`effect_duration=750` (25 seconds) and `effect_magnitude=1`

Also, effect magnitude is now used for shield HP
