### PR TITLE
Implement per-enemy loot tables

### DIFF
--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -299,12 +299,6 @@ bool Enemy::takeHit(const Hazard &h) {
  * Upon enemy death, handle rewards (currency, xp, loot)
  */
 void Enemy::doRewards() {
-	bool loot_drop = false;
-
-	int roll = rand() % 100;
-	if (roll < stats.loot_chance) {
-		loot_drop = true;
-	}
 	reward_xp = true;
 
 	// some creatures create special loot if we're on a quest
@@ -312,10 +306,7 @@ void Enemy::doRewards() {
 
 		// the loot manager will check quest_loot_id
 		// if set (not zero), the loot manager will 100% generate that loot.
-		if (map->camp->checkStatus(stats.quest_loot_requires) && !map->camp->checkStatus(stats.quest_loot_not)) {
-			loot_drop = true;
-		}
-		else {
+		if (!(map->camp->checkStatus(stats.quest_loot_requires) && !map->camp->checkStatus(stats.quest_loot_not))) {
 			stats.quest_loot_id = 0;
 		}
 	}
@@ -324,7 +315,6 @@ void Enemy::doRewards() {
 	// this must be done in conjunction with defeat status
 	if (stats.first_defeat_loot > 0) {
 		if (!map->camp->checkStatus(stats.defeat_status)) {
-			loot_drop = true;
 			stats.quest_loot_id = stats.first_defeat_loot;
 		}
 	}
@@ -334,8 +324,7 @@ void Enemy::doRewards() {
 		map->camp->setStatus(stats.defeat_status);
 	}
 
-	// if (loot_drop)
-		LootManager::getInstance()->addEnemyLoot(this);
+	LootManager::getInstance()->addEnemyLoot(this);
 }
 
 /**

--- a/src/LootManager.h
+++ b/src/LootManager.h
@@ -73,18 +73,12 @@ private:
 
 	// functions
 	void loadGraphics();
-	void calcTables();
 	int lootLevel(int base_level);
 
 	Mix_Chunk *loot_flip;
 
 	// loot refers to ItemManager indices
 	std::vector<Loot> loot;
-
-	// loot tables multiplied out
-	// currently loot can range from levels 0-20
-	int loot_table[21][1024]; // level, number.  the int is an item id
-	int loot_table_count[21]; // total number per level
 
 	SDL_Rect animation_pos;
 	Point animation_offset;
@@ -107,10 +101,7 @@ public:
 	// called by enemy, who definitly wants to drop loot.
 	void addEnemyLoot(const Enemy *e);
 	void checkMapForLoot();
-	void determineLoot(int base_level, Point pos); // uniformly distributed within the base_level set, randomly chosen
-	void determineLootByClass(const Enemy *e, Point pos); // distributed according to enemies loot type probabilities, only from specific item class
 	void determineLootByEnemy(const Enemy *e, Point pos); // pick from enemy-specific loot table
-	int randomItem(int base_level);
 	void addLoot(ItemStack stack, Point pos);
 	void addCurrency(int count, Point pos);
 	ItemStack checkPickup(Point mouse, Point cam, Point hero_pos, int &currency, MenuInventory *inv);

--- a/src/NPC.cpp
+++ b/src/NPC.cpp
@@ -55,7 +55,6 @@ NPC::NPC(MapRenderer *_map, ItemManager *_items)
 	, vendor(false)
 	// stock
 	, stock_count(0)
-	, random_stock(0)
 	, vox_intro(vector<Mix_Chunk*>())
 	, vox_quests(vector<Mix_Chunk*>())
 	, dialog(vector<vector<Event_Component> >())
@@ -148,9 +147,6 @@ void NPC::load(const string& npc_id, int hero_level) {
 						stack.item = toInt(infile.nextValue());
 						stock.add(stack);
 					}
-				}
-				else if (infile.key == "random_stock") {
-					random_stock = toInt(infile.val);
 				}
 
 				// handle vocals

--- a/src/NPC.h
+++ b/src/NPC.h
@@ -74,7 +74,6 @@ public:
 	bool vendor;
 	ItemStorage stock;
 	int stock_count;
-	int random_stock;
 
 	// vocals
 	std::vector<Mix_Chunk*> vox_intro;

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -81,13 +81,6 @@ void NPCManager::handleNewMap() {
 		npc->pos.x = mn.pos.x;
 		npc->pos.y = mn.pos.y;
 
-		// if this NPC needs randomized items
-		while (npc->random_stock > 0 && npc->stock_count < NPC_VENDOR_MAX_STOCK) {
-			item_roll.item = loot->randomItem(npc->level);
-			item_roll.quantity = rand() % items->items[item_roll.item].rand_vendor + 1;
-			npc->stock.add(item_roll);
-			npc->random_stock--;
-		}
 		npc->stock.sort();
 		npcs.push_back(npc);
 	}

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -118,10 +118,6 @@ StatBlock::StatBlock() {
 	}
 
 	loot = vector<EnemyLoot>();
-	loot_chance = 50;
-	item_classes = vector<string>();
-	item_class_prob = vector<int>();
-	item_class_prob_sum = 0;
 	teleportation = false;
 
 	powers_list = vector<int>();
@@ -239,22 +235,6 @@ void StatBlock::load(const string& filename) {
 			el.id = toInt(infile.nextValue());
 			el.chance = toInt(infile.nextValue());
 			loot.push_back(el);
-		}
-		else if (infile.key == "loot_chance") loot_chance = num;
-		else if (infile.key == "item_class") {
-			string str;
-			while ((str = infile.nextValue()) != "") {
-				if (!isInt(str)) {
-					item_classes.push_back(str);
-					item_class_prob.push_back(1);
-					item_class_prob_sum++;
-				}
-				else {
-					num = toInt(str);
-					item_class_prob[item_classes.size()-1] = num;
-					item_class_prob_sum += num - 1; // one was already added, so add one less
-				}
-			}
 		}
 		else if (infile.key == "defeat_status") defeat_status = infile.val;
 		else if (infile.key == "first_defeat_loot") first_defeat_loot = num;

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -258,11 +258,6 @@ public:
 	bool suppress_hp; // hide an enemy HP bar
 
 	std::vector<EnemyLoot> loot;
-	int loot_chance;
-	std::vector<std::string> item_classes; // which kind of loot is able to be dropped
-	// the strings given in item_class correspond to the item class
-	std::vector<int> item_class_prob;      // weights for each kind of drop.
-	int item_class_prob_sum;               // sum of all loot_prob entries.
 
 	// for the teleport spell
 	bool teleportation;


### PR DESCRIPTION
For #266

Use `loot=<id>,<chance>` in enemy definition files, where `id` is an item
id and `chance` is a percentage chance that it will be dropped.
An id of 0 represents a gold drop.

If multiple loot items have the same chance, it's sent to a second list of
ids which go through another RNG roll.
