### PR TITLE
Unload sounds when destroying MapRenderer

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -1341,5 +1341,12 @@ MapRenderer::~MapRenderer() {
 	clearEvents();
 	clearQueues();
 	delete tip;
+
+	/* unload sounds */
+	snd->reset();
+	while (!sids.empty()) {
+		snd->unload(sids.back());
+		sids.pop_back();
+	}
 }
 


### PR DESCRIPTION
This fixes environment sounds continuing to play after exiting to the
title screen from gameplay.
