### PR TITLE
Allow effects to be rendered above their entities

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -936,7 +936,7 @@ void Avatar::addRenders(vector<Renderable> &r) {
 			if (anims[index]) {
 				Renderable ren = anims[index]->getCurrentFrame(stats.direction);
 				ren.map_pos = stats.pos;
-				ren.prio = i;
+				ren.prio = i+1;
 				r.push_back(ren);
 			}
 		}
@@ -950,6 +950,8 @@ void Avatar::addRenders(vector<Renderable> &r) {
 		if (stats.effects.effect_list[i].animation && !stats.effects.effect_list[i].animation->isCompleted()) {
 			Renderable ren = stats.effects.effect_list[i].animation->getCurrentFrame(0);
 			ren.map_pos = stats.pos;
+			if (stats.effects.effect_list[i].render_above) ren.prio = layer_def[stats.direction].size()+1;
+			else ren.prio = 0;
 			r.push_back(ren);
 		}
 	}

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -126,77 +126,78 @@ void EffectManager::logic() {
 	}
 }
 
-void EffectManager::addEffect(int _id, int _icon, int _duration, int _magnitude, std::string _type, std::string _animation, bool _additive, bool _item, bool _trigger) {
+void EffectManager::addEffect(int id, int icon, int duration, int magnitude, std::string type, std::string animation, bool additive, bool item, bool trigger, bool render_above) {
 	// if we're already immune, don't add negative effects
 	if (immunity) {
-		if (_type == "bleed") return;
-		else if (_type == "speed" && _magnitude < 100) return;
-		else if (_type == "stun") return;
+		if (type == "bleed") return;
+		else if (type == "speed" && magnitude < 100) return;
+		else if (type == "stun") return;
 	}
 
 	// only allow one forced_move effect
 	// TODO remove this limitation
 	if (forced_move) {
-		if (_type == "forced_move") return;
+		if (type == "forced_move") return;
 	}
 
 	for (unsigned i=0; i<effect_list.size(); i++) {
-		if (effect_list[i].id == _id) {
-			if (effect_list[i].duration <= _duration) {
-				effect_list[i].ticks = effect_list[i].duration = _duration;
+		if (effect_list[i].id == id) {
+			if (effect_list[i].duration <= duration) {
+				effect_list[i].ticks = effect_list[i].duration = duration;
 				if (effect_list[i].animation) effect_list[i].animation->reset();
 			}
-			if (_additive) {
-				effect_list[i].magnitude += _magnitude;
-				effect_list[i].magnitude_max += _magnitude;
-			} else if (effect_list[i].magnitude_max <= _magnitude) {
-				effect_list[i].magnitude = effect_list[i].magnitude_max = _magnitude;
+			if (additive) {
+				effect_list[i].magnitude += magnitude;
+				effect_list[i].magnitude_max += magnitude;
+			} else if (effect_list[i].magnitude_max <= magnitude) {
+				effect_list[i].magnitude = effect_list[i].magnitude_max = magnitude;
 				if (effect_list[i].animation) effect_list[i].animation->reset();
 			}
 			return; // we already have this effect
 		}
 		// if we're adding an immunity effect, remove all negative effects
-		if (_type == "immunity") {
+		if (type == "immunity") {
 			clearNegativeEffects();
 		}
 	}
 
 	Effect e;
 
-	e.id = _id;
-	e.icon = _icon;
-	e.ticks = e.duration = _duration;
-	e.magnitude = e.magnitude_max = _magnitude;
-	e.type = _type;
-	e.item = _item;
-	e.trigger = _trigger;
+	e.id = id;
+	e.icon = icon;
+	e.ticks = e.duration = duration;
+	e.magnitude = e.magnitude_max = magnitude;
+	e.type = type;
+	e.item = item;
+	e.trigger = trigger;
+	e.render_above = render_above;
 
-	if (_animation != "") {
-		anim->increaseCount(_animation);
-		e.animation = loadAnimation(_animation);
-		e.animation_name = _animation;
+	if (animation != "") {
+		anim->increaseCount(animation);
+		e.animation = loadAnimation(animation);
+		e.animation_name = animation;
 	}
 
 	effect_list.push_back(e);
 }
 
-void EffectManager::removeEffect(int _id) {
-	removeAnimation(_id);
-	effect_list.erase(effect_list.begin()+_id);
+void EffectManager::removeEffect(int id) {
+	removeAnimation(id);
+	effect_list.erase(effect_list.begin()+id);
 }
 
-void EffectManager::removeAnimation(int _id) {
-	if (effect_list[_id].animation && effect_list[_id].animation_name != "") {
-		anim->decreaseCount(effect_list[_id].animation_name);
-		delete effect_list[_id].animation;
-		effect_list[_id].animation = NULL;
-		effect_list[_id].animation_name = "";
+void EffectManager::removeAnimation(int id) {
+	if (effect_list[id].animation && effect_list[id].animation_name != "") {
+		anim->decreaseCount(effect_list[id].animation_name);
+		delete effect_list[id].animation;
+		effect_list[id].animation = NULL;
+		effect_list[id].animation_name = "";
 	}
 }
 
-void EffectManager::removeEffectType(std::string _type) {
+void EffectManager::removeEffectType(std::string type) {
 	for (unsigned i=effect_list.size(); i>0; i--) {
-		if (effect_list[i-1].type == _type) removeEffect(i-1);
+		if (effect_list[i-1].type == type) removeEffect(i-1);
 	}
 }
 
@@ -226,12 +227,12 @@ void EffectManager::clearTriggeredEffects() {
 	}
 }
 
-int EffectManager::damageShields(int _dmg) {
-	int over_dmg = _dmg;
+int EffectManager::damageShields(int dmg) {
+	int over_dmg = dmg;
 
 	for (unsigned i=0; i<effect_list.size(); i++) {
 		if (effect_list[i].magnitude_max > 0 && effect_list[i].type == "shield") {
-			effect_list[i].magnitude -= _dmg;
+			effect_list[i].magnitude -= dmg;
 			if (effect_list[i].magnitude < 0) {
 				if (abs(effect_list[i].magnitude) < over_dmg) over_dmg = abs(effect_list[i].magnitude);
 				effect_list[i].magnitude = 0;

--- a/src/EffectManager.h
+++ b/src/EffectManager.h
@@ -49,6 +49,7 @@ struct Effect{
 	Animation* animation;
 	bool item;
 	bool trigger;
+	bool render_above;
 
 	Effect()
 	 : id(0)
@@ -62,6 +63,7 @@ struct Effect{
 	 , animation(NULL)
 	 , item(false)
 	 , trigger(false)
+	 , render_above(false)
 	{}
 
 	~Effect() {
@@ -72,21 +74,21 @@ struct Effect{
 class EffectManager {
 private:
 	Animation* loadAnimation(std::string &s);
-	void removeEffect(int _id);
-	void removeAnimation(int _id);
+	void removeEffect(int id);
+	void removeAnimation(int id);
 
 public:
 	EffectManager();
 	~EffectManager();
 	void clearStatus();
 	void logic();
-	void addEffect(int _id, int _icon, int _duration, int _magnitude, std::string _type, std::string _animation, bool _additive, bool _item, bool _trigger);
-	void removeEffectType(std::string _type);
+	void addEffect(int id, int icon, int duration, int magnitude, std::string type, std::string animation, bool additive, bool item, bool trigger, bool render_above);
+	void removeEffectType(std::string type);
 	void clearEffects();
 	void clearNegativeEffects();
 	void clearItemEffects();
 	void clearTriggeredEffects();
-	int damageShields(int _dmg);
+	int damageShields(int dmg);
 
 	std::vector<Effect> effect_list;
 

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -299,6 +299,7 @@ void EnemyManager::addRenders(vector<Renderable> &r, vector<Renderable> &r_dead)
 		bool dead = (*it)->stats.corpse;
 		if (!dead || (dead && (*it)->stats.corpse_ticks > 0)) {
 			Renderable re = (*it)->getRender();
+			re.prio = 1;
 
 			// draw corpses below objects so that floor loot is more visible
 			(dead ? r_dead : r).push_back(re);
@@ -308,6 +309,8 @@ void EnemyManager::addRenders(vector<Renderable> &r, vector<Renderable> &r_dead)
 				if ((*it)->stats.effects.effect_list[i].animation) {
 					Renderable ren = (*it)->stats.effects.effect_list[i].animation->getCurrentFrame(0);
 					ren.map_pos = (*it)->stats.pos;
+					if ((*it)->stats.effects.effect_list[i].render_above) ren.prio = 2;
+					else ren.prio = 0;
 					r.push_back(ren);
 				}
 			}

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -806,7 +806,7 @@ void MenuInventory::applyItemStats(ItemStack *equipped) {
 			int id = powers->getIdFromTag(item.bonus_stat[bonus_counter]);
 
 			if (id > 0)
-				stats->effects.addEffect(id, powers->powers[id].icon, 0, item.bonus_val[bonus_counter], powers->powers[id].effect_type, powers->powers[id].animation_name, powers->powers[id].effect_additive, true, false);
+				stats->effects.addEffect(id, powers->powers[id].icon, 0, item.bonus_val[bonus_counter], powers->powers[id].effect_type, powers->powers[id].animation_name, powers->powers[id].effect_additive, true, false, powers->powers[id].effect_render_above);
 
 			bonus_counter++;
 		}
@@ -843,7 +843,7 @@ void MenuInventory::applyItemSetBonuses(ItemStack *equipped) {
 			int id = powers->getIdFromTag(temp_set.bonus[bonus_counter].bonus_stat);
 
 			if (id > 0)
-				stats->effects.addEffect(id, powers->powers[id].icon, 0, temp_set.bonus[bonus_counter].bonus_val, powers->powers[id].effect_type, powers->powers[id].animation_name, powers->powers[id].effect_additive, true, false);
+				stats->effects.addEffect(id, powers->powers[id].icon, 0, temp_set.bonus[bonus_counter].bonus_val, powers->powers[id].effect_type, powers->powers[id].animation_name, powers->powers[id].effect_additive, true, false, powers->powers[id].effect_render_above);
 		}
 	}
 }

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -265,6 +265,8 @@ void PowerManager::loadPowers(const std::string& filename) {
 			powers[input_id].effect_type = infile.val;
 		else if (infile.key == "effect_additive")
 			powers[input_id].effect_additive = toBool(infile.val);
+		else if (infile.key == "effect_render_above")
+			powers[input_id].effect_render_above = toBool(infile.val);
 		// pre and post power effects
 		else if (infile.key == "post_power")
 			powers[input_id].post_power = toInt(infile.val);
@@ -693,7 +695,7 @@ bool PowerManager::effect(StatBlock *src_stats, int power_index) {
 				if (src_stats->hp > src_stats->maxhp) src_stats->hp = src_stats->maxhp;
 			}
 
-			src_stats->effects.addEffect(effect_index, powers[effect_index].icon, duration, magnitude, powers[effect_index].effect_type, powers[effect_index].animation_name, powers[effect_index].effect_additive, false, is_triggered);
+			src_stats->effects.addEffect(effect_index, powers[effect_index].icon, duration, magnitude, powers[effect_index].effect_type, powers[effect_index].animation_name, powers[effect_index].effect_additive, false, is_triggered, powers[effect_index].effect_render_above);
 		}
 
 		// If there's a sound effect, play it here

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -165,6 +165,7 @@ public:
 	std::vector<PostEffect> post_effects;
 	std::string effect_type;
 	bool effect_additive;
+	bool effect_render_above;
 
 	int post_power;
 	int wall_power;
@@ -243,6 +244,7 @@ public:
 
 		, effect_type("")
 		, effect_additive(false)
+		, effect_render_above(false)
 
 		, post_power(0)
 		, wall_power(0)


### PR DESCRIPTION
Added a new effect power property: `effect_render_above`
When true, the effect will be rendered above the player/enemy.
Otherwise, it will be placed behind them (this is the default behavior).
