### PR TITLE
Temporary fix for '%%' typo in speed bonus

### DIFF
--- a/mods/default/languages/engine.en.po
+++ b/mods/default/languages/engine.en.po
@@ -1,0 +1,21 @@
+# Copyright (C) 2013 Justin Jacobs
+# This file is distributed under the same license as the Flare package.
+# Justin Jacobs <jajdorkster@gmail.com>, 2013
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: 0.18\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-03-25 19:51+0100\n"
+"Last-Translator: Justin Jacobs\n"
+"Language-Team: \n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../../src/ItemManager.cpp:517
+#, c-format
+msgid "%d%% Speed"
+msgstr "%d% Speed"
+


### PR DESCRIPTION
Basically, provide a minimal English-to-English translation to correct it.
