### PR TITLE
Optimize isometric rendering.

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -722,22 +722,25 @@ void MapRenderer::renderIsoLayer(SDL_Surface *wheretorender, Point offset, const
 			tiles_width -= i + 1;
 			i = -1;
 		}
-		short d = j - h;
+		const short d = j - h;
 		if (d >= 0) {
 			j -= d; tiles_width += d; i += d;
 		}
-		short j_end = std::max((j+i-w+1), std::max(j - max_tiles_width, 0));
+		const short j_end = std::max((j+i-w+1), std::max(j - max_tiles_width, 0));
 
+
+		Point p = map_to_screen(i * UNITS_PER_TILE, j * UNITS_PER_TILE, shakycam.x, shakycam.y);
+		p = center_tile(p);
 		// draw one horizontal line
 		while (j > j_end) {
-			--j; ++i;
+			--j;
+			++i;
 			++tiles_width;
+			p.x += TILE_W;
 
-			unsigned short current_tile = layerdata[i][j];
+			const unsigned short current_tile = layerdata[i][j];
 
 			if (current_tile) {
-				Point p = map_to_screen(i * UNITS_PER_TILE, j * UNITS_PER_TILE, shakycam.x, shakycam.y);
-				p = center_tile(p);
 				dest.x = p.x - tset.tiles[current_tile].offset.x + offset.x;
 				dest.y = p.y - tset.tiles[current_tile].offset.y + offset.y;
 				// no need to set w and h in dest, as it is ignored
@@ -787,22 +790,25 @@ void MapRenderer::renderIsoFrontObjects(vector<Renderable> &r) {
 			tiles_width -= i + 1;
 			i = -1;
 		}
-		short d = j - h;
+		const short d = j - h;
 		if (d >= 0) {
 			j -= d; tiles_width += d; i += d;
 		}
-		short j_end = std::max((j+i-w+1), std::max(j - max_tiles_width, 0));
+		const short j_end = std::max((j+i-w+1), std::max(j - max_tiles_width, 0));
 
 		// draw one horizontal line
+		Point p = map_to_screen(i * UNITS_PER_TILE, j * UNITS_PER_TILE, shakycam.x, shakycam.y);
+		p = center_tile(p);
 		while (j > j_end) {
-			--j; ++i;
+			--j;
+			++i;
 			++tiles_width;
+			p.x += TILE_W;
 
-			unsigned short current_tile = object[i][j];
+			const unsigned short current_tile = object[i][j];
 
 			if (current_tile) {
-				Point p = map_to_screen(i * UNITS_PER_TILE, j * UNITS_PER_TILE, shakycam.x, shakycam.y);
-				p = center_tile(p);
+
 				dest.x = p.x - tset.tiles[current_tile].offset.x;
 				dest.y = p.y - tset.tiles[current_tile].offset.y;
 				SDL_BlitSurface(tset.sprites, &(tset.tiles[current_tile].src), screen, &dest);


### PR DESCRIPTION
Closes #326.

The benchmark scenario was using flare-game with commit
51af6ab3f1feb897172398f232b2256f5cb70f58

The hero was standing at the default starting point
in the frontier outpost.

The code was compiled with
  cmake . && make
so no special care on compiler optimization (such as O3, lto)
(gcc version 4.7.2)

I run the benchmark using
  perf stat -p $(pidof flare) sleep 10

Using an Intel i7-2760 cpu:
without this patch: 0.389 CPUs utilized
with    this patch: 0.356 CPUs utilized
resulting in        0.033 CPUs less

Using an Intel Atom N270
without this patch: 0.582 CPUs utilized
with    this patch: 0.565 CPUs utilized
resulting in        0.017 CPUs less

On the Intel Atom N270 map_to_screen was using 17.14% of the time
before this patch, now it is only using 5.42% of the time.
(The time was only measured executing the flare binary itself,
libs excluded)
