### PR TITLE
Use prefix for saved user settings

### DIFF
--- a/src/GameStateConfig.cpp
+++ b/src/GameStateConfig.cpp
@@ -1259,7 +1259,7 @@ bool GameStateConfig::setMods() {
 		if (activemods_lstb->getValue(i) != "") mods->mod_list.push_back(activemods_lstb->getValue(i));
 	}
 	ofstream outfile;
-	outfile.open((PATH_CONF + "mods.txt").c_str(), ios::out);
+	outfile.open((PATH_CONF + MODS_PREFIX + "mods.txt").c_str(), ios::out);
 
 	if (outfile.is_open()) {
 

--- a/src/InputState.cpp
+++ b/src/InputState.cpp
@@ -126,7 +126,7 @@ void InputState::loadKeyBindings() {
 
 	FileParser infile;
 
-	if (!infile.open(PATH_CONF + FILE_KEYBINDINGS, "")) {
+	if (!infile.open(PATH_CONF + MODS_PREFIX + FILE_KEYBINDINGS, "")) {
 		if (!infile.open(mods->locate("engine/default_keybindings.txt"), "")) {
 			saveKeyBindings();
 			return;
@@ -180,7 +180,7 @@ void InputState::loadKeyBindings() {
  */
 void InputState::saveKeyBindings() {
 	ofstream outfile;
-	outfile.open((PATH_CONF + FILE_KEYBINDINGS).c_str(), ios::out);
+	outfile.open((PATH_CONF + MODS_PREFIX + FILE_KEYBINDINGS).c_str(), ios::out);
 
 	if (outfile.is_open()) {
 

--- a/src/ModManager.cpp
+++ b/src/ModManager.cpp
@@ -60,8 +60,25 @@ void ModManager::loadModList() {
 		fprintf(stderr, "Mod \"%s\" not found, skipping\n", FALLBACK_MOD);
 	}
 
+	// get the mods prefix
+	string prefix = PATH_DATA + "mods/mods_prefix.txt";
+	infile.open(prefix.c_str(), ios::in);
+	while(infile.good()) {
+		line = getLine(infile);
+
+		// skip ahead if this line is empty
+		if (line.length() == 0) continue;
+
+		// skip comments
+		starts_with = line.at(0);
+		if (starts_with == "#") continue;
+
+		MODS_PREFIX = line + "_";
+	}
+	infile.close();
+
 	// Add all other mods.
-	string place1 = PATH_CONF + "mods.txt";
+	string place1 = PATH_CONF + MODS_PREFIX + "mods.txt";
 	string place2 = PATH_DATA + "mods/mods.txt";
 
 	infile.open(place1.c_str(), ios::in);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -77,6 +77,7 @@ string PATH_CONF = "";
 string PATH_USER = "";
 string PATH_DATA = "";
 string USER_PATH_DATA = "";
+string MODS_PREFIX = "";
 
 // Filenames
 string FILE_SETTINGS	= "settings.txt";
@@ -513,7 +514,7 @@ bool loadSettings() {
 
 	// try read from file
 	FileParser infile;
-	if (!infile.open(PATH_CONF + FILE_SETTINGS, "")) {
+	if (!infile.open(PATH_CONF + MODS_PREFIX + FILE_SETTINGS, "")) {
 		if (!infile.open(mods->locate("engine/default_settings.txt"), "")) {
 			saveSettings();
 			return true;
@@ -539,7 +540,7 @@ bool loadSettings() {
 bool saveSettings() {
 
 	ofstream outfile;
-	outfile.open((PATH_CONF + FILE_SETTINGS).c_str(), ios::out);
+	outfile.open((PATH_CONF + MODS_PREFIX + FILE_SETTINGS).c_str(), ios::out);
 
 	if (outfile.is_open()) {
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -69,6 +69,7 @@ extern std::string PATH_CONF; // user-configurable settings files
 extern std::string PATH_USER; // important per-user data (saves)
 extern std::string PATH_DATA; // common game data
 extern std::string USER_PATH_DATA; // user-defined replacement for PATH_DATA
+extern std::string MODS_PREFIX; // allows per-game prefixes to local config files such as ~/.config/flare/mods.txt
 
 // Filenames
 extern std::string FILE_SETTINGS;     // Name of the settings file (e.g. "settings.txt").


### PR DESCRIPTION
This prefix is obtained from `mods/mods_prefix.txt`.

See #565 
