### PR TITLE
Fix false positive error messages from console

### DIFF
--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -404,8 +404,6 @@ void GameStateLoad::logic() {
 				perror("Error deleting save from path");
 			stats[selected_slot] = StatBlock();
 			readGameSlot(selected_slot);
-			loadPreview(selected_slot);
-			loadPortrait(selected_slot);
 
 			updateButtons();
 


### PR DESCRIPTION
loadPreview() is called within readGameSlot() and loadPortrait() within updateButtons() so we don't need these calls twice. This removes terminal messages

Couldn't load image: Couldn't open ./images/avatar/male/preview/dagger.png
Couldn't load image: Couldn't open ./images/avatar/male/preview/head_short.png

reported in https://github.com/makrohn/polymorphable/issues/34
