### PR TITLE
Fix elemental resists/weaknesses for enemies

### DIFF
--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -181,6 +181,7 @@ StatBlock::StatBlock()
 	}
 
 	vulnerable = std::vector<int>(ELEMENTS.size(), 100);
+	vulnerable_base = std::vector<int>(ELEMENTS.size(), 100);
 
 	// formula numbers. Used only for hero
 	hp_base = 10;
@@ -229,7 +230,7 @@ void StatBlock::load(const string& filename) {
 
 		for (unsigned int i=0; i<ELEMENTS.size(); i++) {
 			if (infile.key == "vulnerable_" + ELEMENTS[i].name) {
-				vulnerable[i] = num;
+				vulnerable[i] = vulnerable_base[i] = num;
 				valid = true;
 			}
 		}
@@ -448,7 +449,7 @@ void StatBlock::recalc_alt() {
 	poise = poise_base + effects.bonus_poise;
 
 	for (unsigned i=0; i<effects.bonus_resist.size(); i++) {
-		vulnerable[i] = 100 - effects.bonus_resist[i];
+		vulnerable[i] = vulnerable_base[i] - effects.bonus_resist[i];
 	}
 
 	if (hp > maxhp) hp = maxhp;

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -207,6 +207,7 @@ public:
 	bool wielding_mental;
 	bool wielding_offense;
 	std::vector<int> vulnerable;
+	std::vector<int> vulnerable_base;
 
 	// buff and debuff stats
 	int transform_duration;


### PR DESCRIPTION
By having a vulnerable_base stat, the vulnerable_\* values given in enemy
definition files won't be overwritten when effect bonuses are applied.
