### PR TITLE
no need to copy an ItemStorage here

### DIFF
--- a/src/MenuVendor.cpp
+++ b/src/MenuVendor.cpp
@@ -43,7 +43,7 @@ MenuVendor::MenuVendor(ItemManager *_items, StatBlock *_stats)
 	, activetab(VENDOR_BUY)
 	, color_normal(font->getColor("menu_normal"))
 	, npc(NULL)
-	, buyback_stock(ItemStorage())
+	, buyback_stock()
 	, talker_visible(false)
 {
 	loadGraphics();


### PR DESCRIPTION
this is probably optimized out by gcc/mingw but in MSVC this crashes the program when compiled:  the temporary ItemStorage is destructed without having its init() called first
