### PR TITLE
Enable some additional standard related checks for cppcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libsdl1.2-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev cppcheck gcc-snapshot
 script: cmake . && make
-after_script: cppcheck --enable=all -q `git ls-files src/\*.cpp`
+after_script: cppcheck --verbose --enable=all --std=posix --std=c++11 --quiet `git ls-files src/\*.cpp`
 notifications:
   irc:
     channels:


### PR DESCRIPTION
Enables checks related to the POSIX and c++11 standard in cppcheck which might discover additional issues. At least, the posix trigger two extra messages (the portability ones) which someone might want to take a look at.

$ cppcheck --verbose --enable=all --std=posix --std=c++11 --quiet `git ls-files src/\*.cpp`
[src/PowerManager.h:183]: (warning) Member variable 'Power::requires_equipped_item' is not initialized in the constructor.
[src/NPC.cpp:45]: (warning) Member variable 'NPC::stock' is not initialized in the constructor.
[src/UtilsFileSystem.cpp:91]: (portability) Found non reentrant function 'readdir'. For threadsafe applications it is recommended to use the reentrant replacement function 'readdir_r'
[src/UtilsFileSystem.cpp:118]: (portability) Found non reentrant function 'readdir'. For threadsafe applications it is recommended to use the reentrant replacement function 'readdir_r'
