### PR TITLE
Removed Byte order mark (BOM) from languages.txt.

### DIFF
--- a/mods/default/engine/languages.txt
+++ b/mods/default/engine/languages.txt
@@ -1,4 +1,4 @@
-﻿# If default font should be overriden, specify it's filename and ptsize
+# If default font should be overriden, specify it's filename and ptsize
 be=Беларуская
 de=Deutsch
 el=Ελληνικά


### PR DESCRIPTION
This caused a bug where selecting a language in the options menu would instead
give you the language above the one you selected. Presumably it failed to
parse the comment on the first line properly due to the BOM character, thus
believing it is a language code, thus pushing everyone else down one place.

Looks like github's diff fails, doesn't show the real change which is the removal of the first character in the file:
-<U+FEFF># If default font should be overriden, specify it's filename and ptsize
+# If default font should be overriden, specify it's filename and ptsize
(edit: and it fails here too. By checking out the branch and running `git log -p` it should be possible to see the < U + FEFF > character in the old file though.)
