### PR TITLE
Allow transparet background in WidgetScrollBox

### DIFF
--- a/src/GameStateConfig.cpp
+++ b/src/GameStateConfig.cpp
@@ -157,12 +157,12 @@ void GameStateConfig::init() {
 
 	// Allocate KeyBindings
 	for (unsigned int i = 0; i < 25; i++) {
-		 settings_lb[i] = new WidgetLabel();
-		 settings_lb[i]->set(inpt->binding_name[i]);
-		 settings_lb[i]->setJustify(JUSTIFY_RIGHT);
+		settings_lb[i] = new WidgetLabel();
+		settings_lb[i]->set(inpt->binding_name[i]);
+		settings_lb[i]->setJustify(JUSTIFY_RIGHT);
 	}
 	for (unsigned int i = 0; i < 50; i++) {
-		 settings_key[i] = new WidgetButton("images/menus/buttons/button_default.png");
+		settings_key[i] = new WidgetButton("images/menus/buttons/button_default.png");
 	}
 
 	// Allocate resolution list box
@@ -638,10 +638,11 @@ void GameStateConfig::readConfig () {
 	input_scrollbox = new WidgetScrollBox(scrollpane.w, scrollpane.h);
 	input_scrollbox->pos.x = scrollpane.x + frame.x;
 	input_scrollbox->pos.y = scrollpane.y + frame.y;
-	input_scrollbox->resize(scrollpane_contents);
 	input_scrollbox->bg.r = scrollpane_color.r;
 	input_scrollbox->bg.g = scrollpane_color.g;
 	input_scrollbox->bg.b = scrollpane_color.b;
+	input_scrollbox->transparent = false;
+	input_scrollbox->resize(scrollpane_contents);
 
 	// Set positions of secondary key bindings
 	for (unsigned int i = 25; i < 50; i++) {
@@ -1010,12 +1011,14 @@ void GameStateConfig::render ()
 
 	// render keybindings tab
 	if (active_tab == 4) {
-		if (input_scrollbox->update) input_scrollbox->refresh();
-		for (unsigned int i = 0; i < 25; i++) {
-			if (input_scrollbox->update) settings_lb[i]->render(input_scrollbox->contents);
-		}
-		for (unsigned int i = 0; i < 50; i++) {
-			if (input_scrollbox->update) settings_key[i]->render(input_scrollbox->contents);
+		if (input_scrollbox->update) {
+			input_scrollbox->refresh();
+			for (unsigned int i = 0; i < 25; i++) {
+				settings_lb[i]->render(input_scrollbox->contents);
+			}
+			for (unsigned int i = 0; i < 50; i++) {
+				settings_key[i]->render(input_scrollbox->contents);
+			}
 		}
 		input_scrollbox->render();
 	}

--- a/src/MenuLog.cpp
+++ b/src/MenuLog.cpp
@@ -54,10 +54,6 @@ MenuLog::MenuLog() {
 				tab_area.y = eatFirstInt(infile.val,',');
 				tab_area.w = eatFirstInt(infile.val,',');
 				tab_area.h = eatFirstInt(infile.val,',');
-			} else if(infile.key == "tab_bg_color") {
-				tab_bg.r = eatFirstInt(infile.val,',');
-				tab_bg.g = eatFirstInt(infile.val,',');
-				tab_bg.b = eatFirstInt(infile.val,',');
 			}
 		}
 		infile.close();
@@ -67,9 +63,6 @@ MenuLog::MenuLog() {
 	for (int i=0; i<LOG_TYPE_COUNT; i++) {
 		log_count[i] = 0;
 		msg_buffer[i] = new WidgetScrollBox(tab_area.w,tab_area.h);
-		msg_buffer[i]->bg.r = tab_bg.r;
-		msg_buffer[i]->bg.g = tab_bg.g;
-		msg_buffer[i]->bg.b = tab_bg.b;
 	}
 
 	// Initialize the tab control.

--- a/src/WidgetScrollBox.cpp
+++ b/src/WidgetScrollBox.cpp
@@ -35,6 +35,7 @@ WidgetScrollBox::WidgetScrollBox(int width, int height) {
 	scrollbar = new WidgetScrollBar("images/menus/buttons/scrollbar_default.png");
 	update = true;
 	render_to_alpha = false;
+	transparent = true;
 	resize(height);
 }
 
@@ -103,8 +104,10 @@ void WidgetScrollBox::resize(int h) {
 
 	if (pos.h > h) h = pos.h;
 	contents = createAlphaSurface(pos.w,h);
-	SDL_FillRect(contents,NULL,SDL_MapRGB(contents->format,bg.r,bg.g,bg.b));
-	SDL_SetAlpha(contents, 0, 0);
+	if (!transparent) {
+		SDL_FillRect(contents,NULL,SDL_MapRGB(contents->format,bg.r,bg.g,bg.b));
+		SDL_SetAlpha(contents, 0, 0);
+	}
 
 	cursor = 0;
 	refresh();
@@ -119,8 +122,10 @@ void WidgetScrollBox::refresh() {
 		}
 
 		contents = createAlphaSurface(pos.w,h);
-		SDL_FillRect(contents,NULL,SDL_MapRGB(contents->format,bg.r,bg.g,bg.b));
-		SDL_SetAlpha(contents, 0, 0);
+		if (!transparent) {
+			SDL_FillRect(contents,NULL,SDL_MapRGB(contents->format,bg.r,bg.g,bg.b));
+			SDL_SetAlpha(contents, 0, 0);
+		}
 	}
 
 	scrollbar->refresh(pos.x+pos.w, pos.y, pos.h-scrollbar->pos_down.h, cursor, contents->h-pos.h-scrollbar->pos_knob.h);

--- a/src/WidgetScrollBox.h
+++ b/src/WidgetScrollBox.h
@@ -46,6 +46,7 @@ public:
 	SDL_Surface * contents;
 	bool update;
 	SDL_Color bg;
+	bool transparent;
 
 private:
 	void scroll(int amount);


### PR DESCRIPTION
Transparency is true by default. Please note that when rendering other
widgets inside of a transparent WidgetScrollBox, the `render_to_alpha`
flag must be set to true for those widgets.
