### PR TITLE
Implement enemy-style loot tables for map events

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -395,6 +395,7 @@ int MapRenderer::load(string filename) {
 					e->x = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
 					e->y = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
 					e->z = toInt(infile.nextValue());
+					e->w = toInt(infile.nextValue());
 
 					// add repeating loot
 					string repeat_val = infile.nextValue();
@@ -406,6 +407,7 @@ int MapRenderer::load(string filename) {
 						e->x = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
 						e->y = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
 						e->z = toInt(infile.nextValue());
+						e->w = toInt(infile.nextValue());
 
 						repeat_val = infile.nextValue();
 					}
@@ -568,7 +570,7 @@ int MapRenderer::load(string filename) {
 void MapRenderer::clearQueues() {
 	enemies = queue<Map_Enemy>();
 	npcs = queue<Map_NPC>();
-	loot = queue<Event_Component>();
+	loot.clear();
 }
 
 /**
@@ -1251,7 +1253,7 @@ bool MapRenderer::executeEvent(Map_Event &ev) {
 			sids.push_back(sid);
 		}
 		else if (ec->type == "loot") {
-			loot.push(*ec);
+			loot.push_back(*ec);
 		}
 		else if (ec->type == "msg") {
 			log_msg = ec->s;

--- a/src/MapRenderer.h
+++ b/src/MapRenderer.h
@@ -263,7 +263,7 @@ public:
 	std::queue<Map_NPC> npcs;
 
 	// event-created loot or items
-	std::queue<Event_Component> loot;
+	std::vector<Event_Component> loot;
 
 	// teleport handling
 	bool teleportation;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -70,6 +70,7 @@ public:
 	int x;
 	int y;
 	int z;
+	int w;
 
 	Event_Component()
 		: type("")
@@ -77,6 +78,7 @@ public:
 		, x(0)
 		, y(0)
 		, z(0)
+		, w(0)
 	{}
 };
 


### PR DESCRIPTION
The new formatting for the loot property in map events is as follows:

```
item id # or 'currency', x, y, quantity, percentage chance
```

An item id of 0 is equal to 'currency'.

This change has the added benifit of allowing items to drop in stacks of
more than one (e.g. 5 Health Potions).
