### PR TITLE
Loot: fix animation count in assign operator.

### DIFF
--- a/src/AnimationManager.cpp
+++ b/src/AnimationManager.cpp
@@ -48,9 +48,9 @@ AnimationManager::~AnimationManager()
 // NDEBUG is used by posix to disable assertions, so use the same MACRO.
 #ifndef NDEBUG
 	if (!names.empty()) {
-		cout << "ImageManager still holding these images:" << endl;
-		for (vector<string>::iterator it=names.begin(); it != names.end(); ++it)
-			cout << *it << endl;
+		cout << "AnimationManager still holding these animations:" << endl;
+		for (unsigned i = 0; i < names.size(); i++)
+			cout << names[i] << counts[i] << endl;
 	}
 	assert(names.size() == 0);
 #endif

--- a/src/Loot.cpp
+++ b/src/Loot.cpp
@@ -43,7 +43,10 @@ Loot::Loot(const Loot &other) {
 // The assignment operator mainly used in internal vector managing,
 // e.g. in vector::erase()
 Loot& Loot::operator= (const Loot &other) {
+	if (gfx != "")
+		anim->decreaseCount(gfx);
 	delete animation;
+
 	loadAnimation(other.gfx);
 	animation->syncTo(other.animation);
 


### PR DESCRIPTION
Removes the assertion error in #201.
