### PR TITLE
Revert "Merge pull request #378 from stefanbeller/master"

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -43,7 +43,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 using namespace std;
 
 Avatar::Avatar(PowerManager *_powers, MapRenderer *_map)
- : Entity(_map, new AvatarStatBlock())
+ : Entity(_map)
  , lockSwing(false)
  , lockCast(false)
  , lockShoot(false)
@@ -61,7 +61,7 @@ Avatar::Avatar(PowerManager *_powers, MapRenderer *_map)
 	init();
 
 	// default hero animation data
-	statBlock()->cooldown = 4;
+	stats.cooldown = 4;
 
 	// load the hero's animations from hero definition file
 	anim->increaseCount("animations/hero.txt");
@@ -73,16 +73,16 @@ Avatar::Avatar(PowerManager *_powers, MapRenderer *_map)
 
 void Avatar::init() {
 
-	statBlock()->hero_cooldown.resize(POWER_COUNT);
+	stats.hero_cooldown.resize(POWER_COUNT);
 
 	// name, base, look are set by GameStateNew so don't reset it here
 
 	// other init
 	sprites = 0;
-	statBlock()->cur_state = AVATAR_STANCE;
-	statBlock()->pos.x = map->spawn.x;
-	statBlock()->pos.y = map->spawn.y;
-	statBlock()->direction = map->spawn_dir;
+	stats.cur_state = AVATAR_STANCE;
+	stats.pos.x = map->spawn.x;
+	stats.pos.y = map->spawn.y;
+	stats.direction = map->spawn_dir;
 	current_power = 0;
 	newLevelNotification = false;
 
@@ -90,26 +90,26 @@ void Avatar::init() {
 	lockCast = false;
 	lockShoot = false;
 
-	statBlock()->hero = true;
-	statBlock()->humanoid = true;
-	statBlock()->level = 1;
-	statBlock()->xp = 0;
-	statBlock()->physical_character = 1;
-	statBlock()->mental_character = 1;
-	statBlock()->offense_character = 1;
-	statBlock()->defense_character = 1;
-	statBlock()->physical_additional = 0;
-	statBlock()->mental_additional = 0;
-	statBlock()->offense_additional = 0;
-	statBlock()->defense_additional = 0;
-	statBlock()->speed = 14;
-	statBlock()->dspeed = 10;
-	statBlock()->recalc();
+	stats.hero = true;
+	stats.humanoid = true;
+	stats.level = 1;
+	stats.xp = 0;
+	stats.physical_character = 1;
+	stats.mental_character = 1;
+	stats.offense_character = 1;
+	stats.defense_character = 1;
+	stats.physical_additional = 0;
+	stats.mental_additional = 0;
+	stats.offense_additional = 0;
+	stats.defense_additional = 0;
+	stats.speed = 14;
+	stats.dspeed = 10;
+	stats.recalc();
 
 	log_msg = "";
 	respawn = false;
 
-	statBlock()->cooldown_ticks = 0;
+	stats.cooldown_ticks = 0;
 
 	haz = NULL;
 
@@ -121,7 +121,7 @@ void Avatar::init() {
 	last_transform = "";
 	untransform_power = getUntransformPower();
 
-	statBlock()->hero_cooldown = vector<int>(POWER_COUNT, 0);
+	stats.hero_cooldown = vector<int>(POWER_COUNT, 0);
 
 	for (int i=0; i<4; i++) {
 		sound_steps[i] = 0;
@@ -190,7 +190,7 @@ void Avatar::loadGraphics(std::vector<Layer_gfx> _img_gfx) {
 
 	for (unsigned int i=0; i<_img_gfx.size(); i++) {
 		if (_img_gfx[i].gfx != "") {
-			string name = "animations/avatar/"+statBlock()->base+"/"+_img_gfx[i].gfx+".txt";
+			string name = "animations/avatar/"+stats.base+"/"+_img_gfx[i].gfx+".txt";
 			anim->increaseCount(name);
 			animsets.push_back(anim->getAnimationSet(name));
 			anims.push_back(animsets.back()->getAnimation(activeAnimation->getName()));
@@ -218,8 +218,8 @@ void Avatar::loadSounds(const string& type_id) {
 	} else {
 		sound_melee = snd->load("soundfx/melee_attack.ogg", "Avatar melee attack");
 		sound_mental = 0; // hero does not have this sound
-		sound_hit = snd->load("soundfx/" + statBlock()->base + "_hit.ogg", "Avatar was hit");
-		sound_die = snd->load("soundfx/" + statBlock()->base + "_die.ogg", "Avatar death");
+		sound_hit = snd->load("soundfx/" + stats.base + "_hit.ogg", "Avatar was hit");
+		sound_die = snd->load("soundfx/" + stats.base + "_die.ogg", "Avatar death");
 	}
 
 	sound_block = snd->load("soundfx/powers/block.ogg", "Avatar blocking");
@@ -231,7 +231,7 @@ void Avatar::loadSounds(const string& type_id) {
  */
 void Avatar::loadStepFX(const string& stepname) {
 
-	string filename = statBlock()->sfx_step;
+	string filename = stats.sfx_step;
 	if (stepname != "") {
 		filename = stepname;
 	}
@@ -266,90 +266,90 @@ void Avatar::set_direction() {
 	// handle direction changes
 	if (inpt->mouse_emulation) return;
 	if (MOUSE_MOVE) {
-		Point target = screen_to_map(inpt->mouse.x,  inpt->mouse.y, statBlock()->pos.x, statBlock()->pos.y);
+		Point target = screen_to_map(inpt->mouse.x,  inpt->mouse.y, stats.pos.x, stats.pos.y);
 		// if no line of movement to target, use pathfinder
-		if (!map->collider.line_of_movement(statBlock()->pos.x, statBlock()->pos.y, target.x, target.y, statBlock()->movement_type)) {
+		if (!map->collider.line_of_movement(stats.pos.x, stats.pos.y, target.x, target.y, stats.movement_type)) {
 			vector<Point> path;
 
 			// if a path is returned, target first waypoint
-			if ( map->collider.compute_path(statBlock()->pos, target, path, 1000, statBlock()->movement_type)) {
+			if ( map->collider.compute_path(stats.pos, target, path, 1000, stats.movement_type)) {
 				target = path.back();
 			}
 		}
-		statBlock()->direction = face(target.x, target.y);
+		stats.direction = face(target.x, target.y);
 	} else {
-		if (inpt->pressing[UP] && inpt->pressing[LEFT]) statBlock()->direction = 1;
-		else if (inpt->pressing[UP] && inpt->pressing[RIGHT]) statBlock()->direction = 3;
-		else if (inpt->pressing[DOWN] && inpt->pressing[RIGHT]) statBlock()->direction = 5;
-		else if (inpt->pressing[DOWN] && inpt->pressing[LEFT]) statBlock()->direction = 7;
-		else if (inpt->pressing[LEFT]) statBlock()->direction = 0;
-		else if (inpt->pressing[UP]) statBlock()->direction = 2;
-		else if (inpt->pressing[RIGHT]) statBlock()->direction = 4;
-		else if (inpt->pressing[DOWN]) statBlock()->direction = 6;
+		if (inpt->pressing[UP] && inpt->pressing[LEFT]) stats.direction = 1;
+		else if (inpt->pressing[UP] && inpt->pressing[RIGHT]) stats.direction = 3;
+		else if (inpt->pressing[DOWN] && inpt->pressing[RIGHT]) stats.direction = 5;
+		else if (inpt->pressing[DOWN] && inpt->pressing[LEFT]) stats.direction = 7;
+		else if (inpt->pressing[LEFT]) stats.direction = 0;
+		else if (inpt->pressing[UP]) stats.direction = 2;
+		else if (inpt->pressing[RIGHT]) stats.direction = 4;
+		else if (inpt->pressing[DOWN]) stats.direction = 6;
 		// Adjust for ORTHO tilesets
 		if (TILESET_ORIENTATION == TILESET_ORTHOGONAL &&
 				(inpt->pressing[UP] || inpt->pressing[DOWN] ||
 				inpt->pressing[LEFT] || inpt->pressing[RIGHT]))
-			statBlock()->direction = statBlock()->direction == 7 ? 0 : statBlock()->direction + 1;
+			stats.direction = stats.direction == 7 ? 0 : stats.direction + 1;
 	}
 }
 
 void Avatar::handlePower(int actionbar_power) {
-	if (actionbar_power != 0 && statBlock()->cooldown_ticks == 0) {
+	if (actionbar_power != 0 && stats.cooldown_ticks == 0) {
 		const Power &power = powers->getPower(actionbar_power);
 		Point target;
 		if (MOUSE_AIM) {
 			if (power.aim_assist)
-				target = screen_to_map(inpt->mouse.x,  inpt->mouse.y + AIM_ASSIST, statBlock()->pos.x, statBlock()->pos.y);
+				target = screen_to_map(inpt->mouse.x,  inpt->mouse.y + AIM_ASSIST, stats.pos.x, stats.pos.y);
 			else
-				target = screen_to_map(inpt->mouse.x,  inpt->mouse.y, statBlock()->pos.x, statBlock()->pos.y);
+				target = screen_to_map(inpt->mouse.x,  inpt->mouse.y, stats.pos.x, stats.pos.y);
 		} else {
-			FPoint ftarget = calcVector(statBlock()->pos, statBlock()->direction, statBlock()->melee_range);
+			FPoint ftarget = calcVector(stats.pos, stats.direction, stats.melee_range);
 			target.x = static_cast<int>(ftarget.x);
 			target.y = static_cast<int>(ftarget.y);
 		}
 
 		// check requirements
-		if (!statBlock()->canUsePower(power, actionbar_power))
+		if (!stats.canUsePower(power, actionbar_power))
 			return;
-		if (power.requires_los && !map->collider.line_of_sight(statBlock()->pos.x, statBlock()->pos.y, target.x, target.y))
+		if (power.requires_los && !map->collider.line_of_sight(stats.pos.x, stats.pos.y, target.x, target.y))
 			return;
 		if (power.requires_empty_target && !map->collider.is_empty(target.x, target.y))
 			return;
-		if (statBlock()->hero_cooldown[actionbar_power] > 0)
+		if (stats.hero_cooldown[actionbar_power] > 0)
 			return;
-		if (!powers->hasValidTarget(actionbar_power, stats, target))
+		if (!powers->hasValidTarget(actionbar_power,&stats,target))
 			return;
 
-		statBlock()->hero_cooldown[actionbar_power] = power.cooldown; //set the cooldown timer
+		stats.hero_cooldown[actionbar_power] = power.cooldown; //set the cooldown timer
 		current_power = actionbar_power;
 		act_target = target;
 
 		// is this a power that requires changing direction?
 		if (power.face) {
-			statBlock()->direction = face(target.x, target.y);
+			stats.direction = face(target.x, target.y);
 		}
 
 		switch (power.new_state) {
 			case POWSTATE_SWING:	// handle melee powers
-				statBlock()->cur_state = AVATAR_MELEE;
+				stats.cur_state = AVATAR_MELEE;
 				break;
 
 			case POWSTATE_SHOOT:	// handle ranged powers
-				statBlock()->cur_state = AVATAR_SHOOT;
+				stats.cur_state = AVATAR_SHOOT;
 				break;
 
 			case POWSTATE_CAST:		// handle ment powers
-				statBlock()->cur_state = AVATAR_CAST;
+				stats.cur_state = AVATAR_CAST;
 				break;
 
 			case POWSTATE_BLOCK:	// handle blocking
-				statBlock()->cur_state = AVATAR_BLOCK;
-				statBlock()->effects.triggered_block = true;
+				stats.cur_state = AVATAR_BLOCK;
+				stats.effects.triggered_block = true;
 				break;
 
 			case POWSTATE_INSTANT:	// handle instant powers
-				powers->activate(current_power, stats, target);
+				powers->activate(current_power, &stats, target);
 				break;
 		}
 	}
@@ -368,26 +368,26 @@ void Avatar::handlePower(int actionbar_power) {
 void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 	// clear current space to allow correct movement
-	map->collider.unblock(statBlock()->pos.x, statBlock()->pos.y);
+	map->collider.unblock(stats.pos.x, stats.pos.y);
 
 	int stepfx;
-	statBlock()->logic();
-	if (statBlock()->effects.forced_move) {
+	stats.logic();
+	if (stats.effects.forced_move) {
 		move();
 
 		// calc new cam position from player position
 		// cam is focused at player position
-		map->cam.x = statBlock()->pos.x;
-		map->cam.y = statBlock()->pos.y;
-		map->hero_tile.x = statBlock()->pos.x / 32;
-		map->hero_tile.y = statBlock()->pos.y / 32;
+		map->cam.x = stats.pos.x;
+		map->cam.y = stats.pos.y;
+		map->hero_tile.x = stats.pos.x / 32;
+		map->hero_tile.y = stats.pos.y / 32;
 
-		map->collider.block(statBlock()->pos.x, statBlock()->pos.y);
+		map->collider.block(stats.pos.x, stats.pos.y);
 		return;
 	}
-	if (statBlock()->effects.stun) {
+	if (stats.effects.stun) {
 
-		map->collider.block(statBlock()->pos.x, statBlock()->pos.y);
+		map->collider.block(stats.pos.x, stats.pos.y);
 		return;
 	}
 
@@ -396,42 +396,42 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 	bool allowed_to_use_power;
 
 	// check for revive
-	if (statBlock()->hp <= 0 && statBlock()->effects.revive) {
-		statBlock()->hp = statBlock()->maxhp;
-		statBlock()->alive = true;
-		statBlock()->corpse = false;
-		statBlock()->cur_state = AVATAR_STANCE;
+	if (stats.hp <= 0 && stats.effects.revive) {
+		stats.hp = stats.maxhp;
+		stats.alive = true;
+		stats.corpse = false;
+		stats.cur_state = AVATAR_STANCE;
 	}
 
 	// check level up
-	if (statBlock()->xp >= statBlock()->xp_table[statBlock()->level] && statBlock()->level < MAX_CHARACTER_LEVEL) {
-		statBlock()->level_up = true;
-		statBlock()->level++;
+	if (stats.xp >= stats.xp_table[stats.level] && stats.level < MAX_CHARACTER_LEVEL) {
+		stats.level_up = true;
+		stats.level++;
 		stringstream ss;
-		ss << msg->get("Congratulations, you have reached level %d!", statBlock()->level);
-		if (statBlock()->level < statBlock()->max_spendable_stat_points) {
+		ss << msg->get("Congratulations, you have reached level %d!", stats.level);
+		if (stats.level < stats.max_spendable_stat_points) {
 			ss << " " << msg->get("You may increase one attribute through the Character Menu.");
 			newLevelNotification = true;
 		}
 		log_msg = ss.str();
-		statBlock()->recalc();
+		stats.recalc();
 		snd->play(level_up);
 
 		// if the player managed to level up while dead (e.g. via a bleeding creature), restore to life
-		if (statBlock()->cur_state == AVATAR_DEAD) {
-			statBlock()->cur_state = AVATAR_STANCE;
+		if (stats.cur_state == AVATAR_DEAD) {
+			stats.cur_state = AVATAR_STANCE;
 		}
 	}
 
 	// check for bleeding spurt
-	if (statBlock()->effects.damage > 0 && statBlock()->hp > 0) {
-		comb->addMessage(statBlock()->effects.damage, statBlock()->pos, COMBAT_MESSAGE_TAKEDMG);
+	if (stats.effects.damage > 0 && stats.hp > 0) {
+		comb->addMessage(stats.effects.damage, stats.pos, COMBAT_MESSAGE_TAKEDMG);
 	}
 
 	// check for bleeding to death
-	if (statBlock()->hp == 0 && !(statBlock()->cur_state == AVATAR_DEAD)) {
-		statBlock()->effects.triggered_death = true;
-		statBlock()->cur_state = AVATAR_DEAD;
+	if (stats.hp == 0 && !(stats.cur_state == AVATAR_DEAD)) {
+		stats.effects.triggered_death = true;
+		stats.cur_state = AVATAR_DEAD;
 	}
 
 	// assist mouse movement
@@ -449,10 +449,10 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 			anims[i]->advanceFrame();
 
 	// handle transformation
-	if (statBlock()->transform_type != "" && statBlock()->transform_type != "untransform" && transform_triggered == false) transform();
-	if (statBlock()->transform_type != "" && statBlock()->transform_duration == 0) untransform();
+	if (stats.transform_type != "" && stats.transform_type != "untransform" && transform_triggered == false) transform();
+	if (stats.transform_type != "" && stats.transform_duration == 0) untransform();
 
-	switch(statBlock()->cur_state) {
+	switch(stats.cur_state) {
 		case AVATAR_STANCE:
 
 			setAnimation("stance");
@@ -478,7 +478,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 				}
 
 				if (move()) { // no collision
-					statBlock()->cur_state = AVATAR_RUN;
+					stats.cur_state = AVATAR_RUN;
 				}
 
 			}
@@ -517,11 +517,11 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			// handle transition to STANCE
 			if (!pressing_move()) {
-				statBlock()->cur_state = AVATAR_STANCE;
+				stats.cur_state = AVATAR_STANCE;
 				break;
 			}
 			else if (!move()) { // collide with wall
-				statBlock()->cur_state = AVATAR_STANCE;
+				stats.cur_state = AVATAR_STANCE;
 				break;
 			}
 
@@ -541,12 +541,12 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			// do power
 			if (activeAnimation->isActiveFrame()) {
-				powers->activate(current_power, stats, act_target);
+				powers->activate(current_power, &stats, act_target);
 			}
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
-				statBlock()->cur_state = AVATAR_STANCE;
-				if (statBlock()->effects.speed <= 100) statBlock()->cooldown_ticks += statBlock()->cooldown;
+				stats.cur_state = AVATAR_STANCE;
+				if (stats.effects.speed <= 100) stats.cooldown_ticks += stats.cooldown;
 			}
 			break;
 
@@ -561,12 +561,12 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			// do power
 			if (activeAnimation->isActiveFrame()) {
-				powers->activate(current_power, stats, act_target);
+				powers->activate(current_power, &stats, act_target);
 			}
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
-				statBlock()->cur_state = AVATAR_STANCE;
-				if (statBlock()->effects.speed <= 100) statBlock()->cooldown_ticks += statBlock()->cooldown;
+				stats.cur_state = AVATAR_STANCE;
+				if (stats.effects.speed <= 100) stats.cooldown_ticks += stats.cooldown;
 			}
 			break;
 
@@ -579,12 +579,12 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			// do power
 			if (activeAnimation->isActiveFrame()) {
-				powers->activate(current_power, stats, act_target);
+				powers->activate(current_power, &stats, act_target);
 			}
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
-				statBlock()->cur_state = AVATAR_STANCE;
-				if (statBlock()->effects.speed <= 100) statBlock()->cooldown_ticks += statBlock()->cooldown;
+				stats.cur_state = AVATAR_STANCE;
+				if (stats.effects.speed <= 100) stats.cooldown_ticks += stats.cooldown;
 			}
 			break;
 
@@ -593,9 +593,9 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 			setAnimation("block");
 
 			if (powers->powers[actionbar_power].new_state != POWSTATE_BLOCK) {
-				statBlock()->cur_state = AVATAR_STANCE;
-				statBlock()->effects.triggered_block = false;
-				statBlock()->effects.clearTriggerEffects(TRIGGER_BLOCK);
+				stats.cur_state = AVATAR_STANCE;
+				stats.effects.triggered_block = false;
+				stats.effects.clearTriggerEffects(TRIGGER_BLOCK);
 			}
 			break;
 
@@ -604,37 +604,37 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 			setAnimation("hit");
 
 			if (activeAnimation->isFirstFrame()) {
-				statBlock()->effects.triggered_hit = true;
+				stats.effects.triggered_hit = true;
 			}
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
-				statBlock()->cur_state = AVATAR_STANCE;
+				stats.cur_state = AVATAR_STANCE;
 			}
 
 			break;
 
 		case AVATAR_DEAD:
-			if (statBlock()->effects.triggered_death) break;
+			if (stats.effects.triggered_death) break;
 
-			if (statBlock()->transformed) {
-				statBlock()->transform_duration = 0;
+			if (stats.transformed) {
+				stats.transform_duration = 0;
 				untransform();
 			}
 
 			setAnimation("die");
 
 			if (activeAnimation->isFirstFrame() && activeAnimation->getTimesPlayed() < 1) {
-				statBlock()->effects.clearEffects();
+				stats.effects.clearEffects();
 
 				// raise the death penalty flag.  Another module will read this and reset.
-				statBlock()->death_penalty = true;
+				stats.death_penalty = true;
 
 				// close menus in GameStatePlay
 				close_menus = true;
 
 				snd->play(sound_die);
 
-				if (statBlock()->permadeath) {
+				if (stats.permadeath) {
 					log_msg = msg->get("You are defeated. Game over! Press Enter to exit to Title.");
 				}
 				else {
@@ -643,17 +643,17 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 			}
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
-				statBlock()->corpse = true;
+				stats.corpse = true;
 			}
 
 			// allow respawn with Accept if not permadeath
 			if (inpt->pressing[ACCEPT]) {
 				map->teleportation = true;
 				map->teleport_mapname = map->respawn_map;
-				if (statBlock()->permadeath) {
+				if (stats.permadeath) {
 					// set these positions so it doesn't flash before jumping to Title
-					map->teleport_destination.x = statBlock()->pos.x;
-					map->teleport_destination.y = statBlock()->pos.y;
+					map->teleport_destination.x = stats.pos.x;
+					map->teleport_destination.y = stats.pos.y;
 				}
 				else {
 					respawn = true;
@@ -671,26 +671,26 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 	}
 
 	// turn on all passive powers
-	if ((statBlock()->hp > 0 || statBlock()->effects.triggered_death) && !respawn) powers->activatePassives(stats);
+	if ((stats.hp > 0 || stats.effects.triggered_death) && !respawn) powers->activatePassives(&stats);
 
 	// calc new cam position from player position
 	// cam is focused at player position
-	map->cam.x = statBlock()->pos.x;
-	map->cam.y = statBlock()->pos.y;
-	map->hero_tile.x = statBlock()->pos.x / 32;
-	map->hero_tile.y = statBlock()->pos.y / 32;
+	map->cam.x = stats.pos.x;
+	map->cam.y = stats.pos.y;
+	map->hero_tile.x = stats.pos.x / 32;
+	map->hero_tile.y = stats.pos.y / 32;
 
 	// check for map events
-	map->checkEvents(statBlock()->pos);
+	map->checkEvents(stats.pos);
 
 	// decrement all cooldowns
 	for (int i = 0; i < POWER_COUNT; i++){
-		statBlock()->hero_cooldown[i] -= 1000 / MAX_FRAMES_PER_SEC;
-		if (statBlock()->hero_cooldown[i] < 0) statBlock()->hero_cooldown[i] = 0;
+		stats.hero_cooldown[i] -= 1000 / MAX_FRAMES_PER_SEC;
+		if (stats.hero_cooldown[i] < 0) stats.hero_cooldown[i] = 0;
 	}
 
 	// make the current square solid
-	map->collider.block(statBlock()->pos.x, statBlock()->pos.y);
+	map->collider.block(stats.pos.x, stats.pos.y);
 }
 
 /**
@@ -699,14 +699,14 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
  */
 bool Avatar::takeHit(const Hazard &h) {
 
-	if (statBlock()->cur_state != AVATAR_DEAD) {
+	if (stats.cur_state != AVATAR_DEAD) {
 		CombatText *combat_text = comb;
 		// check miss
-		int avoidance = statBlock()->avoidance;
-		if (statBlock()->effects.triggered_block) avoidance *= 2;
+		int avoidance = stats.avoidance;
+		if (stats.effects.triggered_block) avoidance *= 2;
 		clampCeil(avoidance, MAX_AVOIDANCE);
 		if (percentChance(avoidance - h.accuracy - 25)) {
-			combat_text->addMessage(msg->get("miss"), statBlock()->pos, COMBAT_MESSAGE_MISS);
+			combat_text->addMessage(msg->get("miss"), stats.pos, COMBAT_MESSAGE_MISS);
 			return false;
 		}
 
@@ -714,26 +714,26 @@ bool Avatar::takeHit(const Hazard &h) {
 
 		// apply elemental resistance
 
-		if (h.trait_elemental >= 0 && unsigned(h.trait_elemental) < statBlock()->vulnerable.size()) {
+		if (h.trait_elemental >= 0 && unsigned(h.trait_elemental) < stats.vulnerable.size()) {
 			unsigned i = h.trait_elemental;
-			int vulnerable = statBlock()->vulnerable[i];
-			if (statBlock()->vulnerable[i] > MAX_RESIST && statBlock()->vulnerable[i] < 100)
+			int vulnerable = stats.vulnerable[i];
+			if (stats.vulnerable[i] > MAX_RESIST && stats.vulnerable[i] < 100)
 				vulnerable = MAX_RESIST;
 			dmg = (dmg * vulnerable) / 100;
 		}
 
 		if (!h.trait_armor_penetration) { // armor penetration ignores all absorption
 			// apply absorption
-			int absorption = randBetween(statBlock()->absorb_min, statBlock()->absorb_max);
+			int absorption = randBetween(stats.absorb_min, stats.absorb_max);
 
-			if (statBlock()->effects.triggered_block) {
-				absorption += absorption + statBlock()->absorb_max; // blocking doubles your absorb amount
+			if (stats.effects.triggered_block) {
+				absorption += absorption + stats.absorb_max; // blocking doubles your absorb amount
 			}
 
 			if (absorption > 0) {
 				if ((dmg*100)/absorption > MAX_BLOCK)
 					absorption = (absorption * MAX_BLOCK) /100;
-				if ((dmg*100)/absorption > MAX_ABSORB && !statBlock()->effects.triggered_block)
+				if ((dmg*100)/absorption > MAX_ABSORB && !stats.effects.triggered_block)
 					absorption = (absorption * MAX_ABSORB) /100;
 
 				// Sometimes, the absorb limits cause absorbtion to drop to 1
@@ -746,8 +746,8 @@ bool Avatar::takeHit(const Hazard &h) {
 			if (dmg <= 0) {
 				dmg = 0;
 				if (h.trait_elemental < 0) {
-					if (statBlock()->effects.triggered_block && MAX_BLOCK < 100) dmg = 1;
-					else if (!statBlock()->effects.triggered_block && MAX_ABSORB < 100) dmg = 1;
+					if (stats.effects.triggered_block && MAX_BLOCK < 100) dmg = 1;
+					else if (!stats.effects.triggered_block && MAX_ABSORB < 100) dmg = 1;
 				} else {
 					if (MAX_RESIST < 100) dmg = 1;
 				}
@@ -760,21 +760,21 @@ bool Avatar::takeHit(const Hazard &h) {
 		}
 
 
-		int prev_hp = statBlock()->hp;
-		combat_text->addMessage(dmg, statBlock()->pos, COMBAT_MESSAGE_TAKEDMG);
-		statBlock()->takeDamage(dmg);
+		int prev_hp = stats.hp;
+		combat_text->addMessage(dmg, stats.pos, COMBAT_MESSAGE_TAKEDMG);
+		stats.takeDamage(dmg);
 
 		// after effects
-		if (statBlock()->hp > 0 && dmg > 0) {
+		if (stats.hp > 0 && dmg > 0) {
 
-			if (h.mod_power > 0) powers->effect(stats, h.mod_power);
-			powers->effect(stats, h.power_index);
+			if (h.mod_power > 0) powers->effect(&stats, h.mod_power);
+			powers->effect(&stats, h.power_index);
 
-			if (!statBlock()->effects.immunity) {
-				if (statBlock()->effects.forced_move) {
-					float theta = powers->calcTheta(h.src_stats->pos.x, h.src_stats->pos.y, statBlock()->pos.x, statBlock()->pos.y);
-					statBlock()->forced_speed.x = static_cast<int>(ceil(statBlock()->effects.forced_speed * cos(theta)));
-					statBlock()->forced_speed.y = static_cast<int>(ceil(statBlock()->effects.forced_speed * sin(theta)));
+			if (!stats.effects.immunity) {
+				if (stats.effects.forced_move) {
+					float theta = powers->calcTheta(h.src_stats->pos.x, h.src_stats->pos.y, stats.pos.x, stats.pos.y);
+					stats.forced_speed.x = static_cast<int>(ceil(stats.effects.forced_speed * cos(theta)));
+					stats.forced_speed.y = static_cast<int>(ceil(stats.effects.forced_speed * sin(theta)));
 				}
 				if (h.hp_steal != 0) {
 					int steal_amt = (dmg * h.hp_steal) / 100;
@@ -788,17 +788,17 @@ bool Avatar::takeHit(const Hazard &h) {
 
 		// post effect power
 		if (h.post_power > 0 && dmg > 0) {
-			powers->activate(h.post_power, h.src_stats, statBlock()->pos);
+			powers->activate(h.post_power, h.src_stats, stats.pos);
 		}
 
-		if (statBlock()->hp <= 0) {
-			statBlock()->effects.triggered_death = true;
-			statBlock()->cur_state = AVATAR_DEAD;
+		if (stats.hp <= 0) {
+			stats.effects.triggered_death = true;
+			stats.cur_state = AVATAR_DEAD;
 		}
-		else if (prev_hp > statBlock()->hp) { // only interrupt if damage was taken
+		else if (prev_hp > stats.hp) { // only interrupt if damage was taken
 			snd->play(sound_hit);
-			if (!percentChance(statBlock()->poise)) {
-				statBlock()->cur_state = AVATAR_HIT;
+			if (!percentChance(stats.poise)) {
+				stats.cur_state = AVATAR_HIT;
 			}
 		}
 
@@ -811,25 +811,27 @@ bool Avatar::takeHit(const Hazard &h) {
 void Avatar::transform() {
 
 	transform_triggered = true;
-	statBlock()->transformed = true;
+	stats.transformed = true;
 	setPowers = true;
 
 	delete charmed_stats;
-	charmed_stats = new AvatarStatBlock();
-	charmed_stats->load("enemies/" + statBlock()->transform_type + ".txt");
+	charmed_stats = new StatBlock();
+	charmed_stats->load("enemies/" + stats.transform_type + ".txt");
 
 	// temporary save hero stats
 	delete hero_stats;
-	hero_stats = new AvatarStatBlock();
+
+	hero_stats = new StatBlock();
+	*hero_stats = stats;
 
 	// replace some hero stats
-	statBlock()->speed = charmed_stats->speed;
-	statBlock()->dspeed = charmed_stats->dspeed;
-	statBlock()->flying = charmed_stats->flying;
-	statBlock()->humanoid = charmed_stats->humanoid;
-	statBlock()->animations = charmed_stats->animations;
-	statBlock()->powers_list = charmed_stats->powers_list;
-	statBlock()->effects.clearEffects();
+	stats.speed = charmed_stats->speed;
+	stats.dspeed = charmed_stats->dspeed;
+	stats.flying = charmed_stats->flying;
+	stats.humanoid = charmed_stats->humanoid;
+	stats.animations = charmed_stats->animations;
+	stats.powers_list = charmed_stats->powers_list;
+	stats.effects.clearEffects();
 
 	string animationname = "animations/enemies/"+charmed_stats->animations + ".txt";
 	anim->decreaseCount("animations/hero.txt");
@@ -837,31 +839,31 @@ void Avatar::transform() {
 	animationSet = anim->getAnimationSet(animationname);
 	delete activeAnimation;
 	activeAnimation = animationSet->getAnimation();
-	statBlock()->cur_state = AVATAR_STANCE;
+	stats.cur_state = AVATAR_STANCE;
 
 	// damage
-	clampFloor(statBlock()->dmg_melee_min, charmed_stats->dmg_melee_min);
-	clampFloor(statBlock()->dmg_melee_max, charmed_stats->dmg_melee_max);
+	clampFloor(stats.dmg_melee_min, charmed_stats->dmg_melee_min);
+	clampFloor(stats.dmg_melee_max, charmed_stats->dmg_melee_max);
 
-	clampFloor(statBlock()->dmg_ment_min, charmed_stats->dmg_ment_min);
-	clampFloor(statBlock()->dmg_ment_max, charmed_stats->dmg_ment_max);
+	clampFloor(stats.dmg_ment_min, charmed_stats->dmg_ment_min);
+	clampFloor(stats.dmg_ment_max, charmed_stats->dmg_ment_max);
 
-	clampFloor(statBlock()->dmg_ranged_min, charmed_stats->dmg_ranged_min);
-	clampFloor(statBlock()->dmg_ranged_max, charmed_stats->dmg_ranged_max);
+	clampFloor(stats.dmg_ranged_min, charmed_stats->dmg_ranged_min);
+	clampFloor(stats.dmg_ranged_max, charmed_stats->dmg_ranged_max);
 
 	// dexterity
-	clampFloor(statBlock()->absorb_min, charmed_stats->absorb_min);
-	clampFloor(statBlock()->absorb_max, charmed_stats->absorb_max);
+	clampFloor(stats.absorb_min, charmed_stats->absorb_min);
+	clampFloor(stats.absorb_max, charmed_stats->absorb_max);
 
-	clampFloor(statBlock()->avoidance, charmed_stats->avoidance);
+	clampFloor(stats.avoidance, charmed_stats->avoidance);
 
-	clampFloor(statBlock()->accuracy, charmed_stats->accuracy);
+	clampFloor(stats.accuracy, charmed_stats->accuracy);
 
-	clampFloor(statBlock()->crit, charmed_stats->crit);
+	clampFloor(stats.crit, charmed_stats->crit);
 
 	// resistances
-	for (unsigned int i=0; i<statBlock()->vulnerable.size(); i++)
-		clampCeil(statBlock()->vulnerable[i], charmed_stats->vulnerable[i]);
+	for (unsigned int i=0; i<stats.vulnerable.size(); i++)
+		clampCeil(stats.vulnerable[i], charmed_stats->vulnerable[i]);
 
 	loadSounds(charmed_stats->sfx_prefix);
 	loadStepFX("NULL");
@@ -869,53 +871,53 @@ void Avatar::transform() {
 
 void Avatar::untransform() {
 	// Only allow untransform when on a valid tile
-	if (!map->collider.is_valid_position(statBlock()->pos.x,statBlock()->pos.y,MOVEMENT_NORMAL)) return;
+	if (!map->collider.is_valid_position(stats.pos.x,stats.pos.y,MOVEMENT_NORMAL)) return;
 
-	statBlock()->transformed = false;
+	stats.transformed = false;
 	transform_triggered = false;
-	statBlock()->transform_type = "";
+	stats.transform_type = "";
 	revertPowers = true;
-	statBlock()->effects.clearEffects();
+	stats.effects.clearEffects();
 
 	// revert some hero stats to last saved
-	statBlock()->speed = hero_stats->speed;
-	statBlock()->dspeed = hero_stats->dspeed;
-	statBlock()->flying = hero_stats->flying;
-	statBlock()->humanoid = hero_stats->humanoid;
-	statBlock()->animations = hero_stats->animations;
-	statBlock()->effects = hero_stats->effects;
-	statBlock()->powers_list = hero_stats->powers_list;
+	stats.speed = hero_stats->speed;
+	stats.dspeed = hero_stats->dspeed;
+	stats.flying = hero_stats->flying;
+	stats.humanoid = hero_stats->humanoid;
+	stats.animations = hero_stats->animations;
+	stats.effects = hero_stats->effects;
+	stats.powers_list = hero_stats->powers_list;
 
 	anim->increaseCount("animations/hero.txt");
 	anim->decreaseCount("animations/enemies/"+charmed_stats->animations + ".txt");
 	animationSet = anim->getAnimationSet("animations/hero.txt");
 	delete activeAnimation;
 	activeAnimation = animationSet->getAnimation();
-	statBlock()->cur_state = AVATAR_STANCE;
+	stats.cur_state = AVATAR_STANCE;
 
 	// This is a bit of a hack.
 	// In order to switch to the stance animation, we can't already be in a stance animation
 	setAnimation("run");
 
-	statBlock()->dmg_melee_min = hero_stats->dmg_melee_min;
-	statBlock()->dmg_melee_max = hero_stats->dmg_melee_max;
-	statBlock()->dmg_ment_min = hero_stats->dmg_ment_min;
-	statBlock()->dmg_ment_max = hero_stats->dmg_ment_max;
-	statBlock()->dmg_ranged_min = hero_stats->dmg_ranged_min;
-	statBlock()->dmg_ranged_max = hero_stats->dmg_ranged_max;
+	stats.dmg_melee_min = hero_stats->dmg_melee_min;
+	stats.dmg_melee_max = hero_stats->dmg_melee_max;
+	stats.dmg_ment_min = hero_stats->dmg_ment_min;
+	stats.dmg_ment_max = hero_stats->dmg_ment_max;
+	stats.dmg_ranged_min = hero_stats->dmg_ranged_min;
+	stats.dmg_ranged_max = hero_stats->dmg_ranged_max;
 
-	statBlock()->absorb_min = hero_stats->absorb_min;
-	statBlock()->absorb_max = hero_stats->absorb_max;
-	statBlock()->avoidance = hero_stats->avoidance;
-	statBlock()->accuracy = hero_stats->accuracy;
-	statBlock()->crit = hero_stats->crit;
+	stats.absorb_min = hero_stats->absorb_min;
+	stats.absorb_max = hero_stats->absorb_max;
+	stats.avoidance = hero_stats->avoidance;
+	stats.accuracy = hero_stats->accuracy;
+	stats.crit = hero_stats->crit;
 
-	for (unsigned int i=0; i<statBlock()->vulnerable.size(); i++) {
-		statBlock()->vulnerable[i] = hero_stats->vulnerable[i];
+	for (unsigned int i=0; i<stats.vulnerable.size(); i++) {
+		stats.vulnerable[i] = hero_stats->vulnerable[i];
 	}
 
 	loadSounds();
-	loadStepFX(statBlock()->sfx_step);
+	loadStepFX(stats.sfx_step);
 
 	delete charmed_stats;
 	delete hero_stats;
@@ -949,27 +951,27 @@ int Avatar::getUntransformPower() {
 }
 
 void Avatar::addRenders(vector<Renderable> &r) {
-	if (!statBlock()->transformed) {
-		for (unsigned i = 0; i < layer_def[statBlock()->direction].size(); ++i) {
-			unsigned index = layer_def[statBlock()->direction][i];
+	if (!stats.transformed) {
+		for (unsigned i = 0; i < layer_def[stats.direction].size(); ++i) {
+			unsigned index = layer_def[stats.direction][i];
 			if (anims[index]) {
-				Renderable ren = anims[index]->getCurrentFrame(statBlock()->direction);
-				ren.map_pos = statBlock()->pos;
+				Renderable ren = anims[index]->getCurrentFrame(stats.direction);
+				ren.map_pos = stats.pos;
 				ren.prio = i+1;
 				r.push_back(ren);
 			}
 		}
 	} else {
-		Renderable ren = activeAnimation->getCurrentFrame(statBlock()->direction);
-		ren.map_pos = statBlock()->pos;
+		Renderable ren = activeAnimation->getCurrentFrame(stats.direction);
+		ren.map_pos = stats.pos;
 		r.push_back(ren);
 	}
 	// add effects
-	for (unsigned i = 0; i < statBlock()->effects.effect_list.size(); ++i) {
-		if (statBlock()->effects.effect_list[i].animation && !statBlock()->effects.effect_list[i].animation->isCompleted()) {
-			Renderable ren = statBlock()->effects.effect_list[i].animation->getCurrentFrame(0);
-			ren.map_pos = statBlock()->pos;
-			if (statBlock()->effects.effect_list[i].render_above) ren.prio = layer_def[statBlock()->direction].size()+1;
+	for (unsigned i = 0; i < stats.effects.effect_list.size(); ++i) {
+		if (stats.effects.effect_list[i].animation && !stats.effects.effect_list[i].animation->isCompleted()) {
+			Renderable ren = stats.effects.effect_list[i].animation->getCurrentFrame(0);
+			ren.map_pos = stats.pos;
+			if (stats.effects.effect_list[i].render_above) ren.prio = layer_def[stats.direction].size()+1;
 			else ren.prio = 0;
 			r.push_back(ren);
 		}
@@ -978,7 +980,7 @@ void Avatar::addRenders(vector<Renderable> &r) {
 
 Avatar::~Avatar() {
 
-	if (statBlock()->transformed && charmed_stats && charmed_stats->animations != "") {
+	if (stats.transformed && charmed_stats && charmed_stats->animations != "") {
 		anim->decreaseCount("animations/enemies/"+charmed_stats->animations + ".txt");
 	} else {
 		anim->decreaseCount("animations/hero.txt");

--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -100,8 +100,6 @@ public:
 
 	PowerManager *powers;
 
-	AvatarStatBlock *statBlock() { return static_cast<AvatarStatBlock*>(stats); }
-
 	void init();
 	void loadLayerDefinitions();
 	std::vector<std::string> layer_reference_order;

--- a/src/BehaviorStandard.cpp
+++ b/src/BehaviorStandard.cpp
@@ -37,9 +37,9 @@ BehaviorStandard::BehaviorStandard(Enemy *_e) : EnemyBehavior(_e) {
 void BehaviorStandard::logic() {
 
 	// skip all logic if the enemy is dead and no longer animating
-	if (e->stats->corpse) {
-		if (e->stats->corpse_ticks > 0)
-			e->stats->corpse_ticks--;
+	if (e->stats.corpse) {
+		if (e->stats.corpse_ticks > 0)
+			e->stats.corpse_ticks--;
 		return;
 	}
 	doUpkeep();
@@ -56,61 +56,61 @@ void BehaviorStandard::logic() {
  */
 void BehaviorStandard::doUpkeep() {
 
-	e->stats->logic();
+	e->stats.logic();
 
 	// heal rapidly while not in combat
-	if (!e->stats->in_combat) {
-		if (e->stats->alive && e->stats->hero_alive) {
-			e->stats->hp++;
-			if (e->stats->hp > e->stats->maxhp) e->stats->hp = e->stats->maxhp;
+	if (!e->stats.in_combat) {
+		if (e->stats.alive && e->stats.hero_alive) {
+			e->stats.hp++;
+			if (e->stats.hp > e->stats.maxhp) e->stats.hp = e->stats.maxhp;
 		}
 	}
 
-	if (e->stats->effects.forced_move) {
+	if (e->stats.effects.forced_move) {
 		e->move();
 	}
 
-	if (e->stats->waypoint_pause_ticks > 0)
-		e->stats->waypoint_pause_ticks--;
+	if (e->stats.waypoint_pause_ticks > 0)
+		e->stats.waypoint_pause_ticks--;
 
-	if (e->stats->wander_ticks > 0)
-		e->stats->wander_ticks--;
+	if (e->stats.wander_ticks > 0)
+		e->stats.wander_ticks--;
 
-	if (e->stats->wander_pause_ticks > 0)
-		e->stats->wander_pause_ticks--;
+	if (e->stats.wander_pause_ticks > 0)
+		e->stats.wander_pause_ticks--;
 
 	// check for revive
-	if (e->stats->hp <= 0 && e->stats->effects.revive) {
-		e->stats->hp = e->stats->maxhp;
-		e->stats->alive = true;
-		e->stats->corpse = false;
-		e->stats->cur_state = ENEMY_STANCE;
+	if (e->stats.hp <= 0 && e->stats.effects.revive) {
+		e->stats.hp = e->stats.maxhp;
+		e->stats.alive = true;
+		e->stats.corpse = false;
+		e->stats.cur_state = ENEMY_STANCE;
 	}
 
 	// check for bleeding to death
-	if (e->stats->hp <= 0 && !(e->stats->cur_state == ENEMY_DEAD || e->stats->cur_state == ENEMY_CRITDEAD)) {
+	if (e->stats.hp <= 0 && !(e->stats.cur_state == ENEMY_DEAD || e->stats.cur_state == ENEMY_CRITDEAD)) {
 		e->doRewards();
-		e->stats->effects.triggered_death = true;
-		e->stats->cur_state = ENEMY_DEAD;
-		e->map->collider.unblock(e->stats->pos.x,e->stats->pos.y);
+		e->stats.effects.triggered_death = true;
+		e->stats.cur_state = ENEMY_DEAD;
+		e->map->collider.unblock(e->stats.pos.x,e->stats.pos.y);
 	}
 
 	// TEMP: check for bleeding spurt
-	if (e->stats->effects.damage > 0 && e->stats->hp > 0) {
-		comb->addMessage(e->stats->effects.damage, e->stats->pos, COMBAT_MESSAGE_TAKEDMG);
+	if (e->stats.effects.damage > 0 && e->stats.hp > 0) {
+		comb->addMessage(e->stats.effects.damage, e->stats.pos, COMBAT_MESSAGE_TAKEDMG);
 	}
 
 	// check for teleport powers
-	if (e->stats->teleportation) {
+	if (e->stats.teleportation) {
 
-		e->map->collider.unblock(e->stats->pos.x,e->stats->pos.y);
+		e->map->collider.unblock(e->stats.pos.x,e->stats.pos.y);
 
-		e->stats->pos.x = e->stats->teleport_destination.x;
-		e->stats->pos.y = e->stats->teleport_destination.y;
+		e->stats.pos.x = e->stats.teleport_destination.x;
+		e->stats.pos.y = e->stats.teleport_destination.y;
 
-		e->map->collider.block(e->stats->pos.x,e->stats->pos.y);
+		e->map->collider.block(e->stats.pos.x,e->stats.pos.y);
 
-		e->stats->teleportation = false;
+		e->stats.teleportation = false;
 	}
 }
 
@@ -118,66 +118,66 @@ void BehaviorStandard::doUpkeep() {
  * Locate the player and set various targeting info
  */
 void BehaviorStandard::findTarget() {
-	int stealth_threat_range = (e->stats->threat_range * (100 - e->stats->hero_stealth)) / 100;
+	int stealth_threat_range = (e->stats.threat_range * (100 - e->stats.hero_stealth)) / 100;
 
 	// stunned enemies can't act
-	if (e->stats->effects.stun) return;
+	if (e->stats.effects.stun) return;
 
 	// check distance and line of sight between enemy and hero
-	if (e->stats->hero_alive)
-		dist = e->getDistance(e->stats->hero_pos);
+	if (e->stats.hero_alive)
+		dist = e->getDistance(e->stats.hero_pos);
 	else
 		dist = 0;
 
 	// check line-of-sight
-	if (dist < e->stats->threat_range && e->stats->hero_alive)
-		los = e->map->collider.line_of_sight(e->stats->pos.x, e->stats->pos.y, e->stats->hero_pos.x, e->stats->hero_pos.y);
+	if (dist < e->stats.threat_range && e->stats.hero_alive)
+		los = e->map->collider.line_of_sight(e->stats.pos.x, e->stats.pos.y, e->stats.hero_pos.x, e->stats.hero_pos.y);
 	else
 		los = false;
 
 	// check entering combat (because the player hit the enemy)
-	if (e->stats->join_combat) {
+	if (e->stats.join_combat) {
 		if (dist <= (stealth_threat_range *2)) {
-			e->stats->join_combat = false;
+			e->stats.join_combat = false;
 		}
 		else {
-			e->stats->in_combat = true;
-			e->powers->activate(e->stats->power_index[BEACON], e->stats, e->stats->pos); //emit beacon
+			e->stats.in_combat = true;
+			e->powers->activate(e->stats.power_index[BEACON], &e->stats, e->stats.pos); //emit beacon
 		}
 	}
 
 	// check entering combat (because the player got too close)
-	if (!e->stats->in_combat && los && dist < stealth_threat_range) {
+	if (!e->stats.in_combat && los && dist < stealth_threat_range) {
 
-		if (e->stats->in_combat) e->stats->join_combat = true;
-		e->stats->in_combat = true;
-		e->powers->activate(e->stats->power_index[BEACON], e->stats, e->stats->pos); //emit beacon
+		if (e->stats.in_combat) e->stats.join_combat = true;
+		e->stats.in_combat = true;
+		e->powers->activate(e->stats.power_index[BEACON], &e->stats, e->stats.pos); //emit beacon
 	}
 
 	// check exiting combat (player died or got too far away)
-	if (e->stats->in_combat && dist > (e->stats->threat_range *2) && !e->stats->join_combat) {
-		e->stats->in_combat = false;
+	if (e->stats.in_combat && dist > (e->stats.threat_range *2) && !e->stats.join_combat) {
+		e->stats.in_combat = false;
 	}
 
 	// check exiting combat (player or enemy died)
-	if (!e->stats->alive || !e->stats->hero_alive) {
-		e->stats->in_combat = false;
+	if (!e->stats.alive || !e->stats.hero_alive) {
+		e->stats.in_combat = false;
 	}
 
 	// if the creature is a wanderer, pick a random point within the wander area to travel to
-	if (e->stats->wander && !e->stats->in_combat && e->stats->wander_area.w > 0 && e->stats->wander_area.h > 0) {
-		if (e->stats->wander_ticks == 0) {
-			pursue_pos.x = e->stats->wander_area.x + (rand() % (e->stats->wander_area.w));
-			pursue_pos.y = e->stats->wander_area.y + (rand() % (e->stats->wander_area.h));
-			e->stats->wander_ticks = (rand() % 150) + 150;
+	if (e->stats.wander && !e->stats.in_combat && e->stats.wander_area.w > 0 && e->stats.wander_area.h > 0) {
+		if (e->stats.wander_ticks == 0) {
+			pursue_pos.x = e->stats.wander_area.x + (rand() % (e->stats.wander_area.w));
+			pursue_pos.y = e->stats.wander_area.y + (rand() % (e->stats.wander_area.h));
+			e->stats.wander_ticks = (rand() % 150) + 150;
 		}
 	} else {
 		// by default, the enemy pursues the hero directly
-		pursue_pos.x = e->stats->hero_pos.x;
-		pursue_pos.y = e->stats->hero_pos.y;
+		pursue_pos.x = e->stats.hero_pos.x;
+		pursue_pos.y = e->stats.hero_pos.y;
 
-		if (!(e->stats->in_combat || e->stats->waypoints.empty())) {
-			Point waypoint = e->stats->waypoints.front();
+		if (!(e->stats.in_combat || e->stats.waypoints.empty())) {
+			Point waypoint = e->stats.waypoints.front();
 			pursue_pos.x = waypoint.x;
 			pursue_pos.y = waypoint.y;
 		}
@@ -192,13 +192,13 @@ void BehaviorStandard::findTarget() {
 void BehaviorStandard::checkPower() {
 
 	// stunned enemies can't act
-	if (e->stats->effects.stun) return;
+	if (e->stats.effects.stun) return;
 
 	// currently all enemy power use happens during combat
-	if (!e->stats->in_combat) return;
+	if (!e->stats.in_combat) return;
 
 	// if the enemy is on global cooldown it cannot act
-	if (e->stats->cooldown_ticks > 0) return;
+	if (e->stats.cooldown_ticks > 0) return;
 
 	// Note there are two stages to activating a power.
 	// First is the enemy choosing to use a power based on behavioral chance
@@ -207,42 +207,42 @@ void BehaviorStandard::checkPower() {
 
 	// Begin Power Animation:
 	// standard enemies can begin a power-use animation if they're standing around or moving voluntarily.
-	if (los && (e->stats->cur_state == ENEMY_STANCE || e->stats->cur_state == ENEMY_MOVE)) {
+	if (los && (e->stats.cur_state == ENEMY_STANCE || e->stats.cur_state == ENEMY_MOVE)) {
 
 		// check half dead power use
-		if (!e->stats->on_half_dead_casted && e->stats->hp <= e->stats->maxhp/2) {
-			if (percentChance(e->stats->power_chance[ON_HALF_DEAD])) {
+		if (!e->stats.on_half_dead_casted && e->stats.hp <= e->stats.maxhp/2) {
+			if (percentChance(e->stats.power_chance[ON_HALF_DEAD])) {
 				e->newState(ENEMY_POWER);
-				e->stats->activated_powerslot = ON_HALF_DEAD;
+				e->stats.activated_powerslot = ON_HALF_DEAD;
 				return;
 			}
 		}
 
 		// check ranged power use
-		if (dist > e->stats->melee_range) {
+		if (dist > e->stats.melee_range) {
 
-			if (percentChance(e->stats->power_chance[RANGED_PHYS]) && e->stats->power_ticks[RANGED_PHYS] == 0) {
+			if (percentChance(e->stats.power_chance[RANGED_PHYS]) && e->stats.power_ticks[RANGED_PHYS] == 0) {
 				e->newState(ENEMY_POWER);
-				e->stats->activated_powerslot = RANGED_PHYS;
+				e->stats.activated_powerslot = RANGED_PHYS;
 				return;
 			}
-			if (percentChance(e->stats->power_chance[RANGED_MENT]) && e->stats->power_ticks[RANGED_MENT] == 0) {
+			if (percentChance(e->stats.power_chance[RANGED_MENT]) && e->stats.power_ticks[RANGED_MENT] == 0) {
 				e->newState(ENEMY_POWER);
-				e->stats->activated_powerslot = RANGED_MENT;
+				e->stats.activated_powerslot = RANGED_MENT;
 				return;
 			}
 
 		}
 		else { // check melee power use
 
-			if (percentChance(e->stats->power_chance[MELEE_PHYS]) && e->stats->power_ticks[MELEE_PHYS] == 0) {
+			if (percentChance(e->stats.power_chance[MELEE_PHYS]) && e->stats.power_ticks[MELEE_PHYS] == 0) {
 				e->newState(ENEMY_POWER);
-				e->stats->activated_powerslot = MELEE_PHYS;
+				e->stats.activated_powerslot = MELEE_PHYS;
 				return;
 			}
-			if (percentChance(e->stats->power_chance[MELEE_MENT]) && e->stats->power_ticks[MELEE_MENT] == 0) {
+			if (percentChance(e->stats.power_chance[MELEE_MENT]) && e->stats.power_ticks[MELEE_MENT] == 0) {
 				e->newState(ENEMY_POWER);
-				e->stats->activated_powerslot = MELEE_MENT;
+				e->stats.activated_powerslot = MELEE_MENT;
 				return;
 			}
 		}
@@ -251,22 +251,22 @@ void BehaviorStandard::checkPower() {
 
 	// Activate Power:
 	// enemy has started the animation to use a power. Activate the power on the Active animation frame
-	if (e->stats->cur_state == ENEMY_POWER) {
+	if (e->stats.cur_state == ENEMY_POWER) {
 
 		// if we're at the active frame of a power animation,
 		// activate the power and set the local and global cooldowns
 		if (e->activeAnimation->isActiveFrame() || e->instant_power) {
 			e->instant_power = false;
 
-			int power_slot =  e->stats->activated_powerslot;
-			int power_id = e->stats->power_index[e->stats->activated_powerslot];
+			int power_slot =  e->stats.activated_powerslot;
+			int power_id = e->stats.power_index[e->stats.activated_powerslot];
 
-			e->powers->activate(power_id, e->stats, pursue_pos);
-			e->stats->power_ticks[power_slot] = e->stats->power_cooldown[power_slot];
-			e->stats->cooldown_ticks = e->stats->cooldown;
+			e->powers->activate(power_id, &e->stats, pursue_pos);
+			e->stats.power_ticks[power_slot] = e->stats.power_cooldown[power_slot];
+			e->stats.cooldown_ticks = e->stats.cooldown;
 
-			if (e->stats->activated_powerslot == ON_HALF_DEAD) {
-				e->stats->on_half_dead_casted = true;
+			if (e->stats.activated_powerslot == ON_HALF_DEAD) {
+				e->stats.on_half_dead_casted = true;
 			}
 		}
 	}
@@ -279,15 +279,15 @@ void BehaviorStandard::checkPower() {
 void BehaviorStandard::checkMove() {
 
 	// dying enemies can't move
-	if (e->stats->cur_state == ENEMY_DEAD || e->stats->cur_state == ENEMY_CRITDEAD) return;
+	if (e->stats.cur_state == ENEMY_DEAD || e->stats.cur_state == ENEMY_CRITDEAD) return;
 
 	// stunned enemies can't act
-	if (e->stats->effects.stun) return;
+	if (e->stats.effects.stun) return;
 
 	// handle not being in combat and (not patrolling waypoints or waiting at waypoint)
-	if (!e->stats->in_combat && (e->stats->waypoints.empty() || e->stats->waypoint_pause_ticks > 0) && (!e->stats->wander || e->stats->wander_pause_ticks > 0)) {
+	if (!e->stats.in_combat && (e->stats.waypoints.empty() || e->stats.waypoint_pause_ticks > 0) && (!e->stats.wander || e->stats.wander_pause_ticks > 0)) {
 
-		if (e->stats->cur_state == ENEMY_MOVE) {
+		if (e->stats.cur_state == ENEMY_MOVE) {
 			e->newState(ENEMY_STANCE);
 		}
 
@@ -296,36 +296,36 @@ void BehaviorStandard::checkMove() {
 	}
 
 	// clear current space to allow correct movement
-	e->map->collider.unblock(e->stats->pos.x, e->stats->pos.y);
+	e->map->collider.unblock(e->stats.pos.x, e->stats.pos.y);
 
 	// update direction
-	if (e->stats->facing) {
-		if (++e->stats->turn_ticks > e->stats->turn_delay) {
+	if (e->stats.facing) {
+		if (++e->stats.turn_ticks > e->stats.turn_delay) {
 
 			// if blocked, face in pathfinder direction instead
-			if (!e->map->collider.line_of_movement(e->stats->pos.x, e->stats->pos.y, e->stats->hero_pos.x, e->stats->hero_pos.y, e->stats->movement_type)) {
+			if (!e->map->collider.line_of_movement(e->stats.pos.x, e->stats.pos.y, e->stats.hero_pos.x, e->stats.hero_pos.y, e->stats.movement_type)) {
 
 				// if a path is returned, target first waypoint
 				std::vector<Point> path;
 
-				if ( e->map->collider.compute_path(e->stats->pos, pursue_pos, path, e->stats->movement_type) ) {
+				if ( e->map->collider.compute_path(e->stats.pos, pursue_pos, path, e->stats.movement_type) ) {
 					pursue_pos = path.back();
 				}
 			}
 
-			e->stats->direction = e->face(pursue_pos.x, pursue_pos.y);
-			e->stats->turn_ticks = 0;
+			e->stats.direction = e->face(pursue_pos.x, pursue_pos.y);
+			e->stats.turn_ticks = 0;
 		}
 	}
-	int prev_direction = e->stats->direction;
+	int prev_direction = e->stats.direction;
 
 	// try to start moving
-	if (e->stats->cur_state == ENEMY_STANCE) {
+	if (e->stats.cur_state == ENEMY_STANCE) {
 
-		if (dist < e->stats->melee_range) {
+		if (dist < e->stats.melee_range) {
 			// too close, do nothing
 		}
-		else if (percentChance(e->stats->chance_pursue)) {
+		else if (percentChance(e->stats.chance_pursue)) {
 
 			if (e->move()) {
 				e->newState(ENEMY_MOVE);
@@ -333,20 +333,20 @@ void BehaviorStandard::checkMove() {
 			else {
 
 				// hit an obstacle, try the next best angle
-				e->stats->direction = e->faceNextBest(pursue_pos.x, pursue_pos.y);
+				e->stats.direction = e->faceNextBest(pursue_pos.x, pursue_pos.y);
 				if (e->move()) {
 					e->newState(ENEMY_MOVE);
 				}
-				else e->stats->direction = prev_direction;
+				else e->stats.direction = prev_direction;
 			}
 		}
 	}
 
 	// already moving
-	else if (e->stats->cur_state == ENEMY_MOVE) {
+	else if (e->stats.cur_state == ENEMY_MOVE) {
 
 		// close enough to the hero
-		if (dist < e->stats->melee_range) {
+		if (dist < e->stats.melee_range) {
 			e->newState(ENEMY_STANCE);
 		}
 
@@ -354,39 +354,39 @@ void BehaviorStandard::checkMove() {
 		else if (!e->move()) {
 
 			// hit an obstacle.  Try the next best angle
-			e->stats->direction = e->faceNextBest(pursue_pos.x, pursue_pos.y);
+			e->stats.direction = e->faceNextBest(pursue_pos.x, pursue_pos.y);
 			if (!e->move()) {
 				e->newState(ENEMY_STANCE);
-				e->stats->direction = prev_direction;
+				e->stats.direction = prev_direction;
 			}
 		}
 	}
 
 	// if patrolling waypoints and has reached a waypoint, cycle to the next one
-	if (!e->stats->waypoints.empty()) {
-		Point waypoint = e->stats->waypoints.front();
-		Point pos = e->stats->pos;
+	if (!e->stats.waypoints.empty()) {
+		Point waypoint = e->stats.waypoints.front();
+		Point pos = e->stats.pos;
 		// if the patroller is close to the waypoint
 		if (abs(waypoint.x - pos.x) < UNITS_PER_TILE/2 && abs(waypoint.y - pos.y) < UNITS_PER_TILE/2) {
-			e->stats->waypoints.pop();
-			e->stats->waypoints.push(waypoint);
-			e->stats->waypoint_pause_ticks = e->stats->waypoint_pause;
+			e->stats.waypoints.pop();
+			e->stats.waypoints.push(waypoint);
+			e->stats.waypoint_pause_ticks = e->stats.waypoint_pause;
 		}
 	}
 
 	// if a wandering enemy reaches its destination early, reset wander_ticks
-	if (e->stats->wander) {
-		Point pos = e->stats->pos;
+	if (e->stats.wander) {
+		Point pos = e->stats.pos;
 		if (abs(pursue_pos.x - pos.x) < UNITS_PER_TILE/2 && abs(pursue_pos.y - pos.y) < UNITS_PER_TILE/2) {
-			e->stats->wander_ticks = 0;
+			e->stats.wander_ticks = 0;
 		}
-		if (e->stats->wander_ticks == 0 && e->stats->wander_pause_ticks == 0) {
-			e->stats->wander_pause_ticks = rand() % 60;
+		if (e->stats.wander_ticks == 0 && e->stats.wander_pause_ticks == 0) {
+			e->stats.wander_pause_ticks = rand() % 60;
 		}
 	}
 
 	// re-block current space to allow correct movement
-	e->map->collider.block(e->stats->pos.x, e->stats->pos.y);
+	e->map->collider.block(e->stats.pos.x, e->stats.pos.y);
 
 }
 
@@ -398,7 +398,7 @@ void BehaviorStandard::checkMove() {
 void BehaviorStandard::updateState() {
 
 	// stunned enemies can't act
-	if (e->stats->effects.stun) return;
+	if (e->stats.effects.stun) return;
 
 	int power_id;
 	int power_state;
@@ -406,7 +406,7 @@ void BehaviorStandard::updateState() {
 	// continue current animations
 	e->activeAnimation->advanceFrame();
 
-	switch (e->stats->cur_state) {
+	switch (e->stats.cur_state) {
 
 		case ENEMY_STANCE:
 
@@ -420,7 +420,7 @@ void BehaviorStandard::updateState() {
 
 		case ENEMY_POWER:
 
-			power_id = e->stats->power_index[e->stats->activated_powerslot];
+			power_id = e->stats.power_index[e->stats.activated_powerslot];
 			power_state = e->powers->powers[power_id].new_state;
 
 			// animation based on power type
@@ -454,25 +454,25 @@ void BehaviorStandard::updateState() {
 
 			e->setAnimation("hit");
 			if (e->activeAnimation->isFirstFrame()) {
-				e->stats->effects.triggered_hit = true;
+				e->stats.effects.triggered_hit = true;
 			}
 			if (e->activeAnimation->isLastFrame()) e->newState(ENEMY_STANCE);
 			break;
 
 		case ENEMY_DEAD:
-			if (e->stats->effects.triggered_death) break;
+			if (e->stats.effects.triggered_death) break;
 
 			e->setAnimation("die");
 			if (e->activeAnimation->isFirstFrame()) {
 				e->sfx_die = true;
-				e->stats->corpse_ticks = CORPSE_TIMEOUT;
-				e->stats->effects.clearEffects();
+				e->stats.corpse_ticks = CORPSE_TIMEOUT;
+				e->stats.effects.clearEffects();
 			}
 			if (e->activeAnimation->isSecondLastFrame()) {
-				if (percentChance(e->stats->power_chance[ON_DEATH]))
-					e->powers->activate(e->stats->power_index[ON_DEATH], e->stats, e->stats->pos);
+				if (percentChance(e->stats.power_chance[ON_DEATH]))
+					e->powers->activate(e->stats.power_index[ON_DEATH], &e->stats, e->stats.pos);
 			}
-			if (e->activeAnimation->isLastFrame()) e->stats->corpse = true; // puts renderable under object layer
+			if (e->activeAnimation->isLastFrame()) e->stats.corpse = true; // puts renderable under object layer
 
 			break;
 
@@ -481,14 +481,14 @@ void BehaviorStandard::updateState() {
 			e->setAnimation("critdie");
 			if (e->activeAnimation->isFirstFrame()) {
 				e->sfx_critdie = true;
-				e->stats->corpse_ticks = CORPSE_TIMEOUT;
-				e->stats->effects.clearEffects();
+				e->stats.corpse_ticks = CORPSE_TIMEOUT;
+				e->stats.effects.clearEffects();
 			}
 			if (e->activeAnimation->isSecondLastFrame()) {
-				if (percentChance(e->stats->power_chance[ON_DEATH]))
-					e->powers->activate(e->stats->power_index[ON_DEATH], e->stats, e->stats->pos);
+				if (percentChance(e->stats.power_chance[ON_DEATH]))
+					e->powers->activate(e->stats.power_index[ON_DEATH], &e->stats, e->stats.pos);
 			}
-			if (e->activeAnimation->isLastFrame()) e->stats->corpse = true; // puts renderable under object layer
+			if (e->activeAnimation->isLastFrame()) e->stats.corpse = true; // puts renderable under object layer
 
 			break;
 
@@ -497,7 +497,7 @@ void BehaviorStandard::updateState() {
 	}
 
 	// activate all passive powers
-	if (e->stats->hp > 0 || e->stats->effects.triggered_death) e->powers->activatePassives(e->stats);
+	if (e->stats.hp > 0 || e->stats.effects.triggered_death) e->powers->activatePassives(&e->stats);
 }
 
 

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -66,7 +66,7 @@ void EnemyManager::loadSounds(const string& type_id) {
 }
 
 void EnemyManager::loadAnimations(Enemy *e) {
-	string animationsname = "animations/enemies/"+e->stats->animations + ".txt";
+	string animationsname = "animations/enemies/"+e->stats.animations + ".txt";
 	anim->increaseCount(animationsname);
 	e->animationSet = anim->getAnimationSet(animationsname);
 	e->activeAnimation = e->animationSet->getAnimation();
@@ -75,7 +75,7 @@ void EnemyManager::loadAnimations(Enemy *e) {
 Enemy *EnemyManager::getEnemyPrototype(const string& type_id) {
 	for (size_t i = 0; i < prototypes.size(); i++)
 		if (prototypes[i].type == type_id) {
-			string animationsname = "animations/enemies/"+prototypes[i].stats->animations + ".txt";
+			string animationsname = "animations/enemies/"+prototypes[i].stats.animations + ".txt";
 			anim->increaseCount(animationsname);
 			return new Enemy(prototypes[i]);
 		}
@@ -83,16 +83,16 @@ Enemy *EnemyManager::getEnemyPrototype(const string& type_id) {
 	Enemy e = Enemy(powers, map);
 
 	e.eb = new BehaviorStandard(&e);
-	e.stats->load("enemies/" + type_id + ".txt");
+	e.stats.load("enemies/" + type_id + ".txt");
 	e.type = type_id;
 
-	if (e.stats->animations == "")
+	if (e.stats.animations == "")
 		cerr << "Warning: no animation file specified for entity: " << type_id << endl;
-	if (e.stats->sfx_prefix == "")
+	if (e.stats.sfx_prefix == "")
 		cerr << "Warning: no sfx_prefix specified for entity: " << type_id << endl;
 
 	loadAnimations(&e);
-	loadSounds(e.stats->sfx_prefix);
+	loadSounds(e.stats.sfx_prefix);
 
 	prototypes.push_back(e);
 
@@ -137,12 +137,12 @@ void EnemyManager::handleNewMap () {
 
 		Enemy *e = getEnemyPrototype(me.type);
 
-		e->stats->waypoints = me.waypoints;
-		e->stats->pos.x = me.pos.x;
-		e->stats->pos.y = me.pos.y;
-		e->stats->direction = me.direction;
-		e->stats->wander = me.wander;
-		e->stats->wander_area = me.wander_area;
+		e->stats.waypoints = me.waypoints;
+		e->stats.pos.x = me.pos.x;
+		e->stats.pos.y = me.pos.y;
+		e->stats.direction = me.direction;
+		e->stats.wander = me.wander;
+		e->stats.wander_area = me.wander_area;
 
 		enemies.push_back(e);
 
@@ -167,13 +167,13 @@ void EnemyManager::handleSpawn() {
 		// factory
 		e->eb = new BehaviorStandard(e);
 
-		e->stats->pos.x = espawn.pos.x;
-		e->stats->pos.y = espawn.pos.y;
-		e->stats->direction = espawn.direction;
-		e->stats->load("enemies/" + espawn.type + ".txt");
-		if (e->stats->animations != "") {
+		e->stats.pos.x = espawn.pos.x;
+		e->stats.pos.y = espawn.pos.y;
+		e->stats.direction = espawn.direction;
+		e->stats.load("enemies/" + espawn.type + ".txt");
+		if (e->stats.animations != "") {
 			// load the animation file if specified
-			string animationname = "animations/enemies/"+e->stats->animations + ".txt";
+			string animationname = "animations/enemies/"+e->stats.animations + ".txt";
 			anim->increaseCount(animationname);
 			e->animationSet = anim->getAnimationSet(animationname);
 			if (e->animationSet)
@@ -184,10 +184,10 @@ void EnemyManager::handleSpawn() {
 		else {
 			cout << "Warning: no animation file specified for entity: " << espawn.type << endl;
 		}
-		loadSounds(e->stats->sfx_prefix);
+		loadSounds(e->stats.sfx_prefix);
 
 		// special animation state for spawning enemies
-		e->stats->cur_state = ENEMY_SPAWN;
+		e->stats.cur_state = ENEMY_SPAWN;
 		enemies.push_back(e);
 
 		map->collider.block(espawn.pos.x, espawn.pos.y);
@@ -207,13 +207,13 @@ void EnemyManager::logic() {
 		// so process and clear sound effects from previous frames
 		// check sound effects
 		if (AUDIO) {
-			vector<string>::iterator found = find (sfx_prefixes.begin(), sfx_prefixes.end(), enemies[i]->stats->sfx_prefix);
+			vector<string>::iterator found = find (sfx_prefixes.begin(), sfx_prefixes.end(), enemies[i]->stats.sfx_prefix);
 			unsigned pref_id = distance(sfx_prefixes.begin(), found);
 
 			if (pref_id >= sfx_prefixes.size()) {
 				cerr << "ERROR: enemy sfx_prefix doesn't match registered prefixes (enemy: '"
-					 << enemies[i]->stats->name << "', sfx_prefix: '"
-					 << enemies[i]->stats->sfx_prefix << "')" << endl;
+					 << enemies[i]->stats.name << "', sfx_prefix: '"
+					 << enemies[i]->stats.sfx_prefix << "')" << endl;
 			} else {
 				if (enemies[i]->sfx_phys) snd->play(sound_phys[pref_id]);
 				if (enemies[i]->sfx_ment) snd->play(sound_ment[pref_id]);
@@ -231,9 +231,9 @@ void EnemyManager::logic() {
 		}
 
 		// new actions this round
-		enemies[i]->stats->hero_pos = hero_pos;
-		enemies[i]->stats->hero_alive = hero_alive;
-		enemies[i]->stats->hero_stealth = hero_stealth;
+		enemies[i]->stats.hero_pos = hero_pos;
+		enemies[i]->stats.hero_alive = hero_alive;
+		enemies[i]->stats.hero_stealth = hero_stealth;
 		enemies[i]->logic();
 
 	}
@@ -243,10 +243,10 @@ Enemy* EnemyManager::enemyFocus(Point mouse, Point cam, bool alive_only) {
 	Point p;
 	SDL_Rect r;
 	for(unsigned int i = 0; i < enemies.size(); i++) {
-		if(alive_only && (enemies[i]->stats->cur_state == ENEMY_DEAD || enemies[i]->stats->cur_state == ENEMY_CRITDEAD)) {
+		if(alive_only && (enemies[i]->stats.cur_state == ENEMY_DEAD || enemies[i]->stats.cur_state == ENEMY_CRITDEAD)) {
 			continue;
 		}
-		p = map_to_screen(enemies[i]->stats->pos.x, enemies[i]->stats->pos.y, cam.x, cam.y);
+		p = map_to_screen(enemies[i]->stats.pos.x, enemies[i]->stats.pos.y, cam.x, cam.y);
 
 		r.w = enemies[i]->getRender().src.w;
 		r.h = enemies[i]->getRender().src.h;
@@ -267,7 +267,7 @@ Enemy* EnemyManager::enemyFocus(Point mouse, Point cam, bool alive_only) {
 void EnemyManager::checkEnemiesforXP(CampaignManager *camp) {
 	for (unsigned int i=0; i < enemies.size(); i++) {
 		if (enemies[i]->reward_xp) {
-			camp->rewardXP(enemies[i]->stats->xp, false);
+			camp->rewardXP(enemies[i]->stats.xp, false);
 			enemies[i]->reward_xp = false; // clear flag
 		}
 	}
@@ -277,7 +277,7 @@ bool EnemyManager::isCleared() {
 	if (enemies.empty()) return true;
 
 	for (unsigned int i=0; i < enemies.size(); i++) {
-		if (enemies[i]->stats->alive) return false;
+		if (enemies[i]->stats.alive) return false;
 	}
 
 	return true;
@@ -291,8 +291,8 @@ bool EnemyManager::isCleared() {
 void EnemyManager::addRenders(vector<Renderable> &r, vector<Renderable> &r_dead) {
 	vector<Enemy*>::iterator it;
 	for (it = enemies.begin(); it != enemies.end(); ++it) {
-		bool dead = (*it)->stats->corpse;
-		if (!dead || (dead && (*it)->stats->corpse_ticks > 0)) {
+		bool dead = (*it)->stats.corpse;
+		if (!dead || (dead && (*it)->stats.corpse_ticks > 0)) {
 			Renderable re = (*it)->getRender();
 			re.prio = 1;
 
@@ -300,11 +300,11 @@ void EnemyManager::addRenders(vector<Renderable> &r, vector<Renderable> &r_dead)
 			(dead ? r_dead : r).push_back(re);
 
 			// add effects
-			for (unsigned i = 0; i < (*it)->stats->effects.effect_list.size(); ++i) {
-				if ((*it)->stats->effects.effect_list[i].animation) {
-					Renderable ren = (*it)->stats->effects.effect_list[i].animation->getCurrentFrame(0);
-					ren.map_pos = (*it)->stats->pos;
-					if ((*it)->stats->effects.effect_list[i].render_above) ren.prio = 2;
+			for (unsigned i = 0; i < (*it)->stats.effects.effect_list.size(); ++i) {
+				if ((*it)->stats.effects.effect_list[i].animation) {
+					Renderable ren = (*it)->stats.effects.effect_list[i].animation->getCurrentFrame(0);
+					ren.map_pos = (*it)->stats.pos;
+					if ((*it)->stats.effects.effect_list[i].render_above) ren.prio = 2;
 					else ren.prio = 0;
 					r.push_back(ren);
 				}

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -34,12 +34,11 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 using namespace std;
 
-Entity::Entity(MapRenderer* _map, StatBlock *_stats)
+Entity::Entity(MapRenderer* _map)
  : sprites(NULL)
  , activeAnimation(NULL)
  , animationSet(NULL)
  , map(_map)
- , stats(_stats)
 {
 }
 
@@ -48,7 +47,7 @@ Entity::Entity(const Entity &e)
  , activeAnimation(new Animation(*e.activeAnimation))
  , animationSet(e.animationSet)
  , map(e.map)
- , stats(e.stats->clone())
+ , stats(StatBlock(e.stats))
 {
 }
 
@@ -60,44 +59,44 @@ Entity::Entity(const Entity &e)
  */
 bool Entity::move() {
 
-	if (stats->effects.forced_move) {
-		return map->collider.move(stats->pos.x, stats->pos.y, stats->forced_speed.x, stats->forced_speed.y, 1, stats->movement_type);
+	if (stats.effects.forced_move) {
+		return map->collider.move(stats.pos.x, stats.pos.y, stats.forced_speed.x, stats.forced_speed.y, 1, stats.movement_type);
 	}
 
-	if (stats->effects.speed == 0) return false;
+	if (stats.effects.speed == 0) return false;
 
-	int speed_diagonal = stats->dspeed;
-	int speed_straight = stats->speed;
+	int speed_diagonal = stats.dspeed;
+	int speed_straight = stats.speed;
 
-	speed_diagonal = (speed_diagonal * stats->effects.speed) / 100;
-	speed_straight = (speed_straight * stats->effects.speed) / 100;
+	speed_diagonal = (speed_diagonal * stats.effects.speed) / 100;
+	speed_straight = (speed_straight * stats.effects.speed) / 100;
 
 	bool full_move = false;
 
-	switch (stats->direction) {
+	switch (stats.direction) {
 		case 0:
-			full_move = map->collider.move(stats->pos.x, stats->pos.y, -1, 1, speed_diagonal, stats->movement_type);
+			full_move = map->collider.move(stats.pos.x, stats.pos.y, -1, 1, speed_diagonal, stats.movement_type);
 			break;
 		case 1:
-			full_move =  map->collider.move(stats->pos.x, stats->pos.y, -1, 0, speed_straight, stats->movement_type);
+			full_move =  map->collider.move(stats.pos.x, stats.pos.y, -1, 0, speed_straight, stats.movement_type);
 			break;
 		case 2:
-			full_move =  map->collider.move(stats->pos.x, stats->pos.y, -1, -1, speed_diagonal, stats->movement_type);
+			full_move =  map->collider.move(stats.pos.x, stats.pos.y, -1, -1, speed_diagonal, stats.movement_type);
 			break;
 		case 3:
-			full_move =  map->collider.move(stats->pos.x, stats->pos.y, 0, -1, speed_straight, stats->movement_type);
+			full_move =  map->collider.move(stats.pos.x, stats.pos.y, 0, -1, speed_straight, stats.movement_type);
 			break;
 		case 4:
-			full_move =  map->collider.move(stats->pos.x, stats->pos.y, 1, -1, speed_diagonal, stats->movement_type);
+			full_move =  map->collider.move(stats.pos.x, stats.pos.y, 1, -1, speed_diagonal, stats.movement_type);
 			break;
 		case 5:
-			full_move =  map->collider.move(stats->pos.x, stats->pos.y, 1, 0, speed_straight, stats->movement_type);
+			full_move =  map->collider.move(stats.pos.x, stats.pos.y, 1, 0, speed_straight, stats.movement_type);
 			break;
 		case 6:
-			full_move =  map->collider.move(stats->pos.x, stats->pos.y, 1, 1, speed_diagonal, stats->movement_type);
+			full_move =  map->collider.move(stats.pos.x, stats.pos.y, 1, 1, speed_diagonal, stats.movement_type);
 			break;
 		case 7:
-			full_move =  map->collider.move(stats->pos.x, stats->pos.y, 0, 1, speed_straight, stats->movement_type);
+			full_move =  map->collider.move(stats.pos.x, stats.pos.y, 0, 1, speed_straight, stats.movement_type);
 			break;
 	}
 
@@ -109,8 +108,8 @@ bool Entity::move() {
  */
 int Entity::face(int mapx, int mapy) {
 	// inverting Y to convert map coordinates to standard cartesian coordinates
-	int dx = mapx - stats->pos.x;
-	int dy = stats->pos.y - mapy;
+	int dx = mapx - stats.pos.x;
+	int dy = stats.pos.y - mapy;
 
 	// avoid div by zero
 	if (dx == 0) {
@@ -135,7 +134,7 @@ int Entity::face(int mapx, int mapy) {
 		if (dy > 0) return 3;
 		else return 7;
 	}
-	return stats->direction;
+	return stats.direction;
 }
 
 /**

--- a/src/Entity.h
+++ b/src/Entity.h
@@ -39,7 +39,7 @@ protected:
 	SDL_Surface *sprites;
 
 public:
-	Entity(MapRenderer*, StatBlock *_stats);
+	Entity(MapRenderer*);
 	Entity(const Entity&);
 	virtual ~Entity();
 
@@ -53,8 +53,8 @@ public:
 	Animation *activeAnimation;
 	AnimationSet *animationSet;
 
-	MapRenderer *map;
-	StatBlock *stats;
+	MapRenderer* map;
+	StatBlock stats;
 };
 
 #endif

--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -438,7 +438,7 @@ void GameStateLoad::logic() {
 			filename << PATH_USER << "save" << (selected_slot+1) << ".txt";
 			if (remove(filename.str().c_str()) != 0)
 				perror("Error deleting save from path");
-			stats[selected_slot] = AvatarStatBlock();
+			stats[selected_slot] = StatBlock();
 			readGameSlot(selected_slot);
 			loadPreview(selected_slot);
 			loadPortrait(selected_slot);

--- a/src/GameStateLoad.h
+++ b/src/GameStateLoad.h
@@ -72,7 +72,7 @@ private:
 	SDL_Surface *portrait_border;
 	SDL_Surface *portrait;
 	std::vector<SDL_Surface *> sprites[GAME_SLOT_MAX];
-	AvatarStatBlock stats[GAME_SLOT_MAX];
+	StatBlock stats[GAME_SLOT_MAX];
 	std::vector<int> equipped[GAME_SLOT_MAX];
 	std::vector<std::string> preview_layer;
 	SDL_Rect slot_pos[GAME_SLOT_MAX];

--- a/src/GameStateNew.cpp
+++ b/src/GameStateNew.cpp
@@ -257,11 +257,11 @@ void GameStateNew::logic() {
 		// start the new game
 		GameStatePlay* play = new GameStatePlay();
 		Avatar *pc = play->getAvatar();
-		pc->stats->base = base[current_option];
-		pc->stats->head = head[current_option];
-		pc->stats->portrait = portrait[current_option];
-		pc->stats->name = input_name->getText();
-		pc->stats->permadeath = button_permadeath->isChecked();
+		pc->stats.base = base[current_option];
+		pc->stats.head = head[current_option];
+		pc->stats.portrait = portrait[current_option];
+		pc->stats.name = input_name->getText();
+		pc->stats.permadeath = button_permadeath->isChecked();
 		play->game_slot = game_slot;
 		play->resetGame();
 		play->loadClass(class_list->getSelected());

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -74,9 +74,9 @@ GameStatePlay::GameStatePlay()
 	, pc(new Avatar(powers, map))
 	, enemies(new EnemyManager(powers, map))
 	, hazards(new HazardManager(powers, pc, enemies))
-	, menu(new MenuManager(powers, pc->statBlock(), camp, items))
-	, loot(new LootManager(items, map, pc->statBlock()))
-	, npcs(new NPCManager(map, loot, items, pc->statBlock()))
+	, menu(new MenuManager(powers, &pc->stats, camp, items))
+	, loot(new LootManager(items, map, &pc->stats))
+	, npcs(new NPCManager(map, loot, items, &pc->stats))
 	, quests(new QuestLog(camp, menu->log))
 	, loading(new WidgetLabel())
 	, loading_bg(IMG_Load(mods->locate("images/menus/confirm_bg.png").c_str()))
@@ -92,7 +92,7 @@ GameStatePlay::GameStatePlay()
 	camp->items = items;
 	camp->carried_items = &menu->inv->inventory[CARRIED];
 	camp->currency = &menu->inv->currency;
-	camp->hero = pc->stats;
+	camp->hero = &pc->stats;
 	map->powers = powers;
 
 	loading->set(VIEW_W_HALF, VIEW_H_HALF, JUSTIFY_CENTER, VALIGN_CENTER, msg->get("Loading..."), color_normal);
@@ -118,7 +118,7 @@ void GameStatePlay::resetGame() {
 	map->load("spawn.txt");
 	camp->clearAll();
 	pc->init();
-	pc->statBlock()->currency = 0;
+	pc->stats.currency = 0;
 	menu->act->clear();
 	menu->inv->inventory[0].clear();
 	menu->inv->inventory[1].clear();
@@ -130,7 +130,7 @@ void GameStatePlay::resetGame() {
 	loadStash();
 
 	// Finalize new character settings
-	menu->talker->setHero(pc->statBlock()->name, pc->statBlock()->portrait);
+	menu->talker->setHero(pc->stats.name, pc->stats.portrait);
 	pc->loadSounds();
 }
 
@@ -147,7 +147,7 @@ void GameStatePlay::checkEnemyFocus() {
 	if (enemy != NULL) {
 
 		// if there's a living creature in focus, display its stats
-		if (!enemy->stats->suppress_hp) {
+		if (!enemy->stats.suppress_hp) {
 			menu->enemy->enemy = enemy;
 			menu->enemy->timeout = MENU_ENEMY_TIMEOUT;
 		}
@@ -186,17 +186,17 @@ void GameStatePlay::checkLoot() {
 	int currency;
 
 	// Autopickup
-	if (pc->statBlock()->alive && AUTOPICKUP_CURRENCY) {
-		pickup = loot->checkAutoPickup(pc->statBlock()->pos, currency);
+	if (pc->stats.alive && AUTOPICKUP_CURRENCY) {
+		pickup = loot->checkAutoPickup(pc->stats.pos, currency);
 		if (currency > 0) {
 			menu->inv->addCurrency(currency);
 		}
 	}
 
 	// Pickup with mouse click
-	if (inpt->pressing[MAIN1] && !inpt->lock[MAIN1] && pc->statBlock()->alive) {
+	if (inpt->pressing[MAIN1] && !inpt->lock[MAIN1] && pc->stats.alive) {
 
-		pickup = loot->checkPickup(inpt->mouse, map->cam, pc->statBlock()->pos, currency, menu->inv);
+		pickup = loot->checkPickup(inpt->mouse, map->cam, pc->stats.pos, currency, menu->inv);
 		if (pickup.item > 0) {
 			inpt->lock[MAIN1] = true;
 			menu->inv->add(pickup);
@@ -216,9 +216,9 @@ void GameStatePlay::checkLoot() {
 	}
 
 	// Pickup with ACCEPT key/button
-	if ((inpt->pressing[ACCEPT] && !inpt->lock[ACCEPT]) && pc->statBlock()->alive) {
+	if ((inpt->pressing[ACCEPT] && !inpt->lock[ACCEPT]) && pc->stats.alive) {
 
-		pickup = loot->checkNearestPickup(pc->statBlock()->pos, currency, menu->inv);
+		pickup = loot->checkNearestPickup(pc->stats.pos, currency, menu->inv);
 		if (pickup.item > 0) {
 			if (inpt->pressing[ACCEPT]) inpt->lock[ACCEPT] = true;
 			menu->inv->add(pickup);
@@ -241,17 +241,17 @@ void GameStatePlay::checkLoot() {
 void GameStatePlay::checkTeleport() {
 
 	// both map events and player powers can cause teleportation
-	if (map->teleportation || pc->statBlock()->teleportation) {
+	if (map->teleportation || pc->stats.teleportation) {
 
-		map->collider.unblock(pc->statBlock()->pos.x, pc->statBlock()->pos.y);
+		map->collider.unblock(pc->stats.pos.x, pc->stats.pos.y);
 
 		if (map->teleportation) {
-			map->cam.x = pc->statBlock()->pos.x = map->teleport_destination.x;
-			map->cam.y = pc->statBlock()->pos.y = map->teleport_destination.y;
+			map->cam.x = pc->stats.pos.x = map->teleport_destination.x;
+			map->cam.y = pc->stats.pos.y = map->teleport_destination.y;
 		}
 		else {
-			map->cam.x = pc->statBlock()->pos.x = pc->statBlock()->teleport_destination.x;
-			map->cam.y = pc->statBlock()->pos.y = pc->statBlock()->teleport_destination.y;
+			map->cam.x = pc->stats.pos.x = pc->stats.teleport_destination.x;
+			map->cam.y = pc->stats.pos.y = pc->stats.teleport_destination.y;
 		}
 
 		// process intermap teleport
@@ -274,11 +274,11 @@ void GameStatePlay::checkTeleport() {
 
 			// store this as the new respawn point
 			map->respawn_map = map->teleport_mapname;
-			map->respawn_point.x = pc->statBlock()->pos.x;
-			map->respawn_point.y = pc->statBlock()->pos.y;
+			map->respawn_point.x = pc->stats.pos.x;
+			map->respawn_point.y = pc->stats.pos.y;
 
 			// return to title (permadeath) OR auto-save
-			if (pc->statBlock()->permadeath && pc->statBlock()->corpse) {
+			if (pc->stats.permadeath && pc->stats.corpse) {
 				stringstream filename;
 				filename << PATH_USER << "save" << game_slot << ".txt";
 				if(remove(filename.str().c_str()) != 0)
@@ -292,10 +292,10 @@ void GameStatePlay::checkTeleport() {
 			}
 		}
 
-		map->collider.block(pc->statBlock()->pos.x, pc->statBlock()->pos.y);
+		map->collider.block(pc->stats.pos.x, pc->stats.pos.y);
 
 		map->teleportation = false;
-		pc->statBlock()->teleportation = false; // teleport spell
+		pc->stats.teleportation = false; // teleport spell
 
 	}
 }
@@ -390,47 +390,47 @@ void GameStatePlay::loadTitles() {
 }
 
 void GameStatePlay::checkTitle() {
-	if (!pc->statBlock()->check_title || titles.empty()) return;
+	if (!pc->stats.check_title || titles.empty()) return;
 
 	int title_id = -1;
 
 	for (unsigned i=0; i<titles.size(); i++) {
 		if (titles[i].title == "") continue;
 
-		if (titles[i].level > 0 && pc->statBlock()->level < titles[i].level) continue;
-		if (titles[i].power > 0 && find(pc->statBlock()->powers_list.begin(), pc->statBlock()->powers_list.end(), titles[i].power) == pc->statBlock()->powers_list.end()) continue;
+		if (titles[i].level > 0 && pc->stats.level < titles[i].level) continue;
+		if (titles[i].power > 0 && find(pc->stats.powers_list.begin(), pc->stats.powers_list.end(), titles[i].power) == pc->stats.powers_list.end()) continue;
 		if (titles[i].requires_status != "" && !camp->checkStatus(titles[i].requires_status)) continue;
 		if (titles[i].requires_not != "" && camp->checkStatus(titles[i].requires_not)) continue;
 		if (titles[i].primary_stat != "") {
 			if (titles[i].primary_stat == "physical") {
-				if (pc->statBlock()->get_physical() <= pc->statBlock()->get_mental() || pc->statBlock()->get_physical() <= pc->statBlock()->get_offense() || pc->statBlock()->get_physical() <= pc->statBlock()->get_defense())
+				if (pc->stats.get_physical() <= pc->stats.get_mental() || pc->stats.get_physical() <= pc->stats.get_offense() || pc->stats.get_physical() <= pc->stats.get_defense())
 					continue;
 			} else if (titles[i].primary_stat == "offense") {
-				if (pc->statBlock()->get_offense() <= pc->statBlock()->get_mental() || pc->statBlock()->get_offense() <= pc->statBlock()->get_physical() || pc->statBlock()->get_offense() <= pc->statBlock()->get_defense())
+				if (pc->stats.get_offense() <= pc->stats.get_mental() || pc->stats.get_offense() <= pc->stats.get_physical() || pc->stats.get_offense() <= pc->stats.get_defense())
 					continue;
 			} else if (titles[i].primary_stat == "mental") {
-				if (pc->statBlock()->get_mental() <= pc->statBlock()->get_physical() || pc->statBlock()->get_mental() <= pc->statBlock()->get_offense() || pc->statBlock()->get_mental() <= pc->statBlock()->get_defense())
+				if (pc->stats.get_mental() <= pc->stats.get_physical() || pc->stats.get_mental() <= pc->stats.get_offense() || pc->stats.get_mental() <= pc->stats.get_defense())
 					continue;
 			} else if (titles[i].primary_stat == "defense") {
-				if (pc->statBlock()->get_defense() <= pc->statBlock()->get_mental() || pc->statBlock()->get_defense() <= pc->statBlock()->get_offense() || pc->statBlock()->get_defense() <= pc->statBlock()->get_physical())
+				if (pc->stats.get_defense() <= pc->stats.get_mental() || pc->stats.get_defense() <= pc->stats.get_offense() || pc->stats.get_defense() <= pc->stats.get_physical())
 					continue;
 			} else if (titles[i].primary_stat == "physoff") {
-				if (pc->statBlock()->physoff() <= pc->statBlock()->physdef() || pc->statBlock()->physoff() <= pc->statBlock()->mentoff() || pc->statBlock()->physoff() <= pc->statBlock()->mentdef() || pc->statBlock()->physoff() <= pc->statBlock()->physment() || pc->statBlock()->physoff() <= pc->statBlock()->offdef())
+				if (pc->stats.physoff <= pc->stats.physdef || pc->stats.physoff <= pc->stats.mentoff || pc->stats.physoff <= pc->stats.mentdef || pc->stats.physoff <= pc->stats.physment || pc->stats.physoff <= pc->stats.offdef)
 					continue;
 			} else if (titles[i].primary_stat == "physment") {
-				if (pc->statBlock()->physment() <= pc->statBlock()->physdef() || pc->statBlock()->physment() <= pc->statBlock()->mentoff() || pc->statBlock()->physment() <= pc->statBlock()->mentdef() || pc->statBlock()->physment() <= pc->statBlock()->physoff() || pc->statBlock()->physment() <= pc->statBlock()->offdef())
+				if (pc->stats.physment <= pc->stats.physdef || pc->stats.physment <= pc->stats.mentoff || pc->stats.physment <= pc->stats.mentdef || pc->stats.physment <= pc->stats.physoff || pc->stats.physment <= pc->stats.offdef)
 					continue;
 			} else if (titles[i].primary_stat == "physdef") {
-				if (pc->statBlock()->physdef() <= pc->statBlock()->physoff() || pc->statBlock()->physdef() <= pc->statBlock()->mentoff() || pc->statBlock()->physdef() <= pc->statBlock()->mentdef() || pc->statBlock()->physdef() <= pc->statBlock()->physment() || pc->statBlock()->physdef() <= pc->statBlock()->offdef())
+				if (pc->stats.physdef <= pc->stats.physoff || pc->stats.physdef <= pc->stats.mentoff || pc->stats.physdef <= pc->stats.mentdef || pc->stats.physdef <= pc->stats.physment || pc->stats.physdef <= pc->stats.offdef)
 					continue;
 			} else if (titles[i].primary_stat == "mentoff") {
-				if (pc->statBlock()->mentoff() <= pc->statBlock()->physdef() || pc->statBlock()->mentoff() <= pc->statBlock()->physoff() || pc->statBlock()->mentoff() <= pc->statBlock()->mentdef() || pc->statBlock()->mentoff() <= pc->statBlock()->physment() || pc->statBlock()->mentoff() <= pc->statBlock()->offdef())
+				if (pc->stats.mentoff <= pc->stats.physdef || pc->stats.mentoff <= pc->stats.physoff || pc->stats.mentoff <= pc->stats.mentdef || pc->stats.mentoff <= pc->stats.physment || pc->stats.mentoff <= pc->stats.offdef)
 					continue;
 			} else if (titles[i].primary_stat == "offdef") {
-				if (pc->statBlock()->offdef() <= pc->statBlock()->physdef() || pc->statBlock()->offdef() <= pc->statBlock()->mentoff() || pc->statBlock()->offdef() <= pc->statBlock()->mentdef() || pc->statBlock()->offdef() <= pc->statBlock()->physment() || pc->statBlock()->offdef() <= pc->statBlock()->physoff())
+				if (pc->stats.offdef <= pc->stats.physdef || pc->stats.offdef <= pc->stats.mentoff || pc->stats.offdef <= pc->stats.mentdef || pc->stats.offdef <= pc->stats.physment || pc->stats.offdef <= pc->stats.physoff)
 					continue;
 			} else if (titles[i].primary_stat == "mentdef") {
-				if (pc->statBlock()->mentdef() <= pc->statBlock()->physdef() || pc->statBlock()->mentdef() <= pc->statBlock()->mentoff() || pc->statBlock()->mentdef() <= pc->statBlock()->physoff() || pc->statBlock()->mentdef() <= pc->statBlock()->physment() || pc->statBlock()->mentdef() <= pc->statBlock()->offdef())
+				if (pc->stats.mentdef <= pc->stats.physdef || pc->stats.mentdef <= pc->stats.mentoff || pc->stats.mentdef <= pc->stats.physoff || pc->stats.mentdef <= pc->stats.physment || pc->stats.mentdef <= pc->stats.offdef)
 					continue;
 			}
 		}
@@ -439,9 +439,9 @@ void GameStatePlay::checkTitle() {
 		break;
 	}
 
-	if (title_id != -1) pc->statBlock()->character_class = titles[title_id].title;
-	pc->statBlock()->check_title = false;
-	pc->statBlock()->refresh_stats = true;
+	if (title_id != -1) pc->stats.character_class = titles[title_id].title;
+	pc->stats.check_title = false;
+	pc->stats.refresh_stats = true;
 }
 
 void GameStatePlay::checkEquipmentChange() {
@@ -461,12 +461,12 @@ void GameStatePlay::checkEquipmentChange() {
 			}
 			// special case: if we don't have a head, use the portrait's head
 			if (gfx.gfx == "" && pc->layer_reference_order[j] == "head") {
-				gfx.gfx = pc->statBlock()->head;
+				gfx.gfx = pc->stats.head;
 				gfx.type = "head";
 			}
 			// fall back to default if it exists
 			if (gfx.gfx == "") {
-				bool exists = fileExists(mods->locate("animations/avatar/" + pc->statBlock()->base + "/default_" + gfx.type + ".txt"));
+				bool exists = fileExists(mods->locate("animations/avatar/" + pc->stats.base + "/default_" + gfx.type + ".txt"));
 				if (exists) gfx.gfx = "default_" + gfx.type;
 			}
 			img_gfx.push_back(gfx);
@@ -484,14 +484,14 @@ void GameStatePlay::checkLootDrop() {
 
 	// if the player has dropped an item from the inventory
 	if (menu->drop_stack.item > 0) {
-		loot->addLoot(menu->drop_stack, pc->statBlock()->pos);
+		loot->addLoot(menu->drop_stack, pc->stats.pos);
 		menu->drop_stack.item = 0;
 		menu->drop_stack.quantity = 0;
 	}
 
 	// if the player has dropped a quest rward because inventory full
 	if (camp->drop_stack.item > 0) {
-		loot->addLoot(camp->drop_stack, pc->statBlock()->pos);
+		loot->addLoot(camp->drop_stack, pc->stats.pos);
 		camp->drop_stack.item = 0;
 		camp->drop_stack.quantity = 0;
 	}
@@ -555,13 +555,13 @@ void GameStatePlay::checkNPCInteraction() {
 	}
 	// if we press the ACCEPT key, find the nearest NPC to interact with
 	else if (inpt->pressing[ACCEPT] && !inpt->lock[ACCEPT]) {
-		npc_click = npcs->getNearestNPC(pc->statBlock()->pos);
+		npc_click = npcs->getNearestNPC(pc->stats.pos);
 		if (npc_click != -1) npc_id = npc_click;
 	}
 
 	// check distance to this npc
 	if (npc_id != -1) {
-		interact_distance = (int)calcDist(pc->statBlock()->pos, npcs->npcs[npc_id]->pos);
+		interact_distance = (int)calcDist(pc->stats.pos, npcs->npcs[npc_id]->pos);
 	}
 
 	if (map->event_npc != "") {
@@ -574,7 +574,8 @@ void GameStatePlay::checkNPCInteraction() {
 	}
 
 	// if close enough to the NPC, open the appropriate interaction screen
-	if (npc_id != -1 && ((npc_click != -1 && interact_distance < max_interact_distance && pc->statBlock()->alive && pc->statBlock()->humanoid) || eventPendingDialog)) {
+
+	if (npc_id != -1 && ((npc_click != -1 && interact_distance < max_interact_distance && pc->stats.alive && pc->stats.humanoid) || eventPendingDialog)) {
 
 		if (inpt->pressing[MAIN1]) inpt->lock[MAIN1] = true;
 		if (inpt->pressing[ACCEPT]) inpt->lock[ACCEPT] = true;
@@ -600,8 +601,7 @@ void GameStatePlay::checkNPCInteraction() {
 		menu->npc->setNPC(NULL);
 	}
 
-	if (npc_id != -1 && ((interact_distance < max_interact_distance && pc->statBlock()->alive && pc->statBlock()->humanoid) || eventPendingDialog)) {
-
+	if (npc_id != -1 && ((interact_distance < max_interact_distance && pc->stats.alive && pc->stats.humanoid) || eventPendingDialog)) {
 
 		if (menu->talker->vendor_visible && !menu->vendor->talker_visible) {
 
@@ -649,7 +649,7 @@ void GameStatePlay::checkNPCInteraction() {
 
 	// check for walking away from an NPC
 	if (npc_id != -1 && !eventDialogOngoing) {
-		if (interact_distance > max_interact_distance || !pc->statBlock()->alive) {
+		if (interact_distance > max_interact_distance || !pc->stats.alive) {
 			menu->npc->setNPC(NULL);
 			menu->vendor->npc = NULL;
 			menu->talker->npc = NULL;
@@ -681,8 +681,8 @@ void GameStatePlay::checkStash() {
 		if (!menu->inv->visible) menu->stash->visible = false;
 
 		// If the player walks away from the stash, close its menu
-		interact_distance = (int)calcDist(pc->statBlock()->pos, map->stash_pos);
-		if (interact_distance > max_interact_distance || !pc->statBlock()->alive) {
+		interact_distance = (int)calcDist(pc->stats.pos, map->stash_pos);
+		if (interact_distance > max_interact_distance || !pc->stats.alive) {
 			menu->stash->visible = false;
 		}
 
@@ -710,16 +710,16 @@ void GameStatePlay::logic() {
 		checkEnemyFocus();
 		checkNPCInteraction();
 		map->checkHotspots();
-		map->checkNearestEvent(pc->statBlock()->pos);
+		map->checkNearestEvent(pc->stats.pos);
 		checkTitle();
 
 		pc->logic(menu->act->checkAction(inpt->mouse), restrictPowerUse());
 
 		// transfer hero data to enemies, for AI use
-		enemies->hero_pos = pc->statBlock()->pos;
-		enemies->hero_alive = pc->statBlock()->alive;
-		if (pc->statBlock()->effects.bonus_stealth > 100) enemies->hero_stealth = 100;
-		else enemies->hero_stealth = pc->statBlock()->effects.bonus_stealth;
+		enemies->hero_pos = pc->stats.pos;
+		enemies->hero_alive = pc->stats.alive;
+		if (pc->stats.effects.bonus_stealth > 100) enemies->hero_stealth = 100;
+		else enemies->hero_stealth = pc->stats.effects.bonus_stealth;
 
 		enemies->logic();
 		hazards->logic();
@@ -768,10 +768,10 @@ void GameStatePlay::logic() {
 			}
 			if (count == 12) count = 0;
 		}
-		if (pc->statBlock()->manual_untransform && pc->untransform_power > 0) {
+		if (pc->stats.manual_untransform && pc->untransform_power > 0) {
 			menu->act->hotkeys[count] = pc->untransform_power;
 			menu->act->locked[count] = true;
-		} else if (pc->statBlock()->manual_untransform && pc->untransform_power == 0)
+		} else if (pc->stats.manual_untransform && pc->untransform_power == 0)
 			fprintf(stderr, "Untransform power not found, you can't untransform manually\n");
 	}
 	// revert hero powers
@@ -790,13 +790,13 @@ void GameStatePlay::logic() {
 
 	// when the hero (re)spawns, reapply equipment & passive effects
 	if (pc->respawn) {
-		pc->statBlock()->alive = true;
-		pc->statBlock()->corpse = false;
-		pc->statBlock()->cur_state = AVATAR_STANCE;
+		pc->stats.alive = true;
+		pc->stats.corpse = false;
+		pc->stats.cur_state = AVATAR_STANCE;
 		menu->inv->applyEquipment(menu->inv->inventory[EQUIPMENT].storage);
-		pc->powers->activatePassives(pc->stats);
-		pc->statBlock()->logic();
-		pc->statBlock()->recalc();
+		pc->powers->activatePassives(&pc->stats);
+		pc->stats.logic();
+		pc->stats.recalc();
 		pc->respawn = false;
 	}
 }
@@ -835,7 +835,7 @@ void GameStatePlay::render() {
 		map->map_change = false;
 	}
 	menu->mini->getMapTitle(map->title);
-	menu->mini->render(pc->statBlock()->pos);
+	menu->mini->render(pc->stats.pos);
 	menu->render();
 
 	// render combat text last - this should make it obvious you're being

--- a/src/HazardManager.cpp
+++ b/src/HazardManager.cpp
@@ -80,8 +80,8 @@ void HazardManager::logic() {
 				for (unsigned int eindex = 0; eindex < enemies->enemies.size(); eindex++) {
 
 					// only check living enemies
-					if (enemies->enemies[eindex]->stats->hp > 0 && h[i]->active) {
-						if (isWithin(round(h[i]->pos), h[i]->radius, enemies->enemies[eindex]->stats->pos)) {
+					if (enemies->enemies[eindex]->stats.hp > 0 && h[i]->active) {
+						if (isWithin(round(h[i]->pos), h[i]->radius, enemies->enemies[eindex]->stats.pos)) {
 							if (!h[i]->hasEntity(enemies->enemies[eindex])) {
 								h[i]->addEntity(enemies->enemies[eindex]);
 								// hit!
@@ -99,8 +99,8 @@ void HazardManager::logic() {
 
 			// process hazards that can hurt the hero
 			if (h[i]->source_type != SOURCE_TYPE_HERO) { //enemy or neutral sources
-				if (hero->stats->hp > 0 && h[i]->active) {
-					if (isWithin(round(h[i]->pos), h[i]->radius, hero->stats->pos)) {
+				if (hero->stats.hp > 0 && h[i]->active) {
+					if (isWithin(round(h[i]->pos), h[i]->radius, hero->stats.pos)) {
 						if (!h[i]->hasEntity(hero)) {
 							h[i]->addEntity(hero);
 							// hit!

--- a/src/LootManager.cpp
+++ b/src/LootManager.cpp
@@ -200,16 +200,16 @@ void LootManager::checkEnemiesForLoot() {
 
 	for (unsigned i=0; i < enemiesDroppingLoot.size(); ++i) {
 		const Enemy *e = enemiesDroppingLoot[i];
-		if (e->stats->quest_loot_id != 0) {
+		if (e->stats.quest_loot_id != 0) {
 			// quest loot
-			istack.item = e->stats->quest_loot_id;
-			addLoot(istack, e->stats->pos);
+			istack.item = e->stats.quest_loot_id;
+			addLoot(istack, e->stats.pos);
 		}
 		else { // random loot
 			//determine position
 			Point pos = hero->pos;
-			if (map->collider.is_valid_position(e->stats->pos.x, e->stats->pos.y, MOVEMENT_NORMAL))
-				pos = e->stats->pos;
+			if (map->collider.is_valid_position(e->stats.pos.x, e->stats.pos.y, MOVEMENT_NORMAL))
+				pos = e->stats.pos;
 
 			determineLootByEnemy(e, pos);
 		}
@@ -258,19 +258,19 @@ void LootManager::determineLootByEnemy(const Enemy *e, Point pos) {
 
 	int chance = rand() % 100;
 
-	for (unsigned i=0; i<e->stats->loot.size(); i++) {
+	for (unsigned i=0; i<e->stats.loot.size(); i++) {
 		if (possible_ids.empty()) {
 			// find the rarest loot less than the chance roll
-			if (chance < (e->stats->loot[i].chance * (hero->effects.bonus_item_find + 100)) / 100) {
-				possible_ids.push_back(e->stats->loot[i].id);
-				common_chance = e->stats->loot[i].chance;
+			if (chance < (e->stats.loot[i].chance * (hero->effects.bonus_item_find + 100)) / 100) {
+				possible_ids.push_back(e->stats.loot[i].id);
+				common_chance = e->stats.loot[i].chance;
 				i=-1; // start searching from the beginning
 				continue;
 			}
 		} else {
 			// include loot with identical chances
-			if (e->stats->loot[i].chance == common_chance)
-				possible_ids.push_back(e->stats->loot[i].id);
+			if (e->stats.loot[i].chance == common_chance)
+				possible_ids.push_back(e->stats.loot[i].id);
 		}
 	}
 
@@ -282,7 +282,7 @@ void LootManager::determineLootByEnemy(const Enemy *e, Point pos) {
 
 		// an item id of 0 means we should drop currency instead
 		if (new_loot.item == 0) {
-			int level = e->stats->level;
+			int level = e->stats.level;
 			if (level == 0) level = 1; // avoid div/0 if enemy level is not specified
 
 			// TODO: move gold drop amounts to engine/loot.txt

--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -1269,7 +1269,7 @@ bool MapRenderer::executeEvent(Map_Event &ev) {
 			int power_index = ec->x;
 
 			// TODO: delete this without breaking hazards, takeHit, etc.
-			StatBlock *dummy = new EnemyStatBlock();
+			StatBlock *dummy = new StatBlock();
 			dummy->accuracy = 1000; //always hits its target
 
 			// if a power path was specified, place the source position there

--- a/src/MenuActionBar.cpp
+++ b/src/MenuActionBar.cpp
@@ -40,7 +40,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 using namespace std;
 
 
-MenuActionBar::MenuActionBar(PowerManager *_powers, AvatarStatBlock *_hero, SDL_Surface *_icons) {
+MenuActionBar::MenuActionBar(PowerManager *_powers, StatBlock *_hero, SDL_Surface *_icons) {
 	powers = _powers;
 	hero = _hero;
 	icons = _icons;
@@ -204,9 +204,9 @@ void MenuActionBar::clear() {
 		locked[i] = false;
 	}
 
-	// clear menu notifications
-	for (int i=0; i<4; i++)
-		requires_attention[i] = false;
+    // clear menu notifications
+    for (int i=0; i<4; i++)
+        requires_attention[i] = false;
 
 }
 
@@ -269,10 +269,10 @@ void MenuActionBar::renderIcon(int icon_id, int x, int y) {
 void MenuActionBar::renderAttention(int menu_id) {
 	SDL_Rect dest;
 
-	// x-value is 12 hotkeys and 4 empty slots over
+    // x-value is 12 hotkeys and 4 empty slots over
 	dest.x = window_area.x + (menu_id * ICON_SIZE) + ICON_SIZE*15;
 	dest.y = window_area.y+3;
-	dest.w = dest.h = ICON_SIZE;
+    dest.w = dest.h = ICON_SIZE;
 	SDL_BlitSurface(attention, NULL, screen, &dest);
 }
 
@@ -327,10 +327,10 @@ void MenuActionBar::render() {
 	renderCooldowns();
 	renderItemCounts();
 
-	// render log attention notifications
-	for (int i=0; i<4; i++)
-		if (requires_attention[i])
-			renderAttention(i);
+    // render log attention notifications
+    for (int i=0; i<4; i++)
+        if (requires_attention[i])
+            renderAttention(i);
 
 	// draw hotkey labels
 	for (int i=0; i<16;i++) {

--- a/src/MenuActionBar.h
+++ b/src/MenuActionBar.h
@@ -34,7 +34,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "WidgetLabel.h"
 
 class PowerManager;
-class AvatarStatBlock;
+class StatBlock;
 class TooltipData;
 class WidgetLabel;
 
@@ -52,9 +52,9 @@ private:
 	SDL_Surface *emptyslot;
 	SDL_Surface *icons;
 	SDL_Surface *disabled;
-	SDL_Surface *attention;
+    SDL_Surface *attention;
 
-	AvatarStatBlock *hero;
+	StatBlock *hero;
 	PowerManager *powers;
 	SDL_Rect src;
 
@@ -63,7 +63,7 @@ private:
 
 public:
 
-	MenuActionBar(PowerManager *_powers, AvatarStatBlock *hero, SDL_Surface *icons);
+	MenuActionBar(PowerManager *_powers, StatBlock *hero, SDL_Surface *icons);
 	~MenuActionBar();
 	void loadGraphics();
 	void renderIcon(int icon_id, int x, int y);
@@ -89,7 +89,7 @@ public:
 	SDL_Rect menus[4]; // the location of the menu buttons
 	int slot_item_count[12]; // -1 means this power isn't item based.  0 means out of items.  1+ means sufficient items.
 	bool slot_enabled[12];
-	bool requires_attention[4];
+    bool requires_attention[4];
 
 	// these store the area occupied by these hotslot sections.
 	// useful for detecting mouse interactions on those locations

--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -34,7 +34,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 using namespace std;
 
 
-MenuCharacter::MenuCharacter(AvatarStatBlock *_stats) {
+MenuCharacter::MenuCharacter(StatBlock *_stats) {
 	stats = _stats;
 
 	skill_points = 0;

--- a/src/MenuCharacter.h
+++ b/src/MenuCharacter.h
@@ -34,7 +34,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include <string>
 #include <sstream>
 
-class AvatarStatBlock;
+class StatBlock;
 class WidgetButton;
 class WidgetLabel;
 class WidgetListBox;
@@ -66,7 +66,7 @@ public:
 
 class MenuCharacter : public Menu {
 private:
-	AvatarStatBlock *stats;
+	StatBlock *stats;
 
 	WidgetButton *closeButton;
 	WidgetButton *upgradeButton[4];
@@ -98,7 +98,7 @@ private:
 
 
 public:
-	MenuCharacter(AvatarStatBlock *stats);
+	MenuCharacter(StatBlock *stats);
 	~MenuCharacter();
 	void update();
 	void logic();

--- a/src/MenuEnemy.cpp
+++ b/src/MenuEnemy.cpp
@@ -102,7 +102,7 @@ void MenuEnemy::logic() {
 
 void MenuEnemy::render() {
 	if (enemy == NULL) return;
-	if (enemy->stats->corpse && enemy->stats->corpse_ticks == 0) return;
+	if (enemy->stats.corpse && enemy->stats.corpse_ticks == 0) return;
 
 	SDL_Rect src;
 	SDL_Rect dest;
@@ -116,10 +116,10 @@ void MenuEnemy::render() {
 
 	SDL_BlitSurface(background, NULL, screen, &dest);
 
-	if (enemy->stats->maxhp == 0)
+	if (enemy->stats.maxhp == 0)
 		hp_bar_length = 0;
 	else
-		hp_bar_length = (enemy->stats->hp * 100) / enemy->stats->maxhp;
+		hp_bar_length = (enemy->stats.hp * 100) / enemy->stats.maxhp;
 
 	// draw hp bar
 
@@ -132,8 +132,8 @@ void MenuEnemy::render() {
 
 	stringstream ss;
 	ss.str("");
-	if (enemy->stats->hp > 0)
-		ss << enemy->stats->hp << "/" << enemy->stats->maxhp;
+	if (enemy->stats.hp > 0)
+		ss << enemy->stats.hp << "/" << enemy->stats.maxhp;
 	else
 		ss << msg->get("Dead");
 
@@ -141,9 +141,9 @@ void MenuEnemy::render() {
 		WidgetLabel label;
 
 		if (custom_text_pos) {
-			label.set(window_area.x+text_pos.x, window_area.y+text_pos.y, text_pos.justify, text_pos.valign, msg->get("%s level %d", enemy->stats->level, enemy->stats->name), color_normal, text_pos.font_style);
+			label.set(window_area.x+text_pos.x, window_area.y+text_pos.y, text_pos.justify, text_pos.valign, msg->get("%s level %d", enemy->stats.level, enemy->stats.name), color_normal, text_pos.font_style);
 		} else {
-			label.set(window_area.x+bar_pos.x+bar_pos.w/2, window_area.y+bar_pos.y, JUSTIFY_CENTER, VALIGN_BOTTOM, msg->get("%s level %d", enemy->stats->level, enemy->stats->name), color_normal);
+			label.set(window_area.x+bar_pos.x+bar_pos.w/2, window_area.y+bar_pos.y, JUSTIFY_CENTER, VALIGN_BOTTOM, msg->get("%s level %d", enemy->stats.level, enemy->stats.name), color_normal);
 		}
 		label.render();
 

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -38,7 +38,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 using namespace std;
 
 
-MenuInventory::MenuInventory(ItemManager *_items, AvatarStatBlock *_stats, PowerManager *_powers) {
+MenuInventory::MenuInventory(ItemManager *_items, StatBlock *_stats, PowerManager *_powers) {
 	items = _items;
 	stats = _stats;
 	powers = _powers;

--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -36,7 +36,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 class InputState;
 class ItemManager;
 class PowerManager;
-class AvatarStatBlock;
+class StatBlock;
 class WidgetButton;
 
 const int EQUIPMENT = 0;
@@ -45,7 +45,7 @@ const int CARRIED = 1;
 class MenuInventory : public Menu {
 private:
 	ItemManager *items;
-	AvatarStatBlock *stats;
+	StatBlock *stats;
 	PowerManager *powers;
 
 	void loadGraphics();
@@ -69,7 +69,7 @@ private:
 	SDL_Color color_high;
 
 public:
-	MenuInventory(ItemManager *items, AvatarStatBlock *stats, PowerManager *powers);
+	MenuInventory(ItemManager *items, StatBlock *stats, PowerManager *powers);
 	~MenuInventory();
 	void update();
 	void logic();

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -45,7 +45,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "PowerManager.h"
 #include "SharedResources.h"
 
-MenuManager::MenuManager(PowerManager *_powers, AvatarStatBlock *_stats, CampaignManager *_camp, ItemManager *_items)
+MenuManager::MenuManager(PowerManager *_powers, StatBlock *_stats, CampaignManager *_camp, ItemManager *_items)
 	: icons(NULL)
 	, powers(_powers)
 	, stats(_stats)
@@ -165,7 +165,7 @@ MenuManager::MenuManager(PowerManager *_powers, AvatarStatBlock *_stats, Campaig
 				int y = eatFirstInt(infile.val, ',');
 				int w = eatFirstInt(infile.val, ',');
 				int h = eatFirstInt(infile.val, ',');
-
+				
 				menus[menu_index]->window_area.x = x;
 				menus[menu_index]->window_area.y = y;
 				menus[menu_index]->window_area.w = w;
@@ -178,7 +178,7 @@ MenuManager::MenuManager(PowerManager *_powers, AvatarStatBlock *_stats, Campaig
 			} else if (infile.key == "soundfx_close") {
 				menus[menu_index]->sfx_close = snd->load(infile.val, "MenuManager close tab");
 			}
-
+			
 		}
 
 		infile.close();

--- a/src/MenuManager.h
+++ b/src/MenuManager.h
@@ -51,7 +51,7 @@ class MenuStash;
 class CampaignManager;
 class ItemManager;
 class PowerManager;
-class AvatarStatBlock;
+class StatBlock;
 
 const int DRAG_SRC_POWERS = 1;
 const int DRAG_SRC_INVENTORY = 2;
@@ -65,7 +65,7 @@ private:
 	SDL_Surface *icons;
 
 	PowerManager *powers;
-	AvatarStatBlock *stats;
+	StatBlock *stats;
 	CampaignManager *camp;
 
 	TooltipData tip_buf;
@@ -81,7 +81,7 @@ private:
 	bool done;
 
 public:
-	MenuManager(PowerManager *powers, AvatarStatBlock *stats, CampaignManager *camp, ItemManager *items);
+	MenuManager(PowerManager *powers, StatBlock *stats, CampaignManager *camp, ItemManager *items);
 	MenuManager(const MenuManager &copy); // not implemented
 	~MenuManager();
 	void logic();

--- a/src/MenuPowers.cpp
+++ b/src/MenuPowers.cpp
@@ -288,10 +288,10 @@ bool MenuPowers::requirementsMet(int power_index) {
 	if (find(stats->powers_list.begin(), stats->powers_list.end(), power_index) != stats->powers_list.end()) return true;
 
 	// Check the rest requirements
-	if ((stats->physoff() >= power_cell[id].requires_physoff) &&
-		(stats->physdef() >= power_cell[id].requires_physdef) &&
-		(stats->mentoff() >= power_cell[id].requires_mentoff) &&
-		(stats->mentdef() >= power_cell[id].requires_mentdef) &&
+	if ((stats->physoff >= power_cell[id].requires_physoff) &&
+		(stats->physdef >= power_cell[id].requires_physdef) &&
+		(stats->mentoff >= power_cell[id].requires_mentoff) &&
+		(stats->mentdef >= power_cell[id].requires_mentdef) &&
 		(stats->get_defense() >= power_cell[id].requires_defense) &&
 		(stats->get_offense() >= power_cell[id].requires_offense) &&
 		(stats->get_physical() >= power_cell[id].requires_physical) &&
@@ -321,10 +321,10 @@ bool MenuPowers::powerUnlockable(int power_index) {
 	if (requirementsMet(power_index)) return false;
 
 	// Check requirements
-	if ((stats->physoff() >= power_cell[id].requires_physoff) &&
-		(stats->physdef() >= power_cell[id].requires_physdef) &&
-		(stats->mentoff() >= power_cell[id].requires_mentoff) &&
-		(stats->mentdef() >= power_cell[id].requires_mentdef) &&
+	if ((stats->physoff >= power_cell[id].requires_physoff) &&
+		(stats->physdef >= power_cell[id].requires_physdef) &&
+		(stats->mentoff >= power_cell[id].requires_mentoff) &&
+		(stats->mentdef >= power_cell[id].requires_mentdef) &&
 		(stats->get_defense() >= power_cell[id].requires_defense) &&
 		(stats->get_offense() >= power_cell[id].requires_offense) &&
 		(stats->get_physical() >= power_cell[id].requires_physical) &&
@@ -507,24 +507,24 @@ TooltipData MenuPowers::checkTooltip(Point mouse) {
 
 
 				// add requirement
-				if ((power_cell[i].requires_physoff > 0) && (stats->physoff() < power_cell[i].requires_physoff)) {
+				if ((power_cell[i].requires_physoff > 0) && (stats->physoff < power_cell[i].requires_physoff)) {
 					tip.addText(msg->get("Requires Physical Offense %d", power_cell[i].requires_physoff), color_penalty);
-				} else if((power_cell[i].requires_physoff > 0) && (stats->physoff() >= power_cell[i].requires_physoff)) {
+				} else if((power_cell[i].requires_physoff > 0) && (stats->physoff >= power_cell[i].requires_physoff)) {
 					tip.addText(msg->get("Requires Physical Offense %d", power_cell[i].requires_physoff));
 				}
-				if ((power_cell[i].requires_physdef > 0) && (stats->physdef() < power_cell[i].requires_physdef)) {
+				if ((power_cell[i].requires_physdef > 0) && (stats->physdef < power_cell[i].requires_physdef)) {
 					tip.addText(msg->get("Requires Physical Defense %d", power_cell[i].requires_physdef), color_penalty);
-				} else if ((power_cell[i].requires_physdef > 0) && (stats->physdef() >= power_cell[i].requires_physdef)) {
+				} else if ((power_cell[i].requires_physdef > 0) && (stats->physdef >= power_cell[i].requires_physdef)) {
 					tip.addText(msg->get("Requires Physical Defense %d", power_cell[i].requires_physdef));
 				}
-				if ((power_cell[i].requires_mentoff > 0) && (stats->mentoff() < power_cell[i].requires_mentoff)) {
+				if ((power_cell[i].requires_mentoff > 0) && (stats->mentoff < power_cell[i].requires_mentoff)) {
 					tip.addText(msg->get("Requires Mental Offense %d", power_cell[i].requires_mentoff), color_penalty);
-				} else if ((power_cell[i].requires_mentoff > 0) && (stats->mentoff() >= power_cell[i].requires_mentoff)) {
+				} else if ((power_cell[i].requires_mentoff > 0) && (stats->mentoff >= power_cell[i].requires_mentoff)) {
 					tip.addText(msg->get("Requires Mental Offense %d", power_cell[i].requires_mentoff));
 				}
-				if ((power_cell[i].requires_mentdef > 0) && (stats->mentdef() < power_cell[i].requires_mentdef)) {
+				if ((power_cell[i].requires_mentdef > 0) && (stats->mentdef < power_cell[i].requires_mentdef)) {
 					tip.addText(msg->get("Requires Mental Defense %d", power_cell[i].requires_mentdef), color_penalty);
-				} else if ((power_cell[i].requires_mentdef > 0) && (stats->mentdef() >= power_cell[i].requires_mentdef)) {
+				} else if ((power_cell[i].requires_mentdef > 0) && (stats->mentdef >= power_cell[i].requires_mentdef)) {
 					tip.addText(msg->get("Requires Mental Defense %d", power_cell[i].requires_mentdef));
 				}
 				if ((power_cell[i].requires_offense > 0) && (stats->get_offense() < power_cell[i].requires_offense)) {
@@ -626,10 +626,10 @@ bool MenuPowers::meetsUsageStats(unsigned powerid) {
 	// If we didn't find power in power_menu, than it has no stats requirements
 	if (id == -1) return true;
 
-	return stats->physoff() >= power_cell[id].requires_physoff
-		&& stats->physdef() >= power_cell[id].requires_physdef
-		&& stats->mentoff() >= power_cell[id].requires_mentoff
-		&& stats->mentdef() >= power_cell[id].requires_mentdef
+	return stats->physoff >= power_cell[id].requires_physoff
+		&& stats->physdef >= power_cell[id].requires_physdef
+		&& stats->mentoff >= power_cell[id].requires_mentoff
+		&& stats->mentdef >= power_cell[id].requires_mentdef
 		&& stats->get_defense() >= power_cell[id].requires_defense
 		&& stats->get_offense() >= power_cell[id].requires_offense
 		&& stats->get_mental() >= power_cell[id].requires_mental

--- a/src/NPC.cpp
+++ b/src/NPC.cpp
@@ -43,7 +43,7 @@ std::vector<SoundManager::SoundID> vox_quests;
 std::vector<std::vector<Event_Component> > dialog;
 
 NPC::NPC(MapRenderer *_map, ItemManager *_items)
-	: Entity(_map, new NPCStatBlock())
+	: Entity(_map)
 	, items(_items)
 	, name("")
 	, gfx("")
@@ -204,6 +204,7 @@ void NPC::loadGraphics(const string& filename_portrait) {
 int NPC::loadSound(const string& fname, int type) {
 
 	SoundManager::SoundID a = snd->load("soundfx/npcs/" + fname, "NPC voice");
+
 	if (!a)
 		return -1;
 

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -70,25 +70,25 @@ void GameStatePlay::saveGame() {
 	if (outfile.is_open()) {
 
 		// hero name
-		outfile << "name=" << pc->stats->name << "\n";
+		outfile << "name=" << pc->stats.name << "\n";
 
 		// permadeath
-		outfile << "permadeath=" << pc->stats->permadeath << "\n";
+		outfile << "permadeath=" << pc->stats.permadeath << "\n";
 
 		// hero visual option
-		outfile << "option=" << pc->stats->base << "," << pc->stats->head << "," << pc->stats->portrait << "\n";
+		outfile << "option=" << pc->stats.base << "," << pc->stats.head << "," << pc->stats.portrait << "\n";
 
 		// hero class
-		outfile << "class=" << pc->stats->character_class << "\n";
+		outfile << "class=" << pc->stats.character_class << "\n";
 
 		// current experience
-		outfile << "xp=" << pc->stats->xp << "\n";
+		outfile << "xp=" << pc->stats.xp << "\n";
 
 		// hp and mp
-		if (SAVE_HPMP) outfile << "hpmp=" << pc->stats->hp << "," << pc->stats->mp << "\n";
+		if (SAVE_HPMP) outfile << "hpmp=" << pc->stats.hp << "," << pc->stats.mp << "\n";
 
 		// stat spec
-		outfile << "build=" << pc->stats->physical_character << "," << pc->stats->mental_character << "," << pc->stats->offense_character << "," << pc->stats->defense_character << "\n";
+		outfile << "build=" << pc->stats.physical_character << "," << pc->stats.mental_character << "," << pc->stats.offense_character << "," << pc->stats.defense_character << "\n";
 
 		// current currency
 		outfile << "currency=" << menu->inv->currency << "\n";
@@ -107,32 +107,32 @@ void GameStatePlay::saveGame() {
 		// action bar
 		outfile << "actionbar=";
 		for (int i=0; i<12; i++) {
-			if (pc->stats->transformed) outfile << menu->act->actionbar[i];
+			if (pc->stats.transformed) outfile << menu->act->actionbar[i];
 			else outfile << menu->act->hotkeys[i];
 			if (i<11) outfile << ",";
 		}
 		outfile << "\n";
 
 		//shapeshifter value
-		if (pc->stats->transform_type == "untransform" || pc->stats->transform_duration != -1) outfile << "transformed=" << "\n";
-		else outfile << "transformed=" << pc->stats->transform_type << "," << pc->stats->manual_untransform << "\n";
+		if (pc->stats.transform_type == "untransform" || pc->stats.transform_duration != -1) outfile << "transformed=" << "\n";
+		else outfile << "transformed=" << pc->stats.transform_type << "," << pc->stats.manual_untransform << "\n";
 
 		// restore hero powers
-		if (pc->stats->transformed && pc->hero_stats) {
-			pc->stats->powers_list = pc->hero_stats->powers_list;
+		if (pc->stats.transformed && pc->hero_stats) {
+			pc->stats.powers_list = pc->hero_stats->powers_list;
 		}
 
 		// enabled powers
 		outfile << "powers=";
-		for (unsigned int i=0; i<pc->stats->powers_list.size(); i++) {
-			if (i == 0) outfile << pc->stats->powers_list[i];
-			else outfile << "," << pc->stats->powers_list[i];
+		for (unsigned int i=0; i<pc->stats.powers_list.size(); i++) {
+			if (i == 0) outfile << pc->stats.powers_list[i];
+			else outfile << "," << pc->stats.powers_list[i];
 		}
 		outfile << "\n";
 
 		// restore transformed powers
-		if (pc->stats->transformed && pc->charmed_stats) {
-			pc->stats->powers_list = pc->charmed_stats->powers_list;
+		if (pc->stats.transformed && pc->charmed_stats) {
+			pc->stats.powers_list = pc->charmed_stats->powers_list;
 		}
 
 		// campaign data
@@ -193,26 +193,26 @@ void GameStatePlay::loadGame() {
 
 	if (infile.open(ss.str())) {
 		while (infile.next()) {
-			if (infile.key == "name") pc->stats->name = infile.val;
+			if (infile.key == "name") pc->stats.name = infile.val;
 			else if (infile.key == "permadeath") {
 				if (toInt(infile.val) == 1)
-					pc->stats->permadeath = true;
+					pc->stats.permadeath = true;
 				else
-					pc->stats->permadeath = false;
+					pc->stats.permadeath = false;
 			}
 			else if (infile.key == "option") {
-				pc->stats->base = infile.nextValue();
-				pc->stats->head = infile.nextValue();
-				pc->stats->portrait = infile.nextValue();
+				pc->stats.base = infile.nextValue();
+				pc->stats.head = infile.nextValue();
+				pc->stats.portrait = infile.nextValue();
 			}
 			else if (infile.key == "class") {
-				pc->stats->character_class = infile.nextValue();
+				pc->stats.character_class = infile.nextValue();
 			}
 			else if (infile.key == "xp") {
-				pc->stats->xp = toInt(infile.val);
-				if (pc->stats->xp < 0) {
+				pc->stats.xp = toInt(infile.val);
+				if (pc->stats.xp < 0) {
 					fprintf(stderr, "XP value is out of bounds, setting to zero\n");
-					pc->stats->xp = 0;
+					pc->stats.xp = 0;
 				}
 			}
 			else if (infile.key == "hpmp") {
@@ -220,20 +220,20 @@ void GameStatePlay::loadGame() {
 				saved_mp = toInt(infile.nextValue());
 			}
 			else if (infile.key == "build") {
-				pc->stats->physical_character = toInt(infile.nextValue());
-				pc->stats->mental_character = toInt(infile.nextValue());
-				pc->stats->offense_character = toInt(infile.nextValue());
-				pc->stats->defense_character = toInt(infile.nextValue());
-				if (pc->stats->physical_character < 0 || pc->stats->physical_character > pc->stats->max_points_per_stat ||
-					pc->stats->mental_character < 0 || pc->stats->mental_character > pc->stats->max_points_per_stat ||
-					pc->stats->offense_character < 0 || pc->stats->offense_character > pc->stats->max_points_per_stat ||
-					pc->stats->defense_character < 0 || pc->stats->defense_character > pc->stats->max_points_per_stat) {
+				pc->stats.physical_character = toInt(infile.nextValue());
+				pc->stats.mental_character = toInt(infile.nextValue());
+				pc->stats.offense_character = toInt(infile.nextValue());
+				pc->stats.defense_character = toInt(infile.nextValue());
+				if (pc->stats.physical_character < 0 || pc->stats.physical_character > pc->stats.max_points_per_stat ||
+					pc->stats.mental_character < 0 || pc->stats.mental_character > pc->stats.max_points_per_stat ||
+					pc->stats.offense_character < 0 || pc->stats.offense_character > pc->stats.max_points_per_stat ||
+					pc->stats.defense_character < 0 || pc->stats.defense_character > pc->stats.max_points_per_stat) {
 
 					fprintf(stderr, "Some basic stats are out of bounds, setting to zero\n");
-					pc->stats->physical_character = 0;
-					pc->stats->mental_character = 0;
-					pc->stats->offense_character = 0;
-					pc->stats->defense_character = 0;
+					pc->stats.physical_character = 0;
+					pc->stats.mental_character = 0;
+					pc->stats.offense_character = 0;
+					pc->stats.defense_character = 0;
 				}
 			}
 			else if (infile.key == "currency") {
@@ -294,16 +294,16 @@ void GameStatePlay::loadGame() {
 				menu->act->set(hotkeys);
 			}
 			else if (infile.key == "transformed") {
-				pc->stats->transform_type = infile.nextValue();
-				if (pc->stats->transform_type != "") {
-					pc->stats->transform_duration = -1;
-					pc->stats->manual_untransform = toInt(infile.nextValue());
+				pc->stats.transform_type = infile.nextValue();
+				if (pc->stats.transform_type != "") {
+					pc->stats.transform_duration = -1;
+					pc->stats.manual_untransform = toInt(infile.nextValue());
 				}
 			}
 			else if (infile.key == "powers") {
 				string power;
 				while ( (power = infile.nextValue()) != "") {
-					pc->stats->powers_list.push_back(toInt(power));
+					pc->stats.powers_list.push_back(toInt(power));
 				}
 			}
 			else if (infile.key == "campaign") camp->setAll(infile.val);
@@ -319,37 +319,37 @@ void GameStatePlay::loadGame() {
 	loadStash();
 
 	// initialize vars
-	pc->statBlock()->recalc();
+	pc->stats.recalc();
 	menu->inv->applyEquipment(menu->inv->inventory[EQUIPMENT].storage);
 	// trigger passive effects here? Saved HP/MP values might depend on passively boosted HP/MP
 	// powers->activatePassives(pc->stats);
-	pc->stats->logic(); // run stat logic once to apply items bonuses
+	pc->stats.logic(); // run stat logic once to apply items bonuses
 	if (SAVE_HPMP) {
-		if (saved_hp < 0 || saved_hp > pc->stats->maxhp) {
+		if (saved_hp < 0 || saved_hp > pc->stats.maxhp) {
 			fprintf(stderr, "HP value is out of bounds, setting to maximum\n");
-			pc->stats->hp = pc->stats->maxhp;
+			pc->stats.hp = pc->stats.maxhp;
 		}
-		else pc->stats->hp = saved_hp;
+		else pc->stats.hp = saved_hp;
 
-		if (saved_mp < 0 || saved_mp > pc->stats->maxmp) {
+		if (saved_mp < 0 || saved_mp > pc->stats.maxmp) {
 			fprintf(stderr, "MP value is out of bounds, setting to maximum\n");
-			pc->stats->mp = pc->stats->maxmp;
+			pc->stats.mp = pc->stats.maxmp;
 		}
-		else pc->stats->mp = saved_mp;
+		else pc->stats.mp = saved_mp;
 	}
 	else {
-		pc->stats->hp = pc->stats->maxhp;
-		pc->stats->mp = pc->stats->maxmp;
+		pc->stats.hp = pc->stats.maxhp;
+		pc->stats.mp = pc->stats.maxmp;
 	}
 
 	// reset character menu
 	menu->chr->refreshStats();
 
 	// just for aesthetics, turn the hero to face the camera
-	pc->stats->direction = 6;
+	pc->stats.direction = 6;
 
 	// set up MenuTalker for this hero
-	menu->talker->setHero(pc->stats->name, pc->stats->portrait);
+	menu->talker->setHero(pc->stats.name, pc->stats.portrait);
 
 	// load sounds (gender specific)
 	pc->loadSounds();
@@ -362,15 +362,15 @@ void GameStatePlay::loadClass(int index) {
 	// game slots are currently 1-4
 	if (game_slot == 0) return;
 
-	pc->stats->character_class = HERO_CLASSES[index].name;
-	pc->stats->physical_character += HERO_CLASSES[index].physical;
-	pc->stats->mental_character += HERO_CLASSES[index].mental;
-	pc->stats->offense_character += HERO_CLASSES[index].offense;
-	pc->stats->defense_character += HERO_CLASSES[index].defense;
+	pc->stats.character_class = HERO_CLASSES[index].name;
+	pc->stats.physical_character += HERO_CLASSES[index].physical;
+	pc->stats.mental_character += HERO_CLASSES[index].mental;
+	pc->stats.offense_character += HERO_CLASSES[index].offense;
+	pc->stats.defense_character += HERO_CLASSES[index].defense;
 	menu->inv->currency += HERO_CLASSES[index].currency;
 	menu->inv->inventory[EQUIPMENT].setItems(HERO_CLASSES[index].equipment);
 	for (unsigned i=0; i<HERO_CLASSES[index].powers.size(); i++) {
-		pc->stats->powers_list.push_back(HERO_CLASSES[index].powers[i]);
+		pc->stats.powers_list.push_back(HERO_CLASSES[index].powers[i]);
 	}
 	for (unsigned i=0; i<HERO_CLASSES[index].statuses.size(); i++) {
 		camp->setStatus(HERO_CLASSES[index].statuses[i]);
@@ -380,7 +380,7 @@ void GameStatePlay::loadClass(int index) {
 	menu->inv->inventory[EQUIPMENT].fillEquipmentSlots();
 
 	// initialize vars
-	pc->statBlock()->recalc();
+	pc->stats.recalc();
 	menu->inv->applyEquipment(menu->inv->inventory[EQUIPMENT].storage);
 
 	// reset character menu

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -36,7 +36,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 using namespace std;
 
 StatBlock::StatBlock()
-	: alive(true)
+	: statsLoaded(false)
+	, alive(true)
 	, corpse(false)
 	, corpse_ticks(0)
 	, hero(false)
@@ -69,6 +70,12 @@ StatBlock::StatBlock()
 	, bonus_per_mental(0)
 	, bonus_per_offense(0)
 	, bonus_per_defense(0)
+	, physoff(0)
+	, physdef(0)
+	, mentoff(0)
+	, mentdef(0)
+	, physment(0)
+	, offdef(0)
 	, character_class("")
 	, hp(0)
 	, maxhp(0)
@@ -111,6 +118,7 @@ StatBlock::StatBlock()
 	, pos(Point())
 	, forced_speed(Point())
 	, direction(0)
+	, hero_cooldown(vector<int>(POWER_COUNT, 0)) // hero only
 	, poise(0)
 	, poise_base(0)
 	, cur_state(0)
@@ -375,7 +383,7 @@ void StatBlock::takeDamage(int dmg) {
  * Refill HP/MP
  * Creatures might skip these formulas.
  */
-void AvatarStatBlock::recalc() {
+void StatBlock::recalc() {
 
 	if (!statsLoaded) loadHeroStats();
 
@@ -411,6 +419,14 @@ void StatBlock::recalc_alt() {
 		int ment0 = get_mental() -1;
 		int off0 = get_offense() -1;
 		int def0 = get_defense() -1;
+
+		// calculate compound primary stats
+		physoff = get_physical() + get_offense();
+		physdef = get_physical() + get_defense();
+		mentoff = get_mental() + get_offense();
+		mentdef = get_mental() + get_defense();
+		physment = get_physical() + get_mental();
+		offdef = get_offense() + get_defense();
 
 		// calculate other stats
 		maxhp = hp_base + (hp_per_level * lev0) + (hp_per_physical * phys0) + effects.bonus_hp + (effects.bonus_hp_percent * (hp_base + (hp_per_level * lev0) + (hp_per_physical * phys0)) / 100);
@@ -528,7 +544,7 @@ bool StatBlock::canUsePower(const Power &power, unsigned powerid) const {
 
 }
 
-void AvatarStatBlock::loadHeroStats() {
+void StatBlock::loadHeroStats() {
 	// Redefine numbers from config file if present
 	FileParser infile;
 	if (!infile.open(mods->locate("engine/stats.txt"))) {
@@ -633,11 +649,3 @@ void AvatarStatBlock::loadHeroStats() {
 	infile.close();
 }
 
-AvatarStatBlock::AvatarStatBlock()
-	: StatBlock()
-	, statsLoaded(false)
-	, hero_cooldown(vector<int>(POWER_COUNT, 0)) // hero only
-{}
-
-AvatarStatBlock::~AvatarStatBlock()
-{}

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -81,16 +81,17 @@ public:
 };
 
 class StatBlock {
+private:
+	void loadHeroStats();
+	bool statsLoaded;
 
 public:
 	StatBlock();
-	virtual ~StatBlock();
-
-	virtual StatBlock *clone() = 0;
+	~StatBlock();
 
 	void load(const std::string& filename);
 	void takeDamage(int dmg);
-
+	void recalc();
 	void recalc_alt();
 	void logic();
 
@@ -144,12 +145,12 @@ public:
 	int get_mental()   const { return mental_character + mental_additional; }
 
 	// derived stats ("disciplines")
-	int physoff() { return get_physical() + get_offense(); }
-	int physdef() { return get_physical() + get_defense(); }
-	int mentoff() { return get_mental() + get_offense(); }
-	int mentdef() { return get_mental() + get_defense(); }
-	int physment() { return get_physical() + get_mental(); }
-	int offdef() { return get_offense() + get_defense(); }
+	int physoff;
+	int physdef;
+	int mentoff;
+	int mentdef;
+	int physment;
+	int offdef;
 
 	// in Flare there are no distinct character classes.
 	// instead each class is given a descriptor based on their base stat builds
@@ -217,7 +218,7 @@ public:
 	Point pos;
 	Point forced_speed;
 	char direction;
-
+	std::vector<int> hero_cooldown;
 
 	int poise;
 	int poise_base;
@@ -323,29 +324,6 @@ public:
 	int avoidance_per_defense;
 	int crit_base;
 	int crit_per_level;
-};
-
-class AvatarStatBlock : public StatBlock {
-private:
-	void loadHeroStats();
-	bool statsLoaded;
-
-public:
-	AvatarStatBlock();
-	~AvatarStatBlock();
-
-	std::vector<int> hero_cooldown;
-
-	void recalc();
-	StatBlock *clone() { return new AvatarStatBlock(*this); }
-};
-
-class EnemyStatBlock : public StatBlock {
-	StatBlock *clone() { return new EnemyStatBlock(*this); }
-};
-
-class NPCStatBlock : public StatBlock {
-	StatBlock *clone() { return new NPCStatBlock(*this); }
 };
 
 #endif


### PR DESCRIPTION
Yes the transformation is broken by the the StatBlock reorganisation.
While I was refactoring it, I came to the conclusion that the refactoring would be very huge.

So as of now (or before the initial statblock reorganisation) it was very easy code as Justin pointed out, as everybody could just use the StatBlock. Now that it got separated, the stats are no longer just plain there in an Entity, but are a class of their own, being operated on using a pointer.

When thinking initially about the separation of StatBlocks I did not take into account that we had transformation. At rewritign the Avatar I messed up the pointers of the stat blocks (hero_stats, charmed_stats and the stats derived from Entity),
so I'd expect I'll take a little more time to get it smooth and fully working again.

I still think it is a viable way with separated StatBlocks, but specially the Avatar class needs conscious attention at the rewrite and some time, which I probably do not have in the next days.

So this pull request is reverting all the changes applied to stat blocks, so the state is a usable state.
(We don't want to have huge changes close to a release anyway ;)

I'd like to apologize to @hean01 @dorkster and @makrohn for introducing merge conflicts.

Once I have more time to figure it out exactly, I'll rewrite the StatBlocks.

My plan as of now is this (for reference purposes):

The StatBlock is an abstract base class, so it cannot be instantiated directly, but you can only create a subclass (AvatarStatBlock, NPCStatBlock or EnemyStatBlock).

The Entity class needs to have a pointer to a StatBlock and an abstract function `statBlock()`. (The Entity class is already abstract, so it's no big deal) The deriving subclasses would need to implement the statBlock function and return the specific stat block depending on its own type, i.e. the Avatar class will return an AvatarStatBlock, the NPC class will return an NPCStatBlock when calling that function.

The problem with the transforming of the Avatar could be solved similar as it is now:
There will be 2 pointers `charmed_stats` and `hero_stats` which will carry two independent StatBlocks of different type (Avatar and Enemy). The actual `stats` pointer of the Entity class would just need to point to one of both. This yields the advantage to not have to copy over so much data as we're doing now. Now we have 3 StatBlocks (`charmed_stats` and `hero_stats` and `stats`), but operate only on `stats`. During transforming, one of the shadow copies will be taken and some of its data are copied over to the stats block.

If done right with the pointers, we would not need to copy anything, because of addressing always the right data anyway.
(hero_cooldowns, slots, etc could stick to the Avatar block all the time, but movement, speed, resistances and such would be loaded from either of both blocks depending on the transform state.)
