### PR TITLE
Fix Avatar transform stat maxes

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -823,17 +823,17 @@ void Avatar::transform() {
 
 	// damage
 	clampFloor(stats.dmg_melee_min, charmed_stats->dmg_melee_min);
-	clampCeil(stats.dmg_melee_max, charmed_stats->dmg_melee_max);
+	clampFloor(stats.dmg_melee_max, charmed_stats->dmg_melee_max);
 
 	clampFloor(stats.dmg_ment_min, charmed_stats->dmg_ment_min);
-	clampCeil(stats.dmg_ment_max, charmed_stats->dmg_ment_max);
+	clampFloor(stats.dmg_ment_max, charmed_stats->dmg_ment_max);
 
 	clampFloor(stats.dmg_ranged_min, charmed_stats->dmg_ranged_min);
-	clampCeil(stats.dmg_ranged_max, charmed_stats->dmg_ranged_max);
+	clampFloor(stats.dmg_ranged_max, charmed_stats->dmg_ranged_max);
 
 	// dexterity
 	clampFloor(stats.absorb_min, charmed_stats->absorb_min);
-	clampCeil(stats.absorb_max, charmed_stats->absorb_max);
+	clampFloor(stats.absorb_max, charmed_stats->absorb_max);
 
 	clampFloor(stats.avoidance, charmed_stats->avoidance);
 


### PR DESCRIPTION
Closes https://github.com/makrohn/polymorphable/issues/31

I think that clampCeil was erroneously used where it ought to have been clampFloor.  If I understand https://github.com/clintbellanger/flare-engine/blob/master/src/UtilsMath.h#L32 correctly, clampFloor is looking to make sure that the higher of two values is used - in this case, dmg___min or dmg___max.  By using clampCeil on the dmg___max, it was setting dmg___max to the lower of two values - which was causing some really weird damage behavior when transformed (with damage values of say, 4-2).

The same issue affected absorb min and max.

Here's the commit where the error appears to have been introduced.  I believe that I am restoring the original desired behavior.
https://github.com/clintbellanger/flare-engine/commit/5e9c0f47e8b80b36f15bc60cee47b7c717e7789f#L0L836

Tested in Polymorphable, just because it's easier to see there with static damage numbers.
