### PR TITLE
Fix problems with tooltip rendering order

### DIFF
--- a/src/GameStateConfig.cpp
+++ b/src/GameStateConfig.cpp
@@ -51,6 +51,7 @@ GameStateConfig::GameStateConfig ()
 	, defaults_button(NULL)
 	, cancel_button(NULL)
 	, imgFileName(mods->locate("images/menus/config.png"))
+	, tip_buf(TooltipData())
 	, input_key(0)
 	, check_resolution(true)
 {
@@ -68,6 +69,8 @@ GameStateConfig::GameStateConfig ()
 }
 
 void GameStateConfig::init() {
+
+	tip = new WidgetTooltip();
 
 	ok_button = new WidgetButton(mods->locate("images/menus/buttons/button_default.png"));
 	defaults_button = new WidgetButton(mods->locate("images/menus/buttons/button_default.png"));
@@ -1019,6 +1022,25 @@ void GameStateConfig::render ()
 
 	if (input_confirm->visible) input_confirm->render();
 	if (defaults_confirm->visible) defaults_confirm->render();
+
+	// Get tooltips for listboxes
+	// This isn't very elegant right now
+	// In the future, we'll want to get tooltips for all widget types
+	TooltipData tip_new;
+	if (active_tab == 0 && tip_new.isEmpty()) tip_new = resolution_lstb->checkTooltip(inpt->mouse);
+	if (active_tab == 2 && tip_new.isEmpty()) tip_new = language_lstb->checkTooltip(inpt->mouse);
+	if (active_tab == 3 && tip_new.isEmpty()) tip_new = joystick_device_lstb->checkTooltip(inpt->mouse);
+	if (active_tab == 5 && tip_new.isEmpty()) tip_new = activemods_lstb->checkTooltip(inpt->mouse);
+	if (active_tab == 5 && tip_new.isEmpty()) tip_new = inactivemods_lstb->checkTooltip(inpt->mouse);
+
+	if (!tip_new.isEmpty()) {
+		if (!tip_new.compare(&tip_buf)) {
+			tip_buf.clear();
+			tip_buf = tip_new;
+		}
+		tip->render(tip_buf, inpt->mouse, STYLE_FLOAT);
+	}
+
 }
 
 int GameStateConfig::getVideoModes()
@@ -1297,6 +1319,8 @@ void GameStateConfig::scanKey(int button) {
 
 GameStateConfig::~GameStateConfig()
 {
+	tip_buf.clear();
+	delete tip;
 	delete tabControl;
 	delete ok_button;
 	delete defaults_button;

--- a/src/GameStateConfig.h
+++ b/src/GameStateConfig.h
@@ -30,6 +30,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include <vector>
 #include "GameState.h"
+#include "WidgetTooltip.h"
 #include <string>
 
 class MenuConfirm;
@@ -42,6 +43,7 @@ class WidgetListBox;
 class WidgetScrollBox;
 class WidgetSlider;
 class WidgetTabControl;
+class WidgetTooltip;
 
 class GameStateConfig : public GameState {
 public:
@@ -138,6 +140,9 @@ private:
 	MenuConfirm         * input_confirm;
 	MenuConfirm         * defaults_confirm;
 	MenuConfirm         * resolution_confirm;
+
+	WidgetTooltip       * tip;
+	TooltipData         tip_buf;
 
 	int input_key;
 	int mods_total;

--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -529,8 +529,7 @@ TooltipData MenuCharacter::checkTooltip() {
 			return cstat[i].tip;
 	}
 
-	TooltipData tip;
-	return tip;
+	return statList->checkTooltip(inpt->mouse);
 }
 
 /**

--- a/src/Widget.h
+++ b/src/Widget.h
@@ -24,6 +24,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
  * Base interface all widget needs to implement
  */
 #include <SDL.h>
+
 class Widget {
 public:
 	Widget();

--- a/src/WidgetButton.cpp
+++ b/src/WidgetButton.cpp
@@ -152,6 +152,7 @@ void WidgetButton::render(SDL_Surface *target) {
 	wlabel.render(target);
 
 	// render the tooltip
+	// TODO move this to menu rendering
 	if (!tip_new.isEmpty()) {
 		if (!tip_new.compare(&tip_buf)) {
 			tip_buf.clear();

--- a/src/WidgetListBox.cpp
+++ b/src/WidgetListBox.cpp
@@ -99,7 +99,6 @@ bool WidgetListBox::checkClick(int x, int y) {
 	Point mouse(x, y);
 
 	refresh();
-	tip_new = checkTooltip(mouse);
 
 	// check scroll wheel
 	SDL_Rect scroll_area;
@@ -399,16 +398,6 @@ void WidgetListBox::render(SDL_Surface *target) {
 
 	if (has_scroll_bar)
 		scrollbar->render(target);
-
-	if (!tip_new.isEmpty()) {
-		if (!tip_new.compare(&tip_buf)) {
-			tip_buf.clear();
-			tip_buf = tip_new;
-		}
-		tip->render(tip_buf, inpt->mouse, STYLE_FLOAT, target);
-	}
-
-
 }
 
 /**
@@ -478,7 +467,6 @@ void WidgetListBox::refresh() {
 }
 
 WidgetListBox::~WidgetListBox() {
-	tip_buf.clear();
 	SDL_FreeSurface(listboxs);
 	delete[] values;
 	delete[] tooltips;

--- a/src/WidgetListBox.h
+++ b/src/WidgetListBox.h
@@ -51,8 +51,6 @@ private:
 	bool has_scroll_bar;
 	int non_empty_slots;
 	bool any_selected;
-	TooltipData tip_buf;
-	TooltipData tip_new;
 	std::string *values;
 	std::string *tooltips;
 	WidgetLabel *vlabels;


### PR DESCRIPTION
Closes #275

This moves WidgetListBox tooltip rendering to the scope of menu rendering.

Tooltips for WidgetButton remain unchanged for now. Button tooltips are
only currently used in a few spots in GameStateTitle & GameStateLoad.
Rendering order for those tooltips isn't really a problem.
