### PR TITLE
PROPOSAL: A fix for being "stunlocked" due to multiple enemies attacking & being stuck in HIT animation. Also applies to enemies.

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -611,6 +611,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
 				stats.cur_state = AVATAR_STANCE;
+				stats.resillience = stats.resillience_base;
 			}
 
 			break;
@@ -799,8 +800,9 @@ bool Avatar::takeHit(const Hazard &h) {
 		}
 		else if (prev_hp > stats.hp) { // only interrupt if damage was taken
 			snd->play(sound_hit);
-			if (!percentChance(stats.poise)) {
+			if (!percentChance(stats.poise) && stats.resillience == stats.resillience_base) {
 				stats.cur_state = AVATAR_HIT;
+				stats.resillience--;
 			}
 		}
 

--- a/src/BehaviorStandard.cpp
+++ b/src/BehaviorStandard.cpp
@@ -456,7 +456,10 @@ void BehaviorStandard::updateState() {
 			if (e->activeAnimation->isFirstFrame()) {
 				e->stats.effects.triggered_hit = true;
 			}
-			if (e->activeAnimation->isLastFrame()) e->newState(ENEMY_STANCE);
+			if (e->activeAnimation->isLastFrame()) {
+				e->newState(ENEMY_STANCE);
+				e->stats.resillience = e->stats.resillience_base;
+			}
 			break;
 
 		case ENEMY_DEAD:

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -281,7 +281,11 @@ bool Enemy::takeHit(const Hazard &h) {
 			}
 			// don't go through a hit animation if stunned
 			else if (!stats.effects.stun && !percentChance(stats.poise)) {
-				stats.cur_state = ENEMY_HIT;
+				if(stats.resillience == stats.resillience_base){
+					stats.cur_state = ENEMY_HIT;
+					stats.resillience--;
+				}
+
 				sfx_hit = true;
 				// roll to see if the enemy's ON_HIT power is casted
 				if (percentChance(stats.power_chance[ON_HIT])) {

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -152,6 +152,8 @@ StatBlock::StatBlock()
 	, melee_weapon_power(0)
 	, mental_weapon_power(0)
 	, ranged_weapon_power(0)
+	, resillience(8)
+	, resillience_base(8)
 	, currency(0)
 	, death_penalty(false)
 	, defeat_status("")			// enemy only
@@ -278,6 +280,7 @@ void StatBlock::load(const string& filename) {
 		else if (infile.key == "absorb_min") absorb_min = num;
 		else if (infile.key == "absorb_max") absorb_max = num;
 		else if (infile.key == "poise") poise = poise_base = num;
+		else if (infile.key == "resillience_base") resillience = resillience_base = num;
 
 		// behavior stats
 		else if (infile.key == "flying") {
@@ -491,6 +494,13 @@ void StatBlock::logic() {
 		takeDamage(effects.damage);
 	}
 
+	// decrement resillience counter
+	if(resillience > 0 && resillience < resillience_base){
+		--resillience;
+	} else if(resillience == 0){
+		resillience = resillience_base;
+	}
+
 	// apply healing over time
 	if (effects.hpot > 0) {
 		comb->addMessage(msg->get("+%d HP",effects.hpot), pos, COMBAT_MESSAGE_BUFF);
@@ -619,6 +629,8 @@ void StatBlock::loadHeroStats() {
 			stat_points_per_level = value;
 		} else if (infile.key == "power_points_per_level") {
 			power_points_per_level = value;
+		} else if(infile.key == "resillience_base") {
+			resillience_base = value;
 		}
 	}
 	infile.close();

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -222,6 +222,8 @@ public:
 
 	int poise;
 	int poise_base;
+	int resillience;
+	int resillience_base;
 
 	// state
 	int cur_state;


### PR DESCRIPTION
<h3> This is a proposal, please review. </h3>


I've also pushed this logic into the enemy behavior, which /will/ affect the minion branch balance. This will make enemies considerably less useless against multiple minions (probably a good thing, quite honestly.) 

<b>My initial analysis: </b>Most (if not all) HIT (the animation played when you or an enemy is truck) animations are 8 ticks. Most (if not all) swing/melee animations are 16 ticks. This means that if you swing non-stop you will be locking an enemy out of doing anything other than play the hit animation for 8 ticks per every 16 frames. This may be okay, but the problem is that: a) it imbalances future minion patches, where multiple targets are swinging at the enemy, and b) <u>it puts the player in the same position when multiple enemies are hitting him.</u>

<b>My solution: </b> Introduce a variable cooldown timer to the hit animation via a statistic I named resillience. By default resillience_base it is set to 8. You (and enemies) may only enter the hit animation when resillience is at 8, and when the animation is up, resillience is set to resillience_base. If you are struck, resillience is set to resillience_base-1 (essentially including this current frame as a tick) and is decremented once per frame until it reaches zero and is reset, during which time you may not be hit (clarification: forced into animation, damage still registers.)

<b>OH GOD DOES THIS AFFECT THE GAMEPLAY?</b>? You can now navigate away and through a large group of monsters. This has no affect on how you can fight monsters (again, unless you're in the minion branch). You will have no perceptible difference when attacking a monster. This will only prevent scenarios where you are being attacked by 2+ monsters and cannot move because their swing times are adequately staggered.
