### PR TITLE
Fix crashes caused by prematurely deconstructed vectors

### DIFF
--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -98,9 +98,6 @@ public:
 	void clearHighlight();
 
 	SDL_Rect carried_area;
-	std::vector<SDL_Rect> equipped_area;
-	std::vector<std::string> slot_type;
-	std::vector<std::string> slot_desc;
 
 	MenuItemStorage inventory[2];
 	int currency;
@@ -113,6 +110,9 @@ public:
 
 	std::string log_msg;
 
+	std::vector<SDL_Rect> equipped_area;
+	std::vector<std::string> slot_type;
+	std::vector<std::string> slot_desc;
 };
 
 #endif


### PR DESCRIPTION
Closes #201
Closes #208

Apparently, these vectors need to be delcared at the _end_ of
MenuInventory's class declaration. I have tested this several times using
the reproduction method I found for the crashes, and it has fixed them as
far as I can tell.
