### PR TITLE
Allow randomized quantities for map loot

### DIFF
--- a/src/LootManager.cpp
+++ b/src/LootManager.cpp
@@ -239,16 +239,16 @@ void LootManager::checkMapForLoot() {
 	// first drop any 'fixed' (0% chance) items
 	for (unsigned i = map->loot.size(); i > 0; i--) {
 		ec = &map->loot[i-1];
-		if (ec->w == 0) {
+		if (ec->z == 0) {
 			p.x = ec->x;
 			p.y = ec->y;
 
 			// an item id of 0 means we should drop currency instead
 			if (ec->s == "currency" || toInt(ec->s) == 0) {
-				addCurrency(ec->z, p);
+				addCurrency(randBetween(ec->a,ec->b), p);
 			} else {
 				new_loot.item = toInt(ec->s);
-				new_loot.quantity = ec->z;
+				new_loot.quantity = randBetween(ec->a,ec->b);
 				addLoot(new_loot, p);
 			}
 
@@ -262,15 +262,15 @@ void LootManager::checkMapForLoot() {
 
 		if (possible_ids.empty()) {
 			// find the rarest loot less than the chance roll
-			if (chance < (ec->w * (hero->effects.bonus_item_find + 100)) / 100) {
+			if (chance < (ec->z * (hero->effects.bonus_item_find + 100)) / 100) {
 				possible_ids.push_back(i-1);
-				common_chance = ec->w;
+				common_chance = ec->z;
 				i=map->loot.size(); // start searching from the beginning
 				continue;
 			}
 		} else {
 			// include loot with identical chances
-			if (ec->w == common_chance)
+			if (ec->z == common_chance)
 				possible_ids.push_back(i-1);
 		}
 	}
@@ -285,10 +285,10 @@ void LootManager::checkMapForLoot() {
 
 		// an item id of 0 means we should drop currency instead
 		if (ec->s == "currency" || toInt(ec->s) == 0) {
-			addCurrency(ec->z, p);
+			addCurrency(randBetween(ec->a,ec->b), p);
 		} else {
 			new_loot.item = toInt(ec->s);
-			new_loot.quantity = ec->z;
+			new_loot.quantity = randBetween(ec->a,ec->b);
 			addLoot(new_loot, p);
 		}
 	}
@@ -319,7 +319,7 @@ void LootManager::determineLootByEnemy(const Enemy *e, Point pos) {
 				range.x = e->stats.loot[i].count_min;
 				range.y = e->stats.loot[i].count_max;
 				possible_ranges.push_back(range);
-				
+
 				i=-1; // start searching from the beginning
 				continue;
 			}
@@ -331,24 +331,24 @@ void LootManager::determineLootByEnemy(const Enemy *e, Point pos) {
 				range.x = e->stats.loot[i].count_min;
 				range.y = e->stats.loot[i].count_max;
 				possible_ranges.push_back(range);
-				
+
 			}
 		}
 	}
 
 	if (!possible_ids.empty()) {
-	
-		int roll = rand() % possible_ids.size();		
+
+		int roll = rand() % possible_ids.size();
 		new_loot.item = possible_ids[roll];
 		new_loot.quantity = randBetween(possible_ranges[roll].x, possible_ranges[roll].y);
-		
+
 		// an item id of 0 means we should drop currency instead
 		if (new_loot.item == 0) {
-		
+
 			// calculate bonus currency
 			int currency = new_loot.quantity;
 			currency = (currency * (100 + hero->effects.bonus_currency)) / 100;
-			
+
 			addCurrency(currency, pos);
 		} else {
 			addLoot(new_loot, pos);

--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -402,10 +402,17 @@ int MapRenderer::load(string filename) {
 					e->s = infile.nextValue();
 					e->x = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
 					e->y = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
-					e->z = toInt(infile.nextValue());
+
+					// drop chance
 					string chance = infile.nextValue();
-					if (chance == "fixed") e->w = 0;
-					else e->w = toInt(chance);
+					if (chance == "fixed") e->z = 0;
+					else e->z = toInt(chance);
+
+					// quantity min/max
+					e->a = toInt(infile.nextValue());
+					if (e->a < 1) e->a = 1;
+					e->b = toInt(infile.nextValue());
+					if (e->b < e->a) e->b = e->a;
 
 					// add repeating loot
 					string repeat_val = infile.nextValue();
@@ -416,10 +423,15 @@ int MapRenderer::load(string filename) {
 						e->s = repeat_val;
 						e->x = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
 						e->y = toInt(infile.nextValue()) * UNITS_PER_TILE + UNITS_PER_TILE/2;
-						e->z = toInt(infile.nextValue());
-						chance = infile.nextValue();
-						if (chance == "fixed") e->w = 0;
-						else e->w = toInt(chance);
+
+						string chance = infile.nextValue();
+						if (chance == "fixed") e->z = 0;
+						else e->z = toInt(chance);
+
+						e->a = toInt(infile.nextValue());
+						if (e->a < 1) e->a = 1;
+						e->b = toInt(infile.nextValue());
+						if (e->b < e->a) e->b = e->a;
 
 						repeat_val = infile.nextValue();
 					}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -70,7 +70,8 @@ public:
 	int x;
 	int y;
 	int z;
-	int w;
+	int a;
+	int b;
 
 	Event_Component()
 		: type("")
@@ -78,7 +79,8 @@ public:
 		, x(0)
 		, y(0)
 		, z(0)
-		, w(0)
+		, a(0)
+		, b(0)
 	{}
 };
 


### PR DESCRIPTION
This is similar to the recent enemy loot changes.
The new format is: `loot=id,x,y,chance,min_quantity,max_quantity`

`max_quantity` can be omitted for non-random quantities.
