### PR TITLE
Play item sounds in MenuVendor

### DIFF
--- a/src/MenuVendor.cpp
+++ b/src/MenuVendor.cpp
@@ -175,6 +175,7 @@ ItemStack MenuVendor::click(InputState * input) {
  * Cancel the dragging initiated by the clic()
  */
 void MenuVendor::itemReturn(ItemStack stack) {
+	items->playSound(stack.item);
 	stock[activetab].itemReturn(stack);
 	saveInventory();
 }
@@ -186,6 +187,7 @@ void MenuVendor::add(ItemStack stack) {
 		stock[VENDOR_SELL][0].quantity = 0;
 		sort(VENDOR_SELL);
 	}
+	items->playSound(stack.item);
 	stock[VENDOR_SELL].add(stack);
 	saveInventory();
 }


### PR DESCRIPTION
This plays sounds when items are returned/added to either of the vendor
tabs.

Personally, I like playing the item sound with the coins sound when selling items. But this is subjective, so please test this beforehand to make sure that is the effect we want.
