### PR TITLE
Item bonuses as Effects

### DIFF
--- a/src/EffectManager.h
+++ b/src/EffectManager.h
@@ -47,6 +47,7 @@ struct Effect{
 	int magnitude_max;
 	std::string animation_name;
 	Animation* animation;
+	bool item;
 
 	Effect() {
 		id = 0;
@@ -58,6 +59,7 @@ struct Effect{
 		magnitude_max = 0;
 		animation_name = "";
 		animation = NULL;
+		item = false;
 	}
 
 	~Effect() {
@@ -74,11 +76,13 @@ private:
 public:
 	EffectManager();
 	~EffectManager();
+	void clearStatus();
 	void logic();
-	void addEffect(int _id, int _icon, int _duration, int _magnitude, std::string _type, std::string _animation);
+	void addEffect(int _id, int _icon, int _duration, int _magnitude, std::string _type, std::string _animation, bool _additive, bool _item);
 	void removeEffectType(std::string _type);
 	void clearEffects();
 	void clearNegativeEffects();
+	void clearItemEffects();
 	int damageShields(int _dmg);
 
 	std::vector<Effect> effect_list;
@@ -91,6 +95,19 @@ public:
 	bool stun;
 	int forced_speed;
 	bool forced_move;
+
+	int bonus_hp;
+	int bonus_hp_regen;
+	int bonus_mp;
+	int bonus_mp_regen;
+	int bonus_accuracy;
+	int bonus_avoidance;
+	int bonus_crit;
+	int bonus_offense;
+	int bonus_defense;
+	int bonus_physical;
+	int bonus_mental;
+	std::vector<int> bonus_resist;
 };
 
 #endif

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -542,19 +542,25 @@ TooltipData ItemManager::getTooltip(int item, StatBlock *stats, int context) {
 	unsigned bonus_counter = 0;
 	string modifier;
 	while (bonus_counter < items[item].bonus_val.size() && items[item].bonus_stat[bonus_counter] != "") {
-		if (items[item].bonus_val[bonus_counter] > 0) {
-			modifier = msg->get("Increases %s by %d",
-					items[item].bonus_val[bonus_counter],
-					msg->get(items[item].bonus_stat[bonus_counter]));
+		if (items[item].bonus_stat[bonus_counter] == "speed") {
+			modifier = msg->get("%d\% Speed", items[item].bonus_val[bonus_counter]);
+			if (items[item].bonus_val[bonus_counter] >= 100) color = color_bonus;
+			else color = color_penalty;
+		} else {
+			if (items[item].bonus_val[bonus_counter] > 0) {
+				modifier = msg->get("Increases %s by %d",
+						items[item].bonus_val[bonus_counter],
+						msg->get(items[item].bonus_stat[bonus_counter]));
 
-			color = color_bonus;
-		}
-		else {
-			modifier = msg->get("Decreases %s by %d",
-					items[item].bonus_val[bonus_counter],
-					msg->get(items[item].bonus_stat[bonus_counter]));
+				color = color_bonus;
+			}
+			else {
+				modifier = msg->get("Decreases %s by %d",
+						items[item].bonus_val[bonus_counter],
+						msg->get(items[item].bonus_stat[bonus_counter]));
 
-			color = color_penalty;
+				color = color_penalty;
+			}
 		}
 		tip.addText(modifier, color);
 		bonus_counter++;

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -117,6 +117,8 @@ void PowerManager::loadPowers(const std::string& filename) {
 			powers[input_id].name = msg->get(infile.val);
 		else if (infile.key == "description")
 			powers[input_id].description = msg->get(infile.val);
+		else if (infile.key == "tag")
+			powers[input_id].tag = infile.val;
 		else if (infile.key == "icon")
 			powers[input_id].icon = toInt(infile.val);
 		else if (infile.key == "new_state") {
@@ -253,6 +255,8 @@ void PowerManager::loadPowers(const std::string& filename) {
 			powers[input_id].effect_magnitude = toInt(infile.val);
 		else if (infile.key == "effect_type")
 			powers[input_id].effect_type = infile.val;
+		else if (infile.key == "effect_additive")
+			powers[input_id].effect_additive = toBool(infile.val);
 		// pre and post power effects
 		else if (infile.key == "post_power")
 			powers[input_id].post_power = toInt(infile.val);
@@ -679,7 +683,7 @@ bool PowerManager::effect(StatBlock *src_stats, int power_index) {
 			if (src_stats->hp > src_stats->maxhp) src_stats->hp = src_stats->maxhp;
 		}
 
-		src_stats->effects.addEffect(effect_index, powers[effect_index].icon, powers[power_index].effect_duration, magnitude, powers[effect_index].effect_type, powers[effect_index].animation_name);
+		src_stats->effects.addEffect(effect_index, powers[effect_index].icon, powers[power_index].effect_duration, magnitude, powers[effect_index].effect_type, powers[effect_index].animation_name, powers[effect_index].effect_additive, false);
 	}
 
 	// If there's a sound effect, play it here
@@ -992,6 +996,18 @@ void PowerManager::activatePassives(StatBlock *src_stats) {
 			activate(src_stats->powers_list[i], src_stats, src_stats->pos);
 		}
 	}
+}
+
+/**
+ * Find the first power id for a given tag
+ * returns 0 if no tag is found
+ */
+int PowerManager::getIdFromTag(std::string tag) {
+	if (tag == "") return 0;
+	for (unsigned i=1; i<powers.size(); i++) {
+		if (powers[i].tag == tag) return i;
+	}
+	return 0;
 }
 
 PowerManager::~PowerManager() {

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -80,6 +80,7 @@ public:
 	int type; // what kind of activate() this is
 	std::string name;
 	std::string description;
+	std::string tag; // optional unique name used to get power id
 	int icon; // just the number.  The caller menu will have access to the surface.
 	int new_state; // when using this power the user (avatar/enemy) starts a new state
 	bool face; // does the user turn to face the mouse cursor when using this power?
@@ -151,6 +152,7 @@ public:
 	int effect_duration;
 	int effect_magnitude;
 	std::string effect_type;
+	bool effect_additive;
 
 	int post_power;
 	int wall_power;
@@ -164,6 +166,7 @@ public:
 		: type(-1)
 		, name("")
 		, description("")
+		, tag("")
 		, icon(-1)
 		, new_state(-1)
 		, face(false)
@@ -229,6 +232,7 @@ public:
 		, effect_duration(0)
 		, effect_magnitude(0)
 		, effect_type("")
+		, effect_additive(false)
 
 		, post_power(0)
 		, wall_power(0)
@@ -282,6 +286,7 @@ public:
 	bool spawn(const std::string& enemy_type, Point target);
 	bool effect(StatBlock *src_stats, int power_index);
 	void activatePassives(StatBlock *src_stats);
+	int getIdFromTag(std::string tag);
 
 	std::vector<Power> powers;
 	std::queue<Hazard *> hazards; // output; read by HazardManager

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -318,6 +318,7 @@ void GameStatePlay::loadGame() {
 	// initialize vars
 	pc->stats.recalc();
 	menu->inv->applyEquipment(menu->inv->inventory[EQUIPMENT].storage);
+	pc->stats.logic(); // run stat logic once to apply items bonuses
 	if (SAVE_HPMP) {
 		pc->stats.hp = saved_hp;
 		pc->stats.mp = saved_mp;

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -72,6 +72,7 @@ class StatBlock {
 private:
 	void loadHeroStats();
 	bool statsLoaded;
+	void recalc_alt();
 
 public:
 	StatBlock();


### PR DESCRIPTION
items.txt should mostly remain the same, except what's mentioned below.
Corresponding Effects will need to be added to powers.txt.

**speed** is now a percentage, so items that have it as a bonus will need
to be adjusted. For example, `bonus=speed,150` will mean the item grants
150% speed.

Two new keys were added to powers: **tag** and **effect_additive**
tag allows setting a name that can be used to look up the power id
effect_additive is a boolean that determines if an effect magnitude
when adding a new Effect should be cumulitive or should replace itself.
