### PR TITLE
Allow menus to be opened after death

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -53,6 +53,7 @@ Avatar::Avatar(PowerManager *_powers, MapRenderer *_map)
  , attacking (false)
  , drag_walking(false)
  , respawn(false)
+ , close_menus(false)
 {
 
 	init();
@@ -621,6 +622,9 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 				// raise the death penalty flag.  Another module will read this and reset.
 				stats.death_penalty = true;
+
+				// close menus in GameStatePlay
+				close_menus = true;
 
 				if (sound_die)
 					Mix_PlayChannel(-1, sound_die, 0);

--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -130,6 +130,7 @@ public:
 	bool drag_walking;
 	bool newLevelNotification;
 	bool respawn;
+	bool close_menus;
 
 private:
 	void handlePower(int actionbar_power);

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -676,6 +676,12 @@ void GameStatePlay::logic() {
 
 	}
 
+	// close menus when the player dies, but still allow them to be reopened
+	if (pc->close_menus) {
+		pc->close_menus = false;
+		menu->closeAll(false);
+	}
+
 	// these actions occur whether the game is paused or not.
 	checkNotifications();
 	checkLootDrop();

--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -470,7 +470,7 @@ void MenuCharacter::logic() {
 	int spent = stats->physical_character + stats->mental_character + stats->offense_character + stats->defense_character -4;
 	skill_points = (stats->level * stats->stat_points_per_level) - spent;
 
-	if (spent < (stats->level * stats->stat_points_per_level) && spent < stats->max_spendable_stat_points) {
+	if (stats->hp > 0 && spent < (stats->level * stats->stat_points_per_level) && spent < stats->max_spendable_stat_points) {
 		if (stats->physical_character < stats->max_points_per_stat && show_upgrade[0]) upgradeButton[0]->enabled = true;
 		if (stats->mental_character  < stats->max_points_per_stat && show_upgrade[1]) upgradeButton[1]->enabled = true;
 		if (stats->offense_character < stats->max_points_per_stat && show_upgrade[2]) upgradeButton[2]->enabled = true;

--- a/src/MenuLog.cpp
+++ b/src/MenuLog.cpp
@@ -125,18 +125,10 @@ void MenuLog::logic() {
 		visible = false;
 	}
 
+	tabControl->logic();
 	int active_log = tabControl->getActiveTab();
 	msg_buffer[active_log]->logic();
 }
-
-/**
- * Run the logic for the tabs control.
- */
-void MenuLog::tabsLogic()
-{
-	tabControl->logic();
-}
-
 
 /**
  * Render graphics for this frame when the menu is open

--- a/src/MenuLog.h
+++ b/src/MenuLog.h
@@ -74,7 +74,6 @@ public:
 
 	void update();
 	void logic();
-	void tabsLogic();
 	void render();
 	void refresh(int log_type);
 	void add(const std::string& s, int log_type);

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -452,7 +452,6 @@ void MenuManager::logic() {
 
 			if (log->visible && isWithin(log->window_area,inpt->mouse)) {
 				inpt->lock[MAIN1] = true;
-				log->tabsLogic();
 			}
 
 			// pick up an inventory item
@@ -667,7 +666,6 @@ void MenuManager::logic() {
 			drag_src = -1;
 			dragging = false;
 		}
-		closeAll(false);
 	}
 
 	// handle equipment changes affecting hero stats


### PR DESCRIPTION
The menus are still close when the player dies, so they can see the hudlog
message explaining the game over status.

Stat upgrade buttons are now disabled when dead.
Tab behavior in MenuLog is now similar to MenuPowers.
