### PR TITLE
Added game_prefix in engine/misc.txt for ability to segregate saved games

### DIFF
--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -267,9 +267,12 @@ void GameStateLoad::readGameSlot(int slot) {
 	if (slot < 0 || slot >= GAME_SLOT_MAX) return;
 
 	// save slots are named save#.txt
+	filename << PATH_USER;
+	if (GAME_PREFIX.length() > 0)
+	  filename << GAME_PREFIX << "_";
 	filename << "save" << (slot+1) << ".txt";
 
-	if (!infile.open(PATH_USER + filename.str())) return;
+	if (!infile.open(filename.str())) return;
 
 	while (infile.next()) {
 

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -2,6 +2,7 @@
 Copyright © 2011-2012 Clint Bellanger
 Copyright © 2012 Igor Paliychuk
 Copyright © 2012 Stefan Beller
+Copyright © 2013 Henrik Andersson
 
 This file is part of FLARE.
 
@@ -59,7 +60,10 @@ void GameStatePlay::saveGame() {
 
 	stringstream ss;
 	ss.str("");
-	ss << PATH_USER << "save" << game_slot << ".txt";
+	ss << PATH_USER;
+	if (GAME_PREFIX.length() > 0)
+	  ss << GAME_PREFIX << "_";
+	ss << "save" << game_slot << ".txt";
 
 	outfile.open(ss.str().c_str(), ios::out);
 
@@ -144,7 +148,10 @@ void GameStatePlay::saveGame() {
 
 	// Save stash
 	ss.str("");
-	ss << PATH_USER << "stash.txt";
+	ss << PATH_USER;
+	if (GAME_PREFIX.length() > 0)
+	  ss << GAME_PREFIX << "_";
+	ss << "stash.txt";
 
 	outfile.open(ss.str().c_str(), ios::out);
 
@@ -179,7 +186,10 @@ void GameStatePlay::loadGame() {
 
 	stringstream ss;
 	ss.str("");
-	ss << PATH_USER << "save" << game_slot << ".txt";
+	ss << PATH_USER;
+	if (GAME_PREFIX.length() > 0)
+	  ss << GAME_PREFIX << "_";
+	ss << "save" << game_slot << ".txt";
 
 	if (infile.open(ss.str())) {
 		while (infile.next()) {
@@ -306,20 +316,7 @@ void GameStatePlay::loadGame() {
 	menu->inv->inventory[EQUIPMENT].fillEquipmentSlots();
 
 	// Load stash
-	ss.str("");
-	ss << PATH_USER << "stash.txt";
-
-	if (infile.open(ss.str())) {
-		while (infile.next()) {
-			if (infile.key == "item") {
-				menu->stash->stock.setItems(infile.val);
-			}
-			else if (infile.key == "quantity") {
-				menu->stash->stock.setQuantities(infile.val);
-			}
-		}
-		infile.close();
-	}  else fprintf(stderr, "Unable to open %s!\n", ss.str().c_str());
+	loadStash();
 
 	// initialize vars
 	pc->stats.recalc();
@@ -399,7 +396,10 @@ void GameStatePlay::loadStash() {
 	FileParser infile;
 	stringstream ss;
 	ss.str("");
-	ss << PATH_USER << "stash.txt";
+	ss << PATH_USER;
+	if (GAME_PREFIX.length() > 0)
+	  ss << GAME_PREFIX << "_";
+	ss << "stash.txt";
 
 	if (infile.open(ss.str())) {
 		while (infile.next()) {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -163,6 +163,7 @@ bool SHOW_FPS = false;
 int CORPSE_TIMEOUT = 1800;
 bool SELL_WITHOUT_VENDOR = true;
 int AIM_ASSIST = 0;
+std::string GAME_PREFIX = "";
 std::string WINDOW_TITLE = "Flare";
 
 
@@ -370,6 +371,8 @@ void loadMiscSettings() {
 				AIM_ASSIST = toInt(infile.val);
 			} else if (infile.key == "window_title") {
 				WINDOW_TITLE = infile.val;
+			} else if (infile.key == "game_prefix") {
+				GAME_PREFIX = infile.val;
 			}
 
 		}

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -118,6 +118,7 @@ extern int CORPSE_TIMEOUT;
 extern bool SELL_WITHOUT_VENDOR;
 extern int AIM_ASSIST;
 extern std::string WINDOW_TITLE;
+extern std::string GAME_PREFIX;
 
 // Tile Settings
 extern unsigned short UNITS_PER_TILE;


### PR DESCRIPTION
The saved game slot and stash is prefixed with the defined game_prefix so same
code/path can be reused for saved games of different "flare" based games.

Possible fix for issue #364
