### PR TITLE
A man page for FLARE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 
 set(BINDIR  "games"             CACHE STRING "Directory from CMAKE_INSTALL_PREFIX where game executable will be installed.")
 set(DATADIR "share/games/flare" CACHE STRING "Directory from CMAKE_INSTALL_PREFIX where game data files will be installed.")
+set(MANDIR  "share/man"         CACHE STRING "Directory from CMAKE_INSTALL_PREFIX where manual pages will be installed.")
 
 If(NOT IS_ABSOLUTE "${DATADIR}")
 	add_definitions(-DDATA_INSTALL_DIR="${CMAKE_INSTALL_PREFIX}/${DATADIR}")
@@ -198,6 +199,7 @@ install(PROGRAMS
 install(DIRECTORY
   "${CMAKE_CURRENT_SOURCE_DIR}/mods"
   DESTINATION ${DATADIR})
+If (UNIX)
 install(FILES
   "${CMAKE_CURRENT_BINARY_DIR}/flare.desktop"
   DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
@@ -205,3 +207,8 @@ install(FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/distribution/flare_logo.svg"
   DESTINATION ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps
   RENAME flare.svg)
+install(FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/distribution/flare.man"
+  DESTINATION ${MANDIR}/man1
+  RENAME flare.1)
+EndIf (UNIX)

--- a/distribution/flare.man
+++ b/distribution/flare.man
@@ -1,0 +1,40 @@
+.\" -*- nroff -*-
+
+.TH FLARE 1 "March 2013"
+
+.SH NAME
+flare \- action role-playing engine
+
+.SH SYNOPSIS
+.B flare
+.RB [ options ]
+
+.SH DESCRIPTION
+.B FLARE
+(short for Free Libre Action Roleplaying Engine) is a single-player, 2D-isometric
+action role-playing engine. It uses simple file formats (INI-style config files)
+for most of the game data, allowing anyone to easily modify game contents.
+
+.SH OPTIONS
+.IP "\fB\-\-debug_event\fP"
+Switch on event debugging information.
+.IP "\fB\-\-game_data \fIpath\fP"
+Set an alternate path to the game data.
+
+.SH FILES
+.TP
+The settings are stored in
+.LP
+\fB$XDG_CONFIG_HOME\fR/\fB$GAMENAME\fR
+.LP
+\fB$HOME\fR/.config/\fB$GAMENAME\fR
+
+.TP
+The game data is stored in
+.LP
+\fB$XDG_DATA_HOME\fR/\fB$GAMENAME\fR
+.LP
+\fB$HOME\fR/.local/share/\fB$GAMENAME\fR
+
+.SH AVAILABILITY
+For more information about the FLARE engine, visit http://flarerpg.org


### PR DESCRIPTION
Add a manual page for the FLARE engine. Only install UNIX specific stuff when the build platform is UNIX.

```
modified:   CMakeLists.txt
new file:   distribution/flare.man
```
