### PR TITLE
Add the end point to path vector when pathfinding fails

### DIFF
--- a/src/MapCollision.cpp
+++ b/src/MapCollision.cpp
@@ -364,6 +364,7 @@ bool MapCollision::compute_path(Point start_pos, Point end_pos, vector<Point> &p
 
 		// reblock target if needed
 		if (target_blocks) block(end_pos.x, end_pos.y);
+		path.push_back(collision_to_map(end));
 
 		return false;
 	}


### PR DESCRIPTION
Fixes #600
