### PR TITLE
Fix for flare-game 160

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -264,6 +264,12 @@ void setPaths() {
 		return;
 	}
 
+	// Check for the local data before trying installed ones.
+	if (dirExists("./mods")) {
+		PATH_DATA = "./";
+		return;
+	}
+
 	// check $XDG_DATA_DIRS options
 	// a list of directories in preferred order separated by :
 	if (getenv("XDG_DATA_DIRS") != NULL) {


### PR DESCRIPTION
This should be the case when no custom game data folder has been set,
and should permit to run the engine without the need to install it,
at least on linux.

fixes flare-game issue 160.
