### PR TITLE
Allow defining default names for portraits

### DIFF
--- a/src/GameStateNew.h
+++ b/src/GameStateNew.h
@@ -53,10 +53,12 @@ private:
 	void loadPortrait(const std::string& portrait_filename);
 	void loadOptions(const std::string& option_filename);
 	std::string getClassTooltip(int index);
+	void setName(const std::string& default_name);
 
 	std::vector<std::string> base;
 	std::vector<std::string> head;
 	std::vector<std::string> portrait;
+	std::vector<std::string> name;
 	int option_count;
 	int current_option;
 
@@ -75,7 +77,7 @@ private:
 	WidgetListBox *class_list;
 	WidgetTooltip *tip;
 
-	Point name;
+	Point name_pos;
 	LabelInfo portrait_label;
 	LabelInfo name_label;
 	LabelInfo permadeath_label;
@@ -83,6 +85,7 @@ private:
 	SDL_Rect portrait_pos;
 	bool show_classlist;
 	TooltipData tip_buf;
+	bool modified_name;
 
 	SDL_Color color_normal;
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -156,7 +156,6 @@ float VENDOR_RATIO = 0.25;
 
 // Other Settings
 bool MENUS_PAUSE = false;
-std::string DEFAULT_NAME = "";
 bool SAVE_HPMP = false;
 bool ENABLE_PLAYGAME = false;
 bool SHOW_FPS = false;
@@ -351,8 +350,6 @@ void loadMiscSettings() {
 			if (infile.key == "save_hpmp") {
 				if (toInt(infile.val) == 1)
 					SAVE_HPMP = true;
-			} else if (infile.key == "default_name") {
-				DEFAULT_NAME = infile.val;
 			} else if (infile.key == "corpse_timeout") {
 				CORPSE_TIMEOUT = toInt(infile.val);
 			} else if (infile.key == "sell_without_vendor") {

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -110,7 +110,6 @@ extern bool COMBAT_TEXT;
 
 // Engine Settings
 extern bool MENUS_PAUSE;
-extern std::string DEFAULT_NAME;
 extern bool SAVE_HPMP;
 extern bool ENABLE_PLAYGAME;
 extern bool SHOW_FPS;


### PR DESCRIPTION
The name is the last value of an `option` key in `engine/hero_options.txt`.
Example: `option=male,head_short,male01,The Hero`

This means that the `default_name` variable in `engine/misc.txt` is now
obsolete.
