### PR TITLE
Add revive effect

### DIFF
--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -130,6 +130,7 @@ public:
 	bool drag_walking;
 	bool newLevelNotification;
 	bool respawn;
+	bool revived;
 
 private:
 	void handlePower(int actionbar_power);

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -52,6 +52,7 @@ void EffectManager::clearStatus() {
 	stun = false;
 	forced_speed = 0;
 	forced_move = false;
+	revive = false;
 
 	bonus_hp = 0;
 	bonus_hp_regen = 0;
@@ -93,6 +94,7 @@ void EffectManager::logic() {
 				forced_move = true;
 				forced_speed = effect_list[i].magnitude;
 			}
+			else if (effect_list[i].type == "revive") revive = true;
 			else if (effect_list[i].type == "hp") bonus_hp += effect_list[i].magnitude;
 			else if (effect_list[i].type == "hp_regen") bonus_hp_regen += effect_list[i].magnitude;
 			else if (effect_list[i].type == "hp_percent") bonus_hp_percent += effect_list[i].magnitude;

--- a/src/EffectManager.h
+++ b/src/EffectManager.h
@@ -102,6 +102,7 @@ public:
 	bool stun;
 	int forced_speed;
 	bool forced_move;
+	bool revive;
 
 	int bonus_hp;
 	int bonus_hp_regen;

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -673,6 +673,10 @@ void GameStatePlay::logic() {
 	}
 
 	// these actions occur whether the game is paused or not.
+	if (pc->revived) {
+		menu->inv->removeReviveItem();
+		pc->revived = false;
+	}
 	checkNotifications();
 	checkLootDrop();
 	checkTeleport();

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -551,6 +551,9 @@ TooltipData ItemManager::getTooltip(int item, StatBlock *stats, int context) {
 			modifier = msg->get("%d\% Speed", items[item].bonus_val[bonus_counter]);
 			if (items[item].bonus_val[bonus_counter] >= 100) color = color_bonus;
 			else color = color_penalty;
+		} else if (items[item].bonus_stat[bonus_counter] == "revive") {
+			modifier = msg->get("One-time protection from death");
+			color = color_bonus;
 		} else {
 			if (items[item].bonus_val[bonus_counter] > 0) {
 				modifier = msg->get("Increases %s by %d",
@@ -604,7 +607,7 @@ TooltipData ItemManager::getTooltip(int item, StatBlock *stats, int context) {
 	if (items[item].flavor != "") {
 		tip.addText(items[item].flavor, color_flavor);
 	}
-	
+
 	// buy or sell price
 	if (items[item].price > 0) {
 

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -526,6 +526,28 @@ void MenuInventory::remove(int item) {
 }
 
 /**
+ * Removes a one-time-use revive item from the player's equipment
+ */
+void MenuInventory::removeReviveItem() {
+	int item_id;
+	unsigned bonus_counter;
+	for (int i = 0; i < MAX_EQUIPPED; i++) {
+		item_id = inventory[EQUIPMENT][i].item;
+		const Item &item = items->items[item_id];
+		bonus_counter = 0;
+		while (bonus_counter < item.bonus_stat.size() && item.bonus_stat[bonus_counter] != "") {
+			if (item.bonus_stat[bonus_counter] == "revive") {
+				log_msg = msg->get("%s removed", item.name);
+				inventory[EQUIPMENT].remove(item_id);
+				applyEquipment(inventory[EQUIPMENT].storage);
+				return;
+			}
+			bonus_counter++;
+		}
+	}
+}
+
+/**
  * Add currency to the current total
  */
 void MenuInventory::addCurrency(int count) {

--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -83,6 +83,7 @@ public:
 
 	void add( ItemStack stack, int area = CARRIED, int slot = -1);
 	void remove(int item);
+	void removeReviveItem();
 	void addCurrency(int count);
 	bool buy(ItemStack stack, int tab);
 	bool sell(ItemStack stack);


### PR DESCRIPTION
Closes #285

If the player's HP reaches 0 and they have the revive effect:
- Thier HP is refilled
- We remove 1 equipped item that has a revive bonus

Because we always remove an item with the revive bonus, the effect itself
should only be granted as an equippable item bonus.
