### PR TITLE
Allow events to drop multiple pieces of "fixed" loot

### DIFF
--- a/src/LootManager.cpp
+++ b/src/LootManager.cpp
@@ -234,6 +234,27 @@ void LootManager::checkMapForLoot() {
 
 	int chance = rand() % 100;
 
+	// first drop any 'fixed' (0% chance) items
+	for (unsigned i = map->loot.size(); i > 0; i--) {
+		ec = &map->loot[i-1];
+		if (ec->w == 0) {
+			p.x = ec->x;
+			p.y = ec->y;
+
+			// an item id of 0 means we should drop currency instead
+			if (ec->s == "currency" || toInt(ec->s) == 0) {
+				addCurrency(ec->z, p);
+			} else {
+				new_loot.item = toInt(ec->s);
+				new_loot.quantity = ec->z;
+				addLoot(new_loot, p);
+			}
+
+			map->loot.erase(map->loot.begin()+i-1);
+		}
+	}
+
+	// now pick up to 1 random item to drop
 	for (unsigned i = map->loot.size(); i > 0; i--) {
 		ec = &map->loot[i-1];
 

--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -395,7 +395,9 @@ int MapRenderer::load(string filename) {
 					e->x = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
 					e->y = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
 					e->z = toInt(infile.nextValue());
-					e->w = toInt(infile.nextValue());
+					string chance = infile.nextValue();
+					if (chance == "fixed") e->w = 0;
+					else e->w = toInt(chance);
 
 					// add repeating loot
 					string repeat_val = infile.nextValue();
@@ -407,7 +409,9 @@ int MapRenderer::load(string filename) {
 						e->x = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
 						e->y = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
 						e->z = toInt(infile.nextValue());
-						e->w = toInt(infile.nextValue());
+						chance = infile.nextValue();
+						if (chance == "fixed") e->w = 0;
+						else e->w = toInt(chance);
 
 						repeat_val = infile.nextValue();
 					}


### PR DESCRIPTION
As an example, here's a loot event that will drop 10 gold all the time,
and then either Health Potion (id 1) or a Mana Potion (id 2):

```
currency,5,5,10,fixed;1,5,7,1,100;2,7,5,2,100
```

Note, 0 can be used in place of `fixed`.
