### PR TITLE
Pause all env. sound that is out of distance to go easy on

### DIFF
--- a/src/SoundManager.cpp
+++ b/src/SoundManager.cpp
@@ -84,6 +84,12 @@ void SoundManager::logic(Point c) {
 		float dy = c.y - it->second.location.y;
 		float dist = sqrt(dx*dx + dy*dy);
 
+		/* control mixing playback depending on distance */
+		if (dist < SOUND_FALLOFF)
+			Mix_Resume(it->first);
+		else
+			Mix_Pause(it->first);
+
 		/* update sound mix with new distance/location to hero */
 		dist = 255.0f * (dist / SOUND_FALLOFF);
 		d = max(0.0f, min(dist, 255.0f));


### PR DESCRIPTION
SDL mixer, this will decrease mixing of 30 events to 2-4.

A new perf report shows a decrease of 4% CPU usage of total flares CPU usage:

 63,72%  flare  libSDL-1.2.so.0.11.3        [.] 0x000000000001d47a
  5,63%  flare  libSDL-1.2.so.0.11.3        [.] SDL_FillRect
  2,44%  flare  libvorbis.so.0.4.6          [.] 0x0000000000016be1
  1,70%  flare  libvorbis.so.0.4.6          [.] vorbis_book_decodevv_add
  1,45%  flare  libpng15.so.15.10.0         [.] 0x000000000001313f
  1,36%  flare  libz.so.1.2.5               [.] 0x00000000000093c2
  1,00%  flare  libvorbis.so.0.4.6          [.] mdct_backward
  0,96%  flare  flare                       [.] _SDL_gfxBlitBlitterRGBA
  0,71%  flare  flare                       [.] Animation::getCurrentFrame(int)
  0,61%  flare  libc-2.15.so                [.] _int_free
  0,57%  flare  libSDL-1.2.so.0.11.3        [.] SDL_MixAudio
