### PR TITLE
Remove unneeded % escape sequence in german translation.

### DIFF
--- a/mods/default/languages/engine.de.po
+++ b/mods/default/languages/engine.de.po
@@ -505,7 +505,7 @@ msgstr "Absorbieren: %d"
 #: ../../../src/ItemManager.cpp:517
 #, fuzzy, c-format
 msgid "%d%% Speed"
-msgstr "%d\\% Geschwindigkeit"
+msgstr "%d% Geschwindigkeit"
 
 #: ../../../src/ItemManager.cpp:522 ../../../src/ItemManager.cpp:614
 #, c-format


### PR DESCRIPTION
After 0.18 we need to have a proper fix for the original string as well.
