### PR TITLE
Reduce usage of positional audio

### DIFF
--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -216,15 +216,15 @@ void EnemyManager::logic() {
 					 << enemies[i]->stats.sfx_prefix << "')" << endl;
 			} else {
 				if (enemies[i]->sfx_phys)
-					snd->play(sound_phys[pref_id], GLOBAL_VIRTUAL_CHANNEL, enemies[i]->stats.pos, false);
+					snd->play(sound_phys[pref_id]);
 				if (enemies[i]->sfx_ment)
-					snd->play(sound_ment[pref_id], GLOBAL_VIRTUAL_CHANNEL, enemies[i]->stats.pos, false);
+					snd->play(sound_ment[pref_id]);
 				if (enemies[i]->sfx_hit)
-					snd->play(sound_hit[pref_id], GLOBAL_VIRTUAL_CHANNEL, enemies[i]->stats.pos, false);
+					snd->play(sound_hit[pref_id]);
 				if (enemies[i]->sfx_die)
-					snd->play(sound_die[pref_id], GLOBAL_VIRTUAL_CHANNEL, enemies[i]->stats.pos, false);
+					snd->play(sound_die[pref_id]);
 				if (enemies[i]->sfx_critdie)
-					snd->play(sound_critdie[pref_id], GLOBAL_VIRTUAL_CHANNEL, enemies[i]->stats.pos, false);
+					snd->play(sound_critdie[pref_id]);
 			}
 
 			// clear sound flags

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -410,7 +410,7 @@ void ItemManager::renderIcon(ItemStack stack, int x, int y, int size) {
 }
 
 void ItemManager::playSound(int item, Point pos) {
-  snd->play(items[item].sfx, GLOBAL_VIRTUAL_CHANNEL, pos, false);
+  snd->play(items[item].sfx);
 }
 
 TooltipData ItemManager::getShortTooltip(ItemStack stack) {

--- a/src/LootManager.cpp
+++ b/src/LootManager.cpp
@@ -354,7 +354,7 @@ void LootManager::addLoot(ItemStack stack, Point pos) {
 	ld.loadAnimation(animationname);
 	ld.currency = 0;
 	loot.push_back(ld);
-	snd->play(sfx_loot, GLOBAL_VIRTUAL_CHANNEL, pos, false);
+	snd->play(sfx_loot);
 }
 
 void LootManager::addCurrency(int count, Point pos) {
@@ -377,7 +377,7 @@ void LootManager::addCurrency(int count, Point pos) {
 
 	ld.currency = count;
 	loot.push_back(ld);
-	snd->play(sfx_loot, GLOBAL_VIRTUAL_CHANNEL, pos, false);
+	snd->play(sfx_loot);
 }
 
 /**
@@ -511,7 +511,7 @@ void LootManager::addRenders(vector<Renderable> &ren, vector<Renderable> &ren_de
 }
 
 void LootManager::playCurrencySound(Point pos) {
-  snd->play(sfx_currency, GLOBAL_VIRTUAL_CHANNEL, pos, false);
+  snd->play(sfx_currency);
 }
 
 LootManager::~LootManager() {


### PR DESCRIPTION
This fixes a bug where these sounds would sometimes not play. This was
especially common with the enemy death sound. These sounds usually
happen within the vicinity of the player, so the positional effect isn't
that signifigant anyway.
