### PR TITLE
Ignore power id 0 when saving/loading power list

### DIFF
--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -125,8 +125,14 @@ void GameStatePlay::saveGame() {
 		// enabled powers
 		outfile << "powers=";
 		for (unsigned int i=0; i<pc->stats.powers_list.size(); i++) {
-			if (i == 0) outfile << pc->stats.powers_list[i];
-			else outfile << "," << pc->stats.powers_list[i];
+			if (i < pc->stats.powers_list.size()-1) {
+				if (pc->stats.powers_list[i] > 0)
+					outfile << pc->stats.powers_list[i] << ",";
+			}
+			else {
+				if (pc->stats.powers_list[i] > 0)
+					outfile << pc->stats.powers_list[i];
+			}
 		}
 		outfile << "\n";
 
@@ -303,7 +309,8 @@ void GameStatePlay::loadGame() {
 			else if (infile.key == "powers") {
 				string power;
 				while ( (power = infile.nextValue()) != "") {
-					pc->stats.powers_list.push_back(toInt(power));
+					if (toInt(power) > 0)
+						pc->stats.powers_list.push_back(toInt(power));
 				}
 			}
 			else if (infile.key == "campaign") camp->setAll(infile.val);

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -131,7 +131,7 @@ StatBlock::StatBlock()
 	, wander_pause_ticks(0)			// enemy only
 	, chance_pursue(0)
 	, chance_flee(0)				// read in, but unused in formulas.
-	, powers_list(vector<int>(POWERSLOT_COUNT, 0))	// hero only
+	, powers_list(vector<int>(0))	// hero only
 	, powers_list_items(vector<int>(0))	// hero only
 	, power_chance(vector<int>(POWERSLOT_COUNT, 0))		// enemy only
 	, power_index(vector<int>(POWERSLOT_COUNT, 0))		// both


### PR DESCRIPTION
A power id of 0 means no power, so there is no point in adding that id
to the powers list. Also, the size of the powers_list vector itself
should be 0. Previously, it had a initial size of POWERSLOT_COUNT (10).
This meant that the `powers=` key in save files would infinitely expand
because we kept adding 10 zeros to that list every time the player saved.
