### PR TITLE
Remove alot of logic from the audio subsystem callback which

### DIFF
--- a/src/SoundManager.cpp
+++ b/src/SoundManager.cpp
@@ -213,6 +213,7 @@ void SoundManager::play(SoundManager::SoundID sid, std::string channel, Point po
 	p.location = pos;
 	p.virtual_channel = channel;
 	p.loop = loop;
+	p.finished = false;
 
 	if (p.virtual_channel != GLOBAL_VIRTUAL_CHANNEL) {
 


### PR DESCRIPTION
removes the problem with audio thread modifying containers while game thread iterates over it.

Fixes issue #425
