### PR TITLE
Fix NPC map event

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -573,7 +573,6 @@ void MapRenderer::loadEventComponent(FileParser &infile) {
 		}
 	}
 	else if (infile.key == "npc") {
-		npcs.back().id = infile.val;
 		e->s = infile.val;
 	}
 	else if (infile.key == "music") {


### PR DESCRIPTION
The npc map event should not interfere with the npcs itself. It should
only trigger the dialog with a certain npc.

This fixes a crash at the cavern.txt map at polymorphable at
a514306591951b70eec155938f1216a492145a29
which has this structure:

```
[event]
# Unblock passage
type=run_once
npc=gravestone

[npc]
type=gravestone
```

This lead to a crash as the event referencing the npc, was loaded prior to
any npc loaded.
