### PR TITLE
Only open panels if the character is alive

### DIFF
--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -664,10 +664,10 @@ void MenuManager::logic() {
 		closeAll(false);
 	}
 
-	if (MENUS_PAUSE) {
-		pause = (inv->visible || pow->visible || chr->visible || log->visible || vendor->visible || talker->visible);
-	}
 	menus_open = (inv->visible || pow->visible || chr->visible || log->visible || vendor->visible || talker->visible);
+	if (MENUS_PAUSE) {
+		pause = menus_open;
+	}
 
 	// handle equipment changes affecting hero stats
 	if (inv->changed_equipment || inv->changed_artifact) {


### PR DESCRIPTION
When the player character is killed, all open panels are immediately closed. If one tries to open one of them, either through the appropriate buttons or by using the keyboard shortcuts ("i", "c", "p" or "l") a "turn page" sound is played as if a panel was opened, but nothing is displayed.

I looked into src/MenuManager.cpp::logic and discovered that the panels are not actually closed upon death, if a character is no longer alive, all panels are closed each time this method is run. In other words, even if a panel is opened, it would be immediately closed, thus appearing as if the action had no effect. However, the sound for opening a panel is played, seemingly without any results. This patch moves the check for the panels to open inside an existing check for things which only happens if the player is alive. With this, attempting to open a panel will no longer play the sound.

I have to admit I don't know the code all that well, so I don't know if there was a reason for this setup or if should be done differently somehow. Especially the menus_open section since I don't know how important the order is here.

PS. Furthermore I believe the check on whether panels should be displayed or not could be refactored out, since currently all four panels are duplicating essentially the same code with different keys and variable names. I made a brief attempt at splitting out parts of it, but when I tried to make it more generic it wouldn't compile anymore.
