### PR TITLE
lmb attack now obeys MAIN1 lock

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -439,7 +439,9 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 		drag_walking = false;
 		attacking = false;
 	} else {
-		attacking = true;
+        if(!inpt->lock[MAIN1]) {
+            attacking = true;
+		}
 	}
 
 	// handle animation


### PR DESCRIPTION
fixes a bug where npc menu logic wasn't being executed properly while dragging items due to it thinking we were attacking
