### PR TITLE
Don't free screen surface when exiting

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,7 +177,6 @@ static void cleanup() {
 	delete msg;
 	delete snd;
 
-	SDL_FreeSurface(screen);
 	SDL_FreeSurface(titlebar_icon);
 
 	Mix_CloseAudio();


### PR DESCRIPTION
SDL_Quit() already frees this surface.
