### PR TITLE
Only show one tooltip context at a time

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -1087,11 +1087,15 @@ void MapRenderer::checkHotspots() {
 					if ((*it).cooldown_ticks != 0) continue;
 
 					// new tooltip?
-					if (!(*it).tooltip.empty())
+					if (!(*it).tooltip.empty() && TOOLTIP_CONTEXT != TOOLTIP_MENU) {
 						show_tooltip = true;
-					if (!tip_buf.compareFirstLine((*it).tooltip)) {
-						tip_buf.clear();
-						tip_buf.addText((*it).tooltip);
+						if (!tip_buf.compareFirstLine((*it).tooltip)) {
+							tip_buf.clear();
+							tip_buf.addText((*it).tooltip);
+						}
+						TOOLTIP_CONTEXT = TOOLTIP_MAP;
+					} else if (TOOLTIP_CONTEXT != TOOLTIP_MENU) {
+						TOOLTIP_CONTEXT = TOOLTIP_NONE;
 					}
 
 					if ((abs(cam.x - (*it).location.x * UNITS_PER_TILE) < CLICK_RANGE)

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -758,6 +758,9 @@ void MenuManager::render() {
 			tip_buf = tip_new;
 		}
 		tip->render(tip_buf, inpt->mouse, STYLE_FLOAT);
+		TOOLTIP_CONTEXT = TOOLTIP_MENU;
+	} else if (TOOLTIP_CONTEXT != TOOLTIP_MAP) {
+		TOOLTIP_CONTEXT = TOOLTIP_NONE;
 	}
 
 	// draw icon under cursor if dragging

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -153,7 +153,7 @@ void NPCManager::renderTooltips(Point cam, Point mouse) {
 		r.x = p.x - ren.offset.x;
 		r.y = p.y - ren.offset.y;
 
-		if (isWithin(r, mouse)) {
+		if (isWithin(r, mouse) && TOOLTIP_CONTEXT != TOOLTIP_MENU) {
 
 			// adjust dest.y so that the tooltip floats above the item
 			p.y -= tooltip_margin;
@@ -165,8 +165,11 @@ void NPCManager::renderTooltips(Point cam, Point mouse) {
 			}
 
 			tip->render(tip_buf, p, STYLE_TOPLABEL);
+			TOOLTIP_CONTEXT = TOOLTIP_MAP;
 
 			break; // display only one NPC tooltip at a time
+		} else if (TOOLTIP_CONTEXT != TOOLTIP_MENU) {
+			TOOLTIP_CONTEXT = TOOLTIP_NONE;
 		}
 	}
 }

--- a/src/WidgetTooltip.cpp
+++ b/src/WidgetTooltip.cpp
@@ -28,6 +28,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 using namespace std;
 
+int TOOLTIP_CONTEXT = TOOLTIP_NONE;
 
 WidgetTooltip::WidgetTooltip() {
 

--- a/src/WidgetTooltip.h
+++ b/src/WidgetTooltip.h
@@ -36,6 +36,11 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 const int STYLE_FLOAT = 0;
 const int STYLE_TOPLABEL = 1;
 
+extern int TOOLTIP_CONTEXT;
+const int TOOLTIP_NONE = 0;
+const int TOOLTIP_MAP = 1;
+const int TOOLTIP_MENU = 2;
+
 /**
  * TooltipData contains the text and line colors for one tool tip.
  * Useful for keeping the data separate from the widget itself, so the data


### PR DESCRIPTION
Closes #491

Tooltips can either be in the context of the map (events and NPCs), or
in the context of menus. Menu tooltips will always take priority over
map tooltips.
