### PR TITLE
Fixes so that sound is played when close button is pressed on dialogs.

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1,5 +1,6 @@
 /*
 Copyright © 2011-2012 kitano
+Copyright © 2013 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -27,6 +28,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 Menu::Menu()
 	: background(NULL)
 	, visible(false)
+	, sfx_open(0)
+	, sfx_close(0)
 {}
 
 Menu::~Menu() {

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -1,5 +1,6 @@
 /*
 Copyright © 2011-2012 kitano
+Copyright © 2013 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -28,6 +29,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include <SDL_image.h>
 #include <string>
+#include "SoundManager.h"
 
 class Menu {
 protected:
@@ -44,6 +46,9 @@ public:
 
 	virtual void align();
 	virtual void render() = 0;
+
+	SoundManager::SoundID sfx_open;
+	SoundManager::SoundID sfx_close;
 };
 
 #endif

--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -1,5 +1,6 @@
 /*
 Copyright © 2011-2012 Clint Bellanger
+Copyright © 2013 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -468,6 +469,7 @@ void MenuCharacter::logic() {
 
 	if (closeButton->checkClick()) {
 		visible = false;
+		snd->play(sfx_close);
 	}
 
 	// upgrade buttons

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -2,6 +2,7 @@
 Copyright © 2011-2012 Clint Bellanger
 Copyright © 2012 Igor Paliychuk
 Copyright © 2012 Stefan Beller
+Copyright © 2013 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -146,6 +147,7 @@ void MenuInventory::logic() {
 	if (visible) {
 		if (closeButton->checkClick()) {
 			visible = false;
+			snd->play(sfx_close);
 		}
 		if (drag_prev_src == -1) {
 			clearHighlight();

--- a/src/MenuLog.cpp
+++ b/src/MenuLog.cpp
@@ -1,5 +1,6 @@
 /*
 Copyright © 2011-2012 Clint Bellanger
+Copyright © 2013 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -123,6 +124,7 @@ void MenuLog::logic() {
 
 	if (closeButton->checkClick()) {
 		visible = false;
+		snd->play(sfx_close);
 	}
 
 	tabControl->logic();

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -209,6 +209,10 @@ void MenuManager::loadIcons() {
 void MenuManager::loadSounds() {
 	sfx_open = snd->load("soundfx/inventory/inventory_page.ogg", "MenuManager open tab");
 	sfx_close = snd->load("soundfx/inventory/inventory_book.ogg", "MenuManager close tab");
+
+	inv->sfx_close = vendor->sfx_close = stash->sfx_close = sfx_close; 
+	pow->sfx_close = log->sfx_close = chr->sfx_close = sfx_close;
+	
 }
 
 

--- a/src/MenuPowers.cpp
+++ b/src/MenuPowers.cpp
@@ -2,6 +2,7 @@
 Copyright © 2011-2012 Clint Bellanger
 Copyright © 2012 Igor Paliychuk
 Copyright © 2012 Stefan Beller
+Copyright © 2013 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -408,6 +409,7 @@ void MenuPowers::logic() {
 
 	if (closeButton->checkClick()) {
 		visible = false;
+		snd->play(sfx_close);
 	}
 	if (tabs_count > 1) tabControl->logic();
 }

--- a/src/MenuStash.cpp
+++ b/src/MenuStash.cpp
@@ -1,5 +1,6 @@
 /*
 Copyright © 2011-2012 Clint Bellanger
+Copyright © 2013 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -97,6 +98,7 @@ void MenuStash::logic() {
 
 	if (closeButton->checkClick()) {
 		visible = false;
+		snd->play(sfx_close);
 	}
 }
 

--- a/src/MenuVendor.cpp
+++ b/src/MenuVendor.cpp
@@ -1,5 +1,6 @@
 /*
 Copyright © 2011-2012 Clint Bellanger
+Copyright © 2013 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -117,6 +118,7 @@ void MenuVendor::logic() {
 
 	if (closeButton->checkClick()) {
 		visible = false;
+		snd->play(sfx_close);
 	}
 }
 


### PR DESCRIPTION
This affects the following dialogs: Stash, Inventory, Character, Powers, Vendor and Log
- Add sfx_close/open to Menu base class so each parent class can access a open/close sound effect if needed.
- Update MenuManager to set default menu close sound for a few specific menus windows.
- Updated the specific menus to play close sound when close button is pressed.
