### PR TITLE
Introduce Poise stat

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -778,7 +778,9 @@ bool Avatar::takeHit(const Hazard &h) {
 		}
 		else if (prev_hp > stats.hp) { // only interrupt if damage was taken
 			playSfx(sound_hit);
-			stats.cur_state = AVATAR_HIT;
+			if (!percentChance(stats.poise)) {
+				stats.cur_state = AVATAR_HIT;
+			}
 		}
 
 		return true;

--- a/src/BehaviorStandard.cpp
+++ b/src/BehaviorStandard.cpp
@@ -454,7 +454,6 @@ void BehaviorStandard::updateState() {
 
 			e->setAnimation("hit");
 			if (e->activeAnimation->isFirstFrame()) {
-				e->sfx_hit = true;
 				e->stats.effects.triggered_hit = true;
 			}
 			if (e->activeAnimation->isLastFrame()) e->newState(ENEMY_STANCE);

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -71,6 +71,7 @@ void EffectManager::clearStatus() {
 	bonus_currency = 0;
 	bonus_item_find = 0;
 	bonus_stealth = 0;
+	bonus_poise = 0;
 
 	for (unsigned i=0; i<bonus_resist.size(); i++) {
 		bonus_resist[i] = 0;
@@ -111,6 +112,7 @@ void EffectManager::logic() {
 			else if (effect_list[i].type == "currency") bonus_currency += effect_list[i].magnitude;
 			else if (effect_list[i].type == "item_find") bonus_item_find += effect_list[i].magnitude;
 			else if (effect_list[i].type == "stealth") bonus_stealth += effect_list[i].magnitude;
+			else if (effect_list[i].type == "poise") bonus_poise += effect_list[i].magnitude;
 			else {
 				for (unsigned j=0; j<bonus_resist.size(); j++) {
 					if (effect_list[i].type == ELEMENTS[j].name + "_resist")

--- a/src/EffectManager.h
+++ b/src/EffectManager.h
@@ -122,6 +122,7 @@ public:
 	int bonus_currency;
 	int bonus_item_find;
 	int bonus_stealth;
+	int bonus_poise;
 	std::vector<int> bonus_resist;
 
 	bool triggered_others;

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -280,12 +280,16 @@ bool Enemy::takeHit(const Hazard &h) {
 
 			}
 			// don't go through a hit animation if stunned
-			else if (!stats.effects.stun) {
+			else if (!stats.effects.stun && !percentChance(stats.poise)) {
 				stats.cur_state = ENEMY_HIT;
 				// roll to see if the enemy's ON_HIT power is casted
 				if (percentChance(stats.power_chance[ON_HIT])) {
 					powers->activate(stats.power_index[ON_HIT], &stats, stats.pos);
 				}
+			}
+			// just play the hit sound
+			else {
+				sfx_hit = true;
 			}
 
 		}

--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -48,7 +48,7 @@ MenuCharacter::MenuCharacter(StatBlock *_stats) {
 		cstat[i].hover.w = cstat[i].hover.h = 0;
 		cstat[i].visible = true;
 	}
-	for (int i=0; i<16; i++) {
+	for (int i=0; i<STATLIST_COUNT; i++) {
 		show_stat[i] = true;
 	}
 	statlist_rows = 10;
@@ -183,23 +183,25 @@ MenuCharacter::MenuCharacter(StatBlock *_stats) {
 				if (eatFirstInt(infile.val,',') == 0) show_stat[9] = false;
 			} else if (infile.key == "show_absorb"){
 				if (eatFirstInt(infile.val,',') == 0) show_stat[10] = false;
-			} else if (infile.key == "show_bonus_xp"){
+			} else if (infile.key == "show_poise"){
 				if (eatFirstInt(infile.val,',') == 0) show_stat[11] = false;
-			} else if (infile.key == "show_bonus_currency"){
+			} else if (infile.key == "show_bonus_xp"){
 				if (eatFirstInt(infile.val,',') == 0) show_stat[12] = false;
-			} else if (infile.key == "show_bonus_itemfind"){
+			} else if (infile.key == "show_bonus_currency"){
 				if (eatFirstInt(infile.val,',') == 0) show_stat[13] = false;
-			} else if (infile.key == "show_bonus_stealth"){
+			} else if (infile.key == "show_bonus_itemfind"){
 				if (eatFirstInt(infile.val,',') == 0) show_stat[14] = false;
-			} else if (infile.key == "show_resists"){
+			} else if (infile.key == "show_bonus_stealth"){
 				if (eatFirstInt(infile.val,',') == 0) show_stat[15] = false;
+			} else if (infile.key == "show_resists"){
+				if (eatFirstInt(infile.val,',') == 0) show_stat[16] = false;
 			}
 		}
 		infile.close();
 	} else fprintf(stderr, "Unable to open menus/character.txt!\n");
 
 	// stat list
-	statList = new WidgetListBox(15+stats->vulnerable.size(), statlist_rows, mods->locate("images/menus/buttons/listbox_char.png"));
+	statList = new WidgetListBox(STATLIST_COUNT-1+stats->vulnerable.size(), statlist_rows, mods->locate("images/menus/buttons/listbox_char.png"));
 	statList->can_select = false;
 	statList->scrollbar_offset = statlist_scrollbar_offset;
 
@@ -386,29 +388,35 @@ void MenuCharacter::refreshStats() {
 
 	if (show_stat[11]) {
 		ss.str("");
+		ss << msg->get("Poise: ") << stats->poise << "%";
+		statList->set(visible_stats++, ss.str(),msg->get("Reduces your chance of stumbling when hit"));
+	}
+
+	if (show_stat[12]) {
+		ss.str("");
 		ss << msg->get("Bonus") << " XP: " << stats->effects.bonus_xp << "%";
 		statList->set(visible_stats++, ss.str(),msg->get("Increases the XP gained per kill"));
 	}
 
-	if (show_stat[12]) {
+	if (show_stat[13]) {
 		ss.str("");
 		ss << msg->get("Bonus") << " " << CURRENCY << ": " << stats->effects.bonus_currency << "%";
 		statList->set(visible_stats++, ss.str(),msg->get("Increases the %s found per drop",CURRENCY));
 	}
 
-	if (show_stat[13]) {
+	if (show_stat[14]) {
 		ss.str("");
 		ss << msg->get("Bonus Item Find: ") << stats->effects.bonus_item_find << "%";
 		statList->set(visible_stats++, ss.str(),msg->get("Increases the chance that an enemy will drop an item when killed"));
 	}
 
-	if (show_stat[14]) {
+	if (show_stat[15]) {
 		ss.str("");
 		ss << msg->get("Stealth: ") << stats->effects.bonus_stealth << "%";
 		statList->set(visible_stats++, ss.str(),msg->get("Increases your ability to move undetected"));
 	}
 
-	if (show_stat[15]) {
+	if (show_stat[16]) {
 		for (unsigned int j=0; j<stats->vulnerable.size(); j++) {
 			ss.str("");
 			ss << msg->get(ELEMENTS[j].resist) << ": " << (100 - stats->vulnerable[j]) << "%";

--- a/src/MenuCharacter.h
+++ b/src/MenuCharacter.h
@@ -46,6 +46,7 @@ const int CSTAT_MENTAL = 3;
 const int CSTAT_OFFENSE = 4;
 const int CSTAT_DEFENSE = 5;
 const int CSTAT_COUNT = 6;
+const int STATLIST_COUNT = 17;
 
 class CharStat {
 public:
@@ -93,7 +94,7 @@ private:
 	LabelInfo label_pos[CSTAT_COUNT];
 	SDL_Rect value_pos[CSTAT_COUNT];
 	bool show_upgrade[4];
-	bool show_stat[16];
+	bool show_stat[STATLIST_COUNT];
 
 
 public:

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -119,6 +119,8 @@ StatBlock::StatBlock()
 	, forced_speed(Point())
 	, direction(0)
 	, hero_cooldown(vector<int>(POWER_COUNT, 0)) // hero only
+	, poise(0)
+	, poise_base(0)
 	, cur_state(0)
 	, waypoints(queue<Point>())		// enemy only
 	, waypoint_pause(0)				// enemy only
@@ -243,13 +245,13 @@ void StatBlock::load(const string& filename) {
 		// enemy death rewards and events
 		else if (infile.key == "xp") xp = num;
 		else if (infile.key == "loot") {
-		
+
 			// loot entries format:
 			// loot=[id],[percent_chance]
-			
+
 			EnemyLoot el;
 			std::string loot_id = infile.nextValue();
-			
+
 			// id 0 means currency. The keyword "currency" can also be used.
 			if (loot_id == "currency")
 				el.id = 0;
@@ -279,6 +281,7 @@ void StatBlock::load(const string& filename) {
 		else if (infile.key == "dmg_ranged_max") dmg_ranged_max = num;
 		else if (infile.key == "absorb_min") absorb_min = num;
 		else if (infile.key == "absorb_max") absorb_max = num;
+		else if (infile.key == "poise") poise = poise_base = num;
 
 		// behavior stats
 		else if (infile.key == "flying") {
@@ -441,6 +444,8 @@ void StatBlock::recalc_alt() {
 
 	speed = speed_default;
 	dspeed = dspeed_default;
+
+	poise = poise_base + effects.bonus_poise;
 
 	for (unsigned i=0; i<effects.bonus_resist.size(); i++) {
 		vulnerable[i] = 100 - effects.bonus_resist[i];

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -219,6 +219,9 @@ public:
 	char direction;
 	std::vector<int> hero_cooldown;
 
+	int poise;
+	int poise_base;
+
 	// state
 	int cur_state;
 


### PR DESCRIPTION
Closes #80

I went with a percentage chance here as opposed to a damage threshold
because I think it's easier to scale when balancing combat numbers. We can
always change the formula to a damage threshold later if that's the desired
method.

I decided to keep the hit sound effect when damage recoil is skipped, since
it's the only form of feedback when combat text is off.
