### PR TITLE
Fix crash from freeing backgroundsurface twice in MapRenderer

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -1282,7 +1282,6 @@ MapRenderer::~MapRenderer() {
 	}
 	Mix_FreeChunk(sfx);
 
-	SDL_FreeSurface(backgroundsurface);
 	tip_buf.clear();
 	clearLayers();
 	clearEvents();


### PR DESCRIPTION
`backgroundsurface` is already freed in MapRenderer::clearLayers(), which
is called in MapRenderer's deconstructor.
