### PR TITLE
Factor in speed effect to power cooldowns

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -548,7 +548,10 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
 				stats.cur_state = AVATAR_STANCE;
-				if (stats.effects.speed <= 100) stats.cooldown_ticks += stats.cooldown;
+				if (stats.effects.speed > 0)
+					stats.cooldown_ticks += ((100.0f / stats.effects.speed) * stats.cooldown);
+				else
+					stats.cooldown_ticks += 100 * stats.cooldown;
 			}
 			break;
 
@@ -568,7 +571,10 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
 				stats.cur_state = AVATAR_STANCE;
-				if (stats.effects.speed <= 100) stats.cooldown_ticks += stats.cooldown;
+				if (stats.effects.speed > 0)
+					stats.cooldown_ticks += ((100.0f / stats.effects.speed) * stats.cooldown);
+				else
+					stats.cooldown_ticks += 100 * stats.cooldown;
 			}
 			break;
 
@@ -586,7 +592,10 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
 				stats.cur_state = AVATAR_STANCE;
-				if (stats.effects.speed <= 100) stats.cooldown_ticks += stats.cooldown;
+				if (stats.effects.speed > 0)
+					stats.cooldown_ticks += ((100.0f / stats.effects.speed) * stats.cooldown);
+				else
+					stats.cooldown_ticks += 100 * stats.cooldown;
 			}
 			break;
 

--- a/src/BehaviorStandard.cpp
+++ b/src/BehaviorStandard.cpp
@@ -263,7 +263,10 @@ void BehaviorStandard::checkPower() {
 
 			e->powers->activate(power_id, &e->stats, pursue_pos);
 			e->stats.power_ticks[power_slot] = e->stats.power_cooldown[power_slot];
-			e->stats.cooldown_ticks = e->stats.cooldown;
+			if (e->stats.effects.speed > 0)
+				e->stats.cooldown_ticks += ((100.0f / e->stats.effects.speed) * e->stats.cooldown);
+			else
+				e->stats.cooldown_ticks += 100 * e->stats.cooldown;
 
 			if (e->stats.activated_powerslot == ON_HALF_DEAD) {
 				e->stats.on_half_dead_casted = true;


### PR DESCRIPTION
Previously, the hero ignored power cooldown when their speed was above
100%. This worked fine when our only speed effect was Haste, but not
anymore. Enemies weren't much better, as they always used the same
cooldown regardless of any speed bonuses.

This commit fixes these issues. For example, the hero's melee attack has
a cooldown of 4. If the hero has the Boots of Speed equipped (125% speed
bonus), the melee cooldown becomes `(100/125) * 4`, which rounded off is 3.
