### PR TITLE
Allow effects for bonus maximum HP and MP as percentages

### DIFF
--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -55,8 +55,10 @@ void EffectManager::clearStatus() {
 
 	bonus_hp = 0;
 	bonus_hp_regen = 0;
+	bonus_hp_percent = 0;
 	bonus_mp = 0;
 	bonus_mp_regen = 0;
+	bonus_mp_percent = 0;
 	bonus_accuracy = 0;
 	bonus_avoidance = 0;
 	bonus_crit = 0;
@@ -91,8 +93,10 @@ void EffectManager::logic() {
 			}
 			else if (effect_list[i].type == "hp") bonus_hp += effect_list[i].magnitude;
 			else if (effect_list[i].type == "hp_regen") bonus_hp_regen += effect_list[i].magnitude;
+			else if (effect_list[i].type == "hp_percent") bonus_hp_percent += effect_list[i].magnitude;
 			else if (effect_list[i].type == "mp") bonus_mp += effect_list[i].magnitude;
 			else if (effect_list[i].type == "mp_regen") bonus_mp_regen += effect_list[i].magnitude;
+			else if (effect_list[i].type == "mp_percent") bonus_mp_percent += effect_list[i].magnitude;
 			else if (effect_list[i].type == "accuracy") bonus_accuracy += effect_list[i].magnitude;
 			else if (effect_list[i].type == "avoidance") bonus_avoidance += effect_list[i].magnitude;
 			else if (effect_list[i].type == "crit") bonus_crit += effect_list[i].magnitude;

--- a/src/EffectManager.h
+++ b/src/EffectManager.h
@@ -105,8 +105,10 @@ public:
 
 	int bonus_hp;
 	int bonus_hp_regen;
+	int bonus_hp_percent;
 	int bonus_mp;
 	int bonus_mp_regen;
+	int bonus_mp_percent;
 	int bonus_accuracy;
 	int bonus_avoidance;
 	int bonus_crit;

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -395,8 +395,8 @@ void StatBlock::recalc_alt() {
 	int def0 = get_defense() -1;
 
 	if (hero) {
-		maxhp = hp_base + (hp_per_level * lev0) + (hp_per_physical * phys0) + effects.bonus_hp;
-		maxmp = mp_base + (mp_per_level * lev0) + (mp_per_mental * ment0) + effects.bonus_mp;
+		maxhp = hp_base + (hp_per_level * lev0) + (hp_per_physical * phys0) + effects.bonus_hp + (effects.bonus_hp_percent * (hp_base + (hp_per_level * lev0) + (hp_per_physical * phys0)) / 100);
+		maxmp = mp_base + (mp_per_level * lev0) + (mp_per_mental * ment0) + effects.bonus_mp + (effects.bonus_mp_percent * (mp_base + (mp_per_level * lev0) + (mp_per_mental * phys0)) / 100);
 		hp_per_minute = hp_regen_base + (hp_regen_per_level * lev0) + (hp_regen_per_physical * phys0) + effects.bonus_hp_regen;
 		mp_per_minute = mp_regen_base + (mp_regen_per_level * lev0) + (mp_regen_per_mental * ment0) + effects.bonus_mp_regen;
 		accuracy = accuracy_base + (accuracy_per_level * lev0) + (accuracy_per_offense * off0) + effects.bonus_accuracy;


### PR DESCRIPTION
An effect can have effect_type=hp_percent (or mp_percent) for a bonus percentage to that stat, instead of using an absolute value.

It's calculated AFTER base hp/mp and hp/mp per level and per stat point, but BEFORE any other absolute hp/mp bonuses (from other items, passives, etc).  This is the implementation that makes most sense to me, but maybe others think otherwise.
