### PR TITLE
Introduce MOVEMENTTYPE type for safety. Fix bug in Avatar.

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -273,7 +273,7 @@ void Avatar::set_direction() {
 			vector<Point> path;
 
 			// if a path is returned, target first waypoint
-			if ( map->collider.compute_path(stats.pos, target, path, 1000, stats.movement_type)) {
+			if ( map->collider.compute_path(stats.pos, target, path, stats.movement_type), 1000) {
 				target = path.back();
 			}
 		}
@@ -444,8 +444,8 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 		drag_walking = false;
 		attacking = false;
 	} else {
-        if(!inpt->lock[MAIN1]) {
-            attacking = true;
+		if(!inpt->lock[MAIN1]) {
+			attacking = true;
 		}
 	}
 

--- a/src/MapCollision.cpp
+++ b/src/MapCollision.cpp
@@ -50,7 +50,7 @@ void MapCollision::setmap(const unsigned short _colmap[][256], unsigned short w,
  * If we encounter an obstacle at 90 degrees, stop.
  * If we encounter an obstacle at 45 or 135 degrees, slide.
  */
-bool MapCollision::move(int &x, int &y, int step_x, int step_y, int dist, int movement_type) {
+bool MapCollision::move(int &x, int &y, int step_x, int step_y, int dist, MOVEMENTTYPE movement_type) {
 
 	bool diag = step_x && step_y;
 
@@ -125,7 +125,7 @@ bool MapCollision::is_wall(int x, int y) const {
 /**
  * Is this a valid tile for an entity with this movement type?
  */
-bool MapCollision::is_valid_tile(int tile_x, int tile_y, int movement_type) const {
+bool MapCollision::is_valid_tile(int tile_x, int tile_y, MOVEMENTTYPE movement_type) const {
 
 	// outside the map isn't valid
 	if (is_outside_map(tile_x,tile_y)) return false;
@@ -148,7 +148,7 @@ bool MapCollision::is_valid_tile(int tile_x, int tile_y, int movement_type) cons
 /**
  * Is this a valid position for an entity with this movement type?
  */
-bool MapCollision::is_valid_position(int x, int y, int movement_type) const {
+bool MapCollision::is_valid_position(int x, int y, MOVEMENTTYPE movement_type) const {
 
 	const int tile_x = x >> TILE_SHIFT; // fast div
 	const int tile_y = y >> TILE_SHIFT; // fast div
@@ -211,7 +211,7 @@ int MapCollision::is_one_step_around(int x, int y, int xdir, int ydir) {
  * Does not have the "slide" submovement that move() features
  * Line can be arbitrary angles.
  */
-bool MapCollision::line_check(int x1, int y1, int x2, int y2, int check_type, int movement_type) {
+bool MapCollision::line_check(int x1, int y1, int x2, int y2, int check_type, MOVEMENTTYPE movement_type) {
 	float x = (float)x1;
 	float y = (float)y1;
 	float dx = (float)abs(x2 - x1);
@@ -255,10 +255,10 @@ bool MapCollision::line_check(int x1, int y1, int x2, int y2, int check_type, in
 }
 
 bool MapCollision::line_of_sight(int x1, int y1, int x2, int y2) {
-	return line_check(x1, y1, x2, y2, CHECK_SIGHT, 0);
+	return line_check(x1, y1, x2, y2, CHECK_SIGHT, MOVEMENT_NORMAL);
 }
 
-bool MapCollision::line_of_movement(int x1, int y1, int x2, int y2, int movement_type) {
+bool MapCollision::line_of_movement(int x1, int y1, int x2, int y2, MOVEMENTTYPE movement_type) {
 
 	// intangible entities can always move
 	if (movement_type == MOVEMENT_INTANGIBLE) return true;
@@ -285,7 +285,7 @@ bool MapCollision::line_of_movement(int x1, int y1, int x2, int y2, int movement
 * limit is the maximum number of explored node
 * @return true if a path is found
 */
-bool MapCollision::compute_path(Point start_pos, Point end_pos, vector<Point> &path, int movement_type, unsigned int limit) {
+bool MapCollision::compute_path(Point start_pos, Point end_pos, vector<Point> &path, MOVEMENTTYPE movement_type, unsigned int limit) {
 
 	// path must be empty
 	if (!path.empty())

--- a/src/MapCollision.h
+++ b/src/MapCollision.h
@@ -46,9 +46,11 @@ const int CHECK_MOVEMENT = 1;
 const int CHECK_SIGHT = 2;
 
 // movement options
-const int MOVEMENT_NORMAL = 0;
-const int MOVEMENT_FLYING = 1; // can move through BLOCKS_MOVEMENT (e.g. water)
-const int MOVEMENT_INTANGIBLE = 2; // can move through BLOCKS_ALL (e.g. walls)
+typedef enum {
+	MOVEMENT_NORMAL = 0,
+	MOVEMENT_FLYING = 1, // can move through BLOCKS_MOVEMENT (e.g. water)
+	MOVEMENT_INTANGIBLE = 2 // can move through BLOCKS_ALL (e.g. walls)
+} MOVEMENTTYPE;
 
 const unsigned int PATH_MAX_TILES = 256;
 
@@ -56,7 +58,7 @@ const unsigned int PATH_MAX_TILES = 256;
 class MapCollision {
 private:
 
-	bool line_check(int x1, int y1, int x2, int y2, int check_type, int movement_type);
+	bool line_check(int x1, int y1, int x2, int y2, int check_type, MOVEMENTTYPE movement_type);
 	bool is_sidestepable(int tile_x, int tile_y, int offx2, int offy2);
 
 public:
@@ -64,20 +66,20 @@ public:
 	~MapCollision();
 
 	void setmap(const unsigned short _colmap[][256], unsigned short w, unsigned short h);
-	bool move(int &x, int &y, int step_x, int step_y, int dist, int movement_type);
+	bool move(int &x, int &y, int step_x, int step_y, int dist, MOVEMENTTYPE movement_type);
 
 	bool is_outside_map(int tile_x, int tile_y) const;
 	bool is_empty(int x, int y) const;
 	bool is_wall(int x, int y) const;
-	bool is_valid_tile(int x, int y, int movement_type) const;
-	bool is_valid_position(int x, int y, int movement_type) const;
+	bool is_valid_tile(int x, int y, MOVEMENTTYPE movement_type) const;
+	bool is_valid_position(int x, int y, MOVEMENTTYPE movement_type) const;
 
 	int is_one_step_around(int x, int y, int xidr, int ydir);
 
 	bool line_of_sight(int x1, int y1, int x2, int y2);
-	bool line_of_movement(int x1, int y1, int x2, int y2, int movement_type);
+	bool line_of_movement(int x1, int y1, int x2, int y2, MOVEMENTTYPE movement_type);
 
-	bool compute_path(Point start, Point end, std::vector<Point> &path, int movement_type, unsigned int limit = PATH_MAX_TILES);
+	bool compute_path(Point start, Point end, std::vector<Point> &path, MOVEMENTTYPE movement_type, unsigned int limit = PATH_MAX_TILES);
 
 	void block(int map_x, int map_y);
 	void unblock(int map_x, int map_y);

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -32,6 +32,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include <string>
 #include <queue>
 
+#include "MapCollision.h"
+
 class Power;
 
 const int POWERSLOT_COUNT = 10;
@@ -109,7 +111,7 @@ public:
 	bool transformed;
 	bool refresh_stats;
 
-	int movement_type;
+	MOVEMENTTYPE movement_type;
 	bool flying;
 	bool intangible;
 	bool facing; // does this creature turn to face the hero


### PR DESCRIPTION
All places in the code, which deal with the movement type(whether you are flying, walking or a Ghost) were using using integer constants. These were replaced by an enum.

In the Avatar I noticed that there were parameters in the wrong order, so I assume it was a bug:

``````
-      if ( map->collider.compute_path(stats.pos, target, path, 1000, stats.movement_type)) {
+      if ( map->collider.compute_path(stats.pos, target, path, stats.movement_type), 1000) ```

``````
