### PR TITLE
Remove cppcheck-warnings from sound manager and harmonize coding style.

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -78,12 +78,12 @@ void MapRenderer::clearEvents() {
 }
 
 void MapRenderer::playSFX(string filename) {
-        SoundManager::SoundID sid = sfx;
+	SoundManager::SoundID sid = sfx;
 
 	sid = snd->load(filename, "MapRenderer background music");
 
 	if (sid != sfx)
-	  snd->unload(sfx);
+		snd->unload(sfx);
 
 	sfx = sid;
 


### PR DESCRIPTION
[src/SoundManager.cpp:59]: (style) The scope of the variable 'psnd' can be reduced.
[src/SoundManager.cpp:42]: (warning) Member variable 'Sound::chunk' is not initialized in the constructor.
[src/SoundManager.cpp:152]: (performance) Prefer prefix ++/-- operators for non-primitive types.

No changes in functionality intended.
Hereby I also notify @hean01 who is the original author of the sound manager. 
