### PR TITLE
Add option for equipment to apply when transformed

### DIFF
--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -777,6 +777,10 @@ void GameStatePlay::logic() {
 			menu->act->locked[count] = true;
 		} else if (pc->stats.manual_untransform && pc->untransform_power == 0)
 			fprintf(stderr, "Untransform power not found, you can't untransform manually\n");
+
+		// reapply equipment if the transformation allows it
+		if (pc->stats.transform_with_equipment)
+			menu->inv->applyEquipment(menu->inv->inventory[EQUIPMENT].storage);
 	}
 	// revert hero powers
 	if (pc->revertPowers) {

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -252,6 +252,8 @@ void PowerManager::loadPowers(const std::string& filename) {
 			powers[input_id].transform_duration = toInt(infile.val);
 		else if (infile.key == "manual_untransform")
 			powers[input_id].manual_untransform = toBool(infile.val);
+		else if (infile.key == "keep_equipment")
+			powers[input_id].keep_equipment = toBool(infile.val);
 		// buffs
 		else if (infile.key == "buff")
 			powers[input_id].buff= toBool(infile.val);
@@ -906,6 +908,7 @@ bool PowerManager::transform(int power_index, StatBlock *src_stats, Point target
 	buff(power_index, src_stats, target);
 
 	src_stats->manual_untransform = powers[power_index].manual_untransform;
+	src_stats->transform_with_equipment = powers[power_index].keep_equipment;
 
 	// If there's a sound effect, play it here
 	playSound(power_index, src_stats);

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -164,6 +164,7 @@ public:
 
 	int transform_duration;
 	bool manual_untransform; // true binds to the power another recurrence power
+	bool keep_equipment;
 
 	// special effects
 	bool buff;
@@ -246,6 +247,7 @@ public:
 
 		, transform_duration(0)
 		, manual_untransform(false)
+		, keep_equipment(false)
 
 		, buff(false)
 		, buff_teleport(false)

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -109,6 +109,7 @@ StatBlock::StatBlock()
 	, transform_duration(0)
 	, transform_duration_total(0)
 	, manual_untransform(false)
+	, transform_with_equipment(false)
 	, effects(EffectManager())
 	, pos(Point())
 	, forced_speed(Point())
@@ -117,7 +118,7 @@ StatBlock::StatBlock()
 	, poise(0)
 	, poise_base(0)
 	, cooldown_hit(0)
-	, cooldown_hit_ticks(0)	
+	, cooldown_hit_ticks(0)
 	, cur_state(0)
 	, waypoints(queue<Point>())		// enemy only
 	, waypoint_pause(0)				// enemy only
@@ -417,7 +418,7 @@ void StatBlock::calcBaseDmgAndAbs() {
 	dmg_ment_min = dmg_ment_max = bonus_per_mental * ment0;
 	dmg_ranged_min = dmg_ranged_max = bonus_per_offense * off0;
 	absorb_min = absorb_max = bonus_per_defense * def0;
-	
+
 }
 
 /**
@@ -446,7 +447,7 @@ void StatBlock::recalc_alt() {
 		accuracy = accuracy_base + (accuracy_per_level * lev0) + (accuracy_per_offense * off0) + effects.bonus_accuracy;
 		avoidance = avoidance_base + (avoidance_per_level * lev0) + (avoidance_per_defense * def0) + effects.bonus_avoidance;
 		crit = crit_base + (crit_per_level * lev0) + effects.bonus_crit;
-		
+
 	} else {
 		maxhp = hp_base + effects.bonus_hp;
 		maxmp = mp_base + effects.bonus_mp;

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -214,6 +214,7 @@ public:
 	int transform_duration;
 	int transform_duration_total;
 	bool manual_untransform;
+	bool transform_with_equipment;
 	EffectManager effects;
 
 	Point pos;


### PR DESCRIPTION
In response to #448

With this, we can now use `keep_equipment=true` for flare-game's Stealth
power. The default value for this false to retain the old behavior and
avoid breakage with other games.
