### PR TITLE
Support for location based environmental sound effects.

### DIFF
--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -727,6 +727,7 @@ void GameStatePlay::logic() {
 		enemies->checkEnemiesforXP(camp);
 		npcs->logic();
 
+		snd->logic(pc->stats.pos);
 	}
 
 	// close menus when the player dies, but still allow them to be reopened

--- a/src/MapRenderer.h
+++ b/src/MapRenderer.h
@@ -151,11 +151,7 @@ private:
 	Point tip_pos;
 	bool show_tooltip;
 
-	// map events can play random soundfx
-	SoundManager::SoundID sfx;
-
 	bool executeEvent(Map_Event &e);
-	void playSFX(std::string filename);
 	void push_enemy_group(Map_Group g);
 	bool isActive(const Map_Event &e);
 
@@ -164,6 +160,8 @@ private:
 	// map events
 	std::vector<Map_Event> events;
 
+	// map soundids
+	std::vector<SoundManager::SoundID> sids;
 
 	typedef unsigned short maprow[256];
 

--- a/src/SoundManager.h
+++ b/src/SoundManager.h
@@ -28,6 +28,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include <SDL.h>
 #include <SDL_image.h>
 #include <SDL_mixer.h>
+#include "Utils.h"
 
 #include <map>
 #include <string>
@@ -45,8 +46,10 @@ public:
 
 	SoundManager::SoundID load(const std::string& filename, const std::string& errormessage);
 	void unload(SoundManager::SoundID);
+	void play(SoundManager::SoundID, std::string channel = GLOBAL_VIRTUAL_CHANNEL, Point pos = Point(0,0), bool loop = false);
 
-	void play(SoundManager::SoundID, std::string channel = GLOBAL_VIRTUAL_CHANNEL);
+	void logic(Point center);
+	void reset();
 
 private:
 	typedef std::map<std::string, int> VirtualChannelMap;
@@ -55,11 +58,15 @@ private:
 	typedef std::map<SoundID, class Sound *> SoundMap;
 	typedef SoundMap::iterator SoundMapIterator;
 
+	typedef std::map<int, class Playback> PlaybackMap;
+	typedef PlaybackMap::iterator PlaybackMapIterator;
+
 	static void channel_finished(int channel);
 	void on_channel_finished(int channel);
 
 	SoundMap sounds;
 	VirtualChannelMap channels;
+	PlaybackMap playback;
 };
 
 #endif


### PR DESCRIPTION
Make SoundManager support playing sound on locations, were distance
from location to pc controls the amplitude, eg. the further away the
sound is the more faint it is played out.

Made Map events on_load special for looping a sound effect at the
position of the event, this will be used for location based env.
effects like the fires we now have in warp zone and atrium.
