### PR TITLE
Very slightly restyled NPC dialog windows.

### DIFF
--- a/src/FontEngine.cpp
+++ b/src/FontEngine.cpp
@@ -121,6 +121,10 @@ void FontEngine::setFont(string _font) {
 	}
 }
 
+TTF_Font* FontEngine::getFontPtr() {
+	return this->active_font->ttfont;
+}
+
 /**
  * For single-line text, just calculate the width
  */

--- a/src/FontEngine.h
+++ b/src/FontEngine.h
@@ -76,6 +76,7 @@ public:
 
 	SDL_Color getColor(std::string _color);
 	void setFont(std::string _font);
+	TTF_Font* getFontPtr();
 
 	int calc_width(const std::string& text);
 	Point calc_size(const std::string& text_with_newlines, int width);

--- a/src/MenuTalker.cpp
+++ b/src/MenuTalker.cpp
@@ -93,6 +93,7 @@ MenuTalker::MenuTalker(MenuManager *_menu, CampaignManager *_camp) {
 				portrait_you.w = eatFirstInt(infile.val,',');
 				portrait_you.h = eatFirstInt(infile.val,',');
 			}
+
 		}
 		infile.close();
 	} else fprintf(stderr, "Unable to open menus/talker.txt!\n");
@@ -196,11 +197,13 @@ void MenuTalker::createBuffer() {
 
 	// speaker name
 	string etype = npc->dialog[dialog_node][event_cursor].type;
+	string who;
+
 	if (etype == "him" || etype == "her") {
-		line = npc->name + ": ";
+		who = npc->name;
 	}
 	else if (etype == "you") {
-		line = hero_name + ": ";
+		who = hero_name;
 	}
 
 	line = line + npc->dialog[dialog_node][event_cursor].s;
@@ -209,8 +212,11 @@ void MenuTalker::createBuffer() {
 	SDL_FreeSurface(msg_buffer);
 	msg_buffer = createAlphaSurface(text_pos.w,text_pos.h);
 	font->setFont("font_regular");
-	font->render(line, text_offset.x, text_offset.y, JUSTIFY_LEFT, msg_buffer, text_pos.w - text_offset.x*2, color_normal);
 
+	TTF_SetFontStyle(font->getFontPtr(), TTF_STYLE_BOLD);
+	font->render(who, 10, 10, JUSTIFY_LEFT, msg_buffer, 512, color_normal);
+	TTF_SetFontStyle(font->getFontPtr(), TTF_STYLE_NORMAL);
+	font->render(line, text_offset.x, text_offset.y+15, JUSTIFY_LEFT, msg_buffer, text_pos.w - text_offset.x*2, color_normal);
 }
 
 void MenuTalker::render() {


### PR DESCRIPTION
This may be a preferential thing, and I expect it may be debated, but I was slightly bothered by how NPC dialogs were currently being displayed. The problem I had with them was that the character who was speakings name was inline, and on every new window I was reading their name first and it was breaking the flow of the conversation. To solve this I've separated their name from their dialog and bolded it to set it apart more distinctly.

Here are screenshots:

<ul><li><a href="http://i.imgur.com/h5KCwFl.png">new layout</a></li>
<li><a href="http://i.imgur.com/UnPWWCy.png">old layout</a></li></ul>


The way I did it may not be the best way to, and I recommend any and all critiques. At first I had the two styles be configurable (in talker.txt you could set a flag for whatever style) but I've decided to simplify it and just force this style. I've tested in multiple resolutions (even the lowest possible) and it displays properly in them all.

Regards,
Joseph (Ninwa) 
