### PR TITLE
Singleton on PowerManager (for review)

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -44,8 +44,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 using namespace std;
 
-Avatar::Avatar(PowerManager *_powers, MapRenderer *_map)
-	: Entity(_powers, _map)
+Avatar::Avatar(MapRenderer *_map)
+	: Entity(_map)
 	, lockSwing(false)
 	, lockCast(false)
 	, lockShoot(false)
@@ -304,7 +304,7 @@ void Avatar::set_direction() {
 
 void Avatar::handlePower(int actionbar_power) {
 	if (actionbar_power != 0 && stats.cooldown_ticks == 0) {
-		const Power &power = powers->getPower(actionbar_power);
+		const Power &power = PowerManager::instance->getPower(actionbar_power);
 		Point target;
 		if (MOUSE_AIM) {
 			if (power.aim_assist)
@@ -327,7 +327,7 @@ void Avatar::handlePower(int actionbar_power) {
 			return;
 		if (stats.hero_cooldown[actionbar_power] > 0)
 			return;
-		if (!powers->hasValidTarget(actionbar_power,&stats,target))
+		if (!PowerManager::instance->hasValidTarget(actionbar_power,&stats,target))
 			return;
 
 		stats.hero_cooldown[actionbar_power] = power.cooldown; //set the cooldown timer
@@ -358,7 +358,7 @@ void Avatar::handlePower(int actionbar_power) {
 				break;
 
 			case POWSTATE_INSTANT:	// handle instant powers
-				powers->activate(current_power, &stats, target);
+				PowerManager::instance->activate(current_power, &stats, target);
 				break;
 		}
 	}
@@ -406,7 +406,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 	map->collider.unblock(stats.pos.x, stats.pos.y);
 
 	// turn on all passive powers
-	if ((stats.hp > 0 || stats.effects.triggered_death) && !respawn && !transform_triggered) powers->activatePassives(&stats);
+	if ((stats.hp > 0 || stats.effects.triggered_death) && !respawn && !transform_triggered) PowerManager::instance->activatePassives(&stats);
 	if (transform_triggered) transform_triggered = false;
 
 	int stepfx;
@@ -583,7 +583,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			// do power
 			if (activeAnimation->isActiveFrame()) {
-				powers->activate(current_power, &stats, act_target);
+				PowerManager::instance->activate(current_power, &stats, act_target);
 			}
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
@@ -603,7 +603,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			// do power
 			if (activeAnimation->isActiveFrame()) {
-				powers->activate(current_power, &stats, act_target);
+				PowerManager::instance->activate(current_power, &stats, act_target);
 			}
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
@@ -621,7 +621,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			// do power
 			if (activeAnimation->isActiveFrame()) {
-				powers->activate(current_power, &stats, act_target);
+				PowerManager::instance->activate(current_power, &stats, act_target);
 			}
 
 			if (activeAnimation->getTimesPlayed() >= 1) {
@@ -634,7 +634,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 
 			setAnimation("block");
 
-			if (powers->powers[actionbar_power].new_state != POWSTATE_BLOCK) {
+			if (PowerManager::instance->powers[actionbar_power].new_state != POWSTATE_BLOCK) {
 				stats.cur_state = AVATAR_STANCE;
 				stats.effects.triggered_block = false;
 				stats.effects.clearTriggerEffects(TRIGGER_BLOCK);
@@ -881,8 +881,8 @@ void Avatar::setAnimation(std::string name) {
  * Find untransform power index to use for manual untransfrom ability
  */
 int Avatar::getUntransformPower() {
-	for (unsigned id=0; id<powers->powers.size(); id++) {
-		if (powers->powers[id].spawn_type == "untransform" && powers->powers[id].requires_item == -1)
+	for (unsigned id=0; id<PowerManager::instance->powers.size(); id++) {
+		if (PowerManager::instance->powers[id].spawn_type == "untransform" && PowerManager::instance->powers[id].requires_item == -1)
 			return id;
 	}
 	return 0;

--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -27,7 +27,6 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #ifndef AVATAR_H
 #define AVATAR_H
 
-
 #include "Entity.h"
 #include "SharedResources.h"
 #include "SoundManager.h"
@@ -42,7 +41,6 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 class Entity;
 class Hazard;
-class PowerManager;
 class StatBlock;
 
 /**
@@ -95,7 +93,7 @@ private:
 	int getUntransformPower();
 
 public:
-	Avatar(PowerManager *_powers, MapRenderer *_map);
+	Avatar(MapRenderer *_map);
 	~Avatar();
 
 	EnemyManager *enemies;

--- a/src/BehaviorStandard.cpp
+++ b/src/BehaviorStandard.cpp
@@ -59,7 +59,7 @@ void BehaviorStandard::logic() {
  */
 void BehaviorStandard::doUpkeep() {
 	// activate all passive powers
-	if (e->stats.hp > 0 || e->stats.effects.triggered_death) e->powers->activatePassives(&e->stats);
+	if (e->stats.hp > 0 || e->stats.effects.triggered_death) PowerManager::instance->activatePassives(&e->stats);
 
 	e->stats.logic();
 
@@ -165,7 +165,7 @@ void BehaviorStandard::findTarget() {
 		}
 		else {
 			e->stats.in_combat = true;
-			e->powers->activate(e->stats.power_index[BEACON], &e->stats, e->stats.pos); //emit beacon
+			PowerManager::instance->activate(e->stats.power_index[BEACON], &e->stats, e->stats.pos); //emit beacon
 		}
 	}
 
@@ -174,7 +174,7 @@ void BehaviorStandard::findTarget() {
 
 		if (e->stats.in_combat) e->stats.join_combat = true;
 		e->stats.in_combat = true;
-		e->powers->activate(e->stats.power_index[BEACON], &e->stats, e->stats.pos); //emit beacon
+		PowerManager::instance->activate(e->stats.power_index[BEACON], &e->stats, e->stats.pos); //emit beacon
 	}
 
 	// check exiting combat (player died or got too far away)
@@ -309,7 +309,7 @@ void BehaviorStandard::checkPower() {
 			int power_slot =  e->stats.activated_powerslot;
 			int power_id = e->stats.power_index[e->stats.activated_powerslot];
 
-			e->powers->activate(power_id, &e->stats, pursue_pos);
+			PowerManager::instance->activate(power_id, &e->stats, pursue_pos);
 			e->stats.power_ticks[power_slot] = e->stats.power_cooldown[power_slot];
 			e->stats.cooldown_ticks = e->stats.cooldown;
 
@@ -480,7 +480,7 @@ void BehaviorStandard::updateState() {
 		case ENEMY_POWER:
 
 			power_id = e->stats.power_index[e->stats.activated_powerslot];
-			power_state = e->powers->powers[power_id].new_state;
+			power_state = PowerManager::instance->powers[power_id].new_state;
 
 			// animation based on power type
 			if (power_state == POWSTATE_SWING) e->setAnimation("melee");
@@ -533,7 +533,7 @@ void BehaviorStandard::updateState() {
 			}
 			if (e->activeAnimation->isSecondLastFrame()) {
 				if (percentChance(e->stats.power_chance[ON_DEATH]))
-					e->powers->activate(e->stats.power_index[ON_DEATH], &e->stats, e->stats.pos);
+					PowerManager::instance->activate(e->stats.power_index[ON_DEATH], &e->stats, e->stats.pos);
 			}
 			if (e->activeAnimation->isLastFrame()) {
 				e->stats.corpse = true; // puts renderable under object layer
@@ -553,7 +553,7 @@ void BehaviorStandard::updateState() {
 			}
 			if (e->activeAnimation->isSecondLastFrame()) {
 				if (percentChance(e->stats.power_chance[ON_DEATH]))
-					e->powers->activate(e->stats.power_index[ON_DEATH], &e->stats, e->stats.pos);
+					PowerManager::instance->activate(e->stats.power_index[ON_DEATH], &e->stats, e->stats.pos);
 			}
 			if (e->activeAnimation->isLastFrame()) e->stats.corpse = true; // puts renderable under object layer
 

--- a/src/EffectManager.h
+++ b/src/EffectManager.h
@@ -38,7 +38,6 @@ class Avatar;
 class EnemyManager;
 class Hazard;
 class MapCollision;
-class PowerManager;
 
 class Effect{
 public:

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -39,8 +39,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 using namespace std;
 
 
-Enemy::Enemy(PowerManager *_powers, MapRenderer *_map, EnemyManager *_em) : Entity(_powers, _map) {
-	powers = _powers;
+Enemy::Enemy(MapRenderer *_map, EnemyManager *_em) : Entity(_map) {
 	enemies = _em;
 
 	stats.cur_state = ENEMY_STANCE;
@@ -200,7 +199,7 @@ void Enemy::CheckSummonSustained() {
 	//if minion was raised by a spawn power
 	if(summoned && stats.hero_ally) {
 
-		Power *spawn_power = &powers->powers[summoned_power_index];
+		Power *spawn_power = &PowerManager::instance->powers[summoned_power_index];
 
 		int max_summons = 0;
 

--- a/src/Enemy.h
+++ b/src/Enemy.h
@@ -38,13 +38,12 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 class EnemyBehavior;
 class Hazard;
-class PowerManager;
 class MapRenderer;
 
 class Enemy : public Entity {
 
 public:
-	Enemy(PowerManager *_powers, MapRenderer *_map, EnemyManager *_em);
+	Enemy(MapRenderer *_map, EnemyManager *_em);
 	Enemy(const Enemy& e);
 	~Enemy();
 	bool lineOfSight();

--- a/src/EnemyManager.h
+++ b/src/EnemyManager.h
@@ -37,7 +37,6 @@ class EnemyManager {
 private:
 
 	MapRenderer *map;
-	PowerManager *powers;
 
 	void loadSounds(const std::string& type_id);
 	void loadAnimations(Enemy *e);
@@ -60,7 +59,7 @@ private:
 	std::vector<Enemy> prototypes;
 
 public:
-	EnemyManager(PowerManager *_powers, MapRenderer *_map);
+	EnemyManager(MapRenderer *_map);
 	~EnemyManager();
 	void handleNewMap();
 	void handleSpawn();

--- a/src/Entity.h
+++ b/src/Entity.h
@@ -39,7 +39,7 @@ protected:
 	SDL_Surface *sprites;
 
 public:
-	Entity(PowerManager *_powers, MapRenderer*);
+	Entity(MapRenderer*);
 	Entity(const Entity&);
 	virtual ~Entity();
 
@@ -66,7 +66,6 @@ public:
 
 	MapRenderer* map;
 	StatBlock stats;
-	PowerManager *powers;
 };
 
 #endif

--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -32,6 +32,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "Settings.h"
 #include "UtilsFileSystem.h"
 #include "UtilsParsing.h"
+#include "PowerManager.h"
 
 #include <algorithm>
 
@@ -462,6 +463,8 @@ void GameStateLoad::logic() {
 }
 
 void GameStateLoad::logicLoading() {
+    //Initialise Singletons
+	PowerManager::init();
 	// load an existing game
 	GameStatePlay* play = new GameStatePlay();
 	play->resetGame();

--- a/src/GameStatePlay.h
+++ b/src/GameStatePlay.h
@@ -46,7 +46,6 @@ class LootManager;
 class MapRenderer;
 class MenuManager;
 class NPCManager;
-class PowerManager;
 class QuestLog;
 class WidgetLabel;
 
@@ -73,7 +72,6 @@ class GameStatePlay : public GameState {
 private:
 	Enemy *enemy;
 
-	PowerManager *powers;
 	ItemManager *items;
 	CampaignManager *camp;
 	MapRenderer *map;

--- a/src/HazardManager.cpp
+++ b/src/HazardManager.cpp
@@ -31,8 +31,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 using namespace std;
 
-HazardManager::HazardManager(PowerManager *_powers, Avatar *_hero, EnemyManager *_enemies) {
-	powers = _powers;
+HazardManager::HazardManager(Avatar *_hero, EnemyManager *_enemies) {
 	hero = _hero;
 	enemies = _enemies;
 }
@@ -64,8 +63,8 @@ void HazardManager::logic() {
 			target.x = (int)(h[i]->pos.x);
 			target.y = (int)(h[i]->pos.y);
 
-			powers->activate(h[i]->wall_power, h[i]->src_stats, target);
-			if (powers->powers[h[i]->wall_power].directional) powers->hazards.back()->animationKind = h[i]->animationKind;
+			PowerManager::instance->activate(h[i]->wall_power, h[i]->src_stats, target);
+			if (PowerManager::instance->powers[h[i]->wall_power].directional) PowerManager::instance->hazards.back()->animationKind = h[i]->animationKind;
 
 		}
 
@@ -146,9 +145,9 @@ void HazardManager::logic() {
 void HazardManager::checkNewHazards() {
 
 	// check PowerManager for hazards
-	while (!powers->hazards.empty()) {
-		Hazard *new_haz = powers->hazards.front();
-		powers->hazards.pop();
+	while (!PowerManager::instance->hazards.empty()) {
+		Hazard *new_haz = PowerManager::instance->hazards.front();
+		PowerManager::instance->hazards.pop();
 		//new_haz->setCollision(collider);
 
 		h.push_back(new_haz);

--- a/src/HazardManager.h
+++ b/src/HazardManager.h
@@ -40,9 +40,8 @@ class HazardManager {
 private:
 	Avatar *hero;
 	EnemyManager *enemies;
-	PowerManager *powers;
 public:
-	HazardManager(PowerManager *_powers, Avatar *_hero, EnemyManager *_enemies);
+	HazardManager(Avatar *_hero, EnemyManager *_enemies);
 	~HazardManager();
 	void logic();
 	void expire(int index);

--- a/src/MenuActionBar.cpp
+++ b/src/MenuActionBar.cpp
@@ -41,8 +41,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 using namespace std;
 
 
-MenuActionBar::MenuActionBar(PowerManager *_powers, StatBlock *_hero, SDL_Surface *_icons) {
-	powers = _powers;
+MenuActionBar::MenuActionBar(StatBlock *_hero, SDL_Surface *_icons) {
 	hero = _hero;
 	icons = _icons;
 
@@ -284,7 +283,7 @@ void MenuActionBar::render() {
 	src.w = src.h = ICON_SIZE;
 	for (int i=0; i<12; i++) {
 		if (hotkeys[i] != 0) {
-			const Power &power = powers->getPower(hotkeys[i]);
+			const Power &power = PowerManager::instance->getPower(hotkeys[i]);
 			slot_enabled[i] = (hero->hero_cooldown[hotkeys[i]] == 0)
 							  && (slot_item_count[i] != 0)
 							  && !hero->effects.stun
@@ -343,7 +342,7 @@ void MenuActionBar::renderCooldowns() {
 
 			// Wipe from bottom to top
 			if (hero->hero_cooldown[hotkeys[i]]) {
-				item_src.h = (ICON_SIZE * hero->hero_cooldown[hotkeys[i]]) / powers->powers[hotkeys[i]].cooldown;
+				item_src.h = (ICON_SIZE * hero->hero_cooldown[hotkeys[i]]) / PowerManager::instance->powers[hotkeys[i]].cooldown;
 			}
 
 			// SDL_BlitSurface will write to these Rects, so make a copy
@@ -383,7 +382,7 @@ TooltipData MenuActionBar::checkTooltip(Point mouse) {
 	for (int i=0; i<12; i++) {
 		if (hotkeys[i] != 0) {
 			if (isWithin(slots[i]->pos, mouse)) {
-				tip.addText(powers->powers[hotkeys[i]].name);
+				tip.addText(PowerManager::instance->powers[hotkeys[i]].name);
 			}
 		}
 	}

--- a/src/MenuActionBar.h
+++ b/src/MenuActionBar.h
@@ -55,7 +55,6 @@ private:
     SDL_Surface *attention;
 
 	StatBlock *hero;
-	PowerManager *powers;
 	SDL_Rect src;
 
 	WidgetLabel *labels[16];
@@ -63,7 +62,7 @@ private:
 
 public:
 
-	MenuActionBar(PowerManager *_powers, StatBlock *hero, SDL_Surface *icons);
+	MenuActionBar(StatBlock *hero, SDL_Surface *icons);
 	~MenuActionBar();
 	void loadGraphics();
 	void renderAttention(int menu_id);

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -38,10 +38,9 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 using namespace std;
 
 
-MenuInventory::MenuInventory(ItemManager *_items, StatBlock *_stats, PowerManager *_powers) {
+MenuInventory::MenuInventory(ItemManager *_items, StatBlock *_stats) {
 	items = _items;
 	stats = _stats;
-	powers = _powers;
 	MAX_EQUIPPED = 4;
 	MAX_CARRIED = 64;
 	visible = false;
@@ -404,21 +403,21 @@ void MenuInventory::activate(InputState * input) {
 	else if (items->items[inventory[CARRIED][slot].item].type == "consumable") {
 
 		//don't use untransform item if hero is not transformed
-		if (powers->powers[items->items[inventory[CARRIED][slot].item].power].spawn_type == "untransform" && !stats->transformed) return;
+		if (PowerManager::instance->powers[items->items[inventory[CARRIED][slot].item].power].spawn_type == "untransform" && !stats->transformed) return;
 
 		//check for power cooldown
 		if (stats->hero_cooldown[items->items[inventory[CARRIED][slot].item].power] > 0) return;
-		else stats->hero_cooldown[items->items[inventory[CARRIED][slot].item].power] = powers->powers[items->items[inventory[CARRIED][slot].item].power].cooldown;
+		else stats->hero_cooldown[items->items[inventory[CARRIED][slot].item].power] = PowerManager::instance->powers[items->items[inventory[CARRIED][slot].item].power].cooldown;
 
 		// if this item requires targeting it can't be used this way
-		if (!powers->powers[items->items[inventory[CARRIED][slot].item].power].requires_targeting) {
+		if (!PowerManager::instance->powers[items->items[inventory[CARRIED][slot].item].power].requires_targeting) {
 
-			unsigned used_item_count = powers->used_items.size();
-			unsigned used_equipped_item_count = powers->used_equipped_items.size();
-			powers->activate(items->items[inventory[CARRIED][slot].item].power, stats, nullpt);
+			unsigned used_item_count = PowerManager::instance->used_items.size();
+			unsigned used_equipped_item_count = PowerManager::instance->used_equipped_items.size();
+			PowerManager::instance->activate(items->items[inventory[CARRIED][slot].item].power, stats, nullpt);
 			// Remove any used items from the queue of items to be removed. We will destroy the items here.
-			if (used_item_count < powers->used_items.size()) powers->used_items.pop_back();
-			if (used_equipped_item_count < powers->used_equipped_items.size()) powers->used_equipped_items.pop_back();
+			if (used_item_count < PowerManager::instance->used_items.size()) PowerManager::instance->used_items.pop_back();
+			if (used_equipped_item_count < PowerManager::instance->used_equipped_items.size()) PowerManager::instance->used_equipped_items.pop_back();
 			inventory[CARRIED].substract(slot);
 		}
 		else {
@@ -763,7 +762,7 @@ void MenuInventory::applyEquipment(ItemStack *equipped) {
 	for (unsigned i=0; i<stats->powers_list_items.size(); ++i) {
 		int id = stats->powers_list_items[i];
 		// stats->hp > 0 is hack to keep on_death revive passives working
-		if (powers->powers[id].passive && stats->hp > 0)
+		if (PowerManager::instance->powers[id].passive && stats->hp > 0)
 			stats->effects.removeEffectPassive(id);
 	}
 	stats->powers_list_items.clear();
@@ -850,10 +849,10 @@ void MenuInventory::applyItemStats(ItemStack *equipped) {
 		// apply various bonuses
 		unsigned bonus_counter = 0;
 		while (bonus_counter < item.bonus_stat.size() && item.bonus_stat[bonus_counter] != "") {
-			int id = powers->getIdFromTag(item.bonus_stat[bonus_counter]);
+			int id = PowerManager::instance->getIdFromTag(item.bonus_stat[bonus_counter]);
 
 			if (id > 0)
-				stats->effects.addEffect(id, powers->powers[id].icon, 0, item.bonus_val[bonus_counter], powers->powers[id].effect_type, powers->powers[id].animation_name, powers->powers[id].effect_additive, true, -1, powers->powers[id].effect_render_above, 0, SOURCE_TYPE_HERO);
+				stats->effects.addEffect(id, PowerManager::instance->powers[id].icon, 0, item.bonus_val[bonus_counter], PowerManager::instance->powers[id].effect_type, PowerManager::instance->powers[id].animation_name, PowerManager::instance->powers[id].effect_additive, true, -1, PowerManager::instance->powers[id].effect_render_above, 0, SOURCE_TYPE_HERO);
 
 			bonus_counter++;
 		}
@@ -862,7 +861,7 @@ void MenuInventory::applyItemStats(ItemStack *equipped) {
 		if (item.power > 0) {
 			stats->powers_list_items.push_back(item.power);
 			if (stats->effects.triggered_others)
-				powers->activateSinglePassive(stats,item.power);
+				PowerManager::instance->activateSinglePassive(stats,item.power);
 		}
 
 	}
@@ -893,10 +892,10 @@ void MenuInventory::applyItemSetBonuses(ItemStack *equipped) {
 		for (bonus_counter=0; bonus_counter<temp_set.bonus.size(); bonus_counter++) {
 			if (temp_set.bonus[bonus_counter].requirement != quantity[k]) continue;
 
-			int id = powers->getIdFromTag(temp_set.bonus[bonus_counter].bonus_stat);
+			int id = PowerManager::instance->getIdFromTag(temp_set.bonus[bonus_counter].bonus_stat);
 
 			if (id > 0)
-				stats->effects.addEffect(id, powers->powers[id].icon, 0, temp_set.bonus[bonus_counter].bonus_val, powers->powers[id].effect_type, powers->powers[id].animation_name, powers->powers[id].effect_additive, true, -1, powers->powers[id].effect_render_above, 0, SOURCE_TYPE_HERO);
+				stats->effects.addEffect(id, PowerManager::instance->powers[id].icon, 0, temp_set.bonus[bonus_counter].bonus_val, PowerManager::instance->powers[id].effect_type, PowerManager::instance->powers[id].animation_name, PowerManager::instance->powers[id].effect_additive, true, -1, PowerManager::instance->powers[id].effect_render_above, 0, SOURCE_TYPE_HERO);
 		}
 	}
 }

--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -46,7 +46,6 @@ class MenuInventory : public Menu {
 private:
 	ItemManager *items;
 	StatBlock *stats;
-	PowerManager *powers;
 
 	void loadGraphics();
 	int areaOver(Point mouse);
@@ -69,7 +68,7 @@ private:
 	SDL_Color color_high;
 
 public:
-	MenuInventory(ItemManager *items, StatBlock *stats, PowerManager *powers);
+	MenuInventory(ItemManager *items, StatBlock *stats);
 	~MenuInventory();
 	void update();
 	void logic();

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -45,9 +45,8 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "PowerManager.h"
 #include "SharedResources.h"
 
-MenuManager::MenuManager(PowerManager *_powers, StatBlock *_stats, CampaignManager *_camp, ItemManager *_items)
+MenuManager::MenuManager(StatBlock *_stats, CampaignManager *_camp, ItemManager *_items)
 	: icons(NULL)
-	, powers(_powers)
 	, stats(_stats)
 	, camp(_camp)
 	, tip_buf()
@@ -97,7 +96,7 @@ MenuManager::MenuManager(PowerManager *_powers, StatBlock *_stats, CampaignManag
 	menus.push_back(effects); // menus[3]
 	hudlog = new MenuHUDLog();
 	menus.push_back(hudlog); // menus[4]
-	act = new MenuActionBar(powers, stats, icons);
+	act = new MenuActionBar(stats, icons);
 	menus.push_back(act); // menus[5]
 	enemy = new MenuEnemy();
 	menus.push_back(enemy); // menus[6]
@@ -111,9 +110,9 @@ MenuManager::MenuManager(PowerManager *_powers, StatBlock *_stats, CampaignManag
 	menus.push_back(mini); // menus[10]
 	chr = new MenuCharacter(stats);
 	menus.push_back(chr); // menus[11]
-	inv = new MenuInventory(items, stats, powers);
+	inv = new MenuInventory(items, stats);
 	menus.push_back(inv); // menus[12]
-	pow = new MenuPowers(stats, powers, icons);
+	pow = new MenuPowers(stats, icons);
 	menus.push_back(pow); // menus[13]
 	log = new MenuLog();
 	menus.push_back(log); // menus[14]
@@ -813,7 +812,7 @@ void MenuManager::logic() {
 		act->slot_item_count[i] = -1;
 
 		if (act->hotkeys[i] != -1) {
-			int item_id = powers->powers[act->hotkeys[i]].requires_item;
+			int item_id = PowerManager::instance->powers[act->hotkeys[i]].requires_item;
 			if (item_id != -1 && items->items[item_id].type == "consumable") {
 				act->slot_item_count[i] = inv->getItemCountCarried(item_id);
 				if (act->slot_item_count[i] == 0) {
@@ -884,7 +883,7 @@ void MenuManager::render() {
 		if (drag_src == DRAG_SRC_INVENTORY || drag_src == DRAG_SRC_VENDOR || drag_src == DRAG_SRC_STASH)
 			items->renderIcon(drag_stack, inpt->mouse.x - ICON_SIZE/2, inpt->mouse.y - ICON_SIZE/2, ICON_SIZE);
 		else if (drag_src == DRAG_SRC_POWERS || drag_src == DRAG_SRC_ACTIONBAR)
-			renderIcon(powers->powers[drag_power].icon, inpt->mouse.x-ICON_SIZE/2, inpt->mouse.y-ICON_SIZE/2);
+			renderIcon(PowerManager::instance->powers[drag_power].icon, inpt->mouse.x-ICON_SIZE/2, inpt->mouse.y-ICON_SIZE/2);
 	}
 
 }
@@ -958,7 +957,7 @@ void MenuManager::handleKeyboardTooltips() {
 				keyb_tip_buf_inv = keyb_tip_new_inv;
 			}
 			tip->render(keyb_tip_buf_inv, inpt->mouse, STYLE_FLOAT);
-		}	
+		}
 	}
 
 	if (act->tablist.getCurrent() != -1) {

--- a/src/MenuManager.h
+++ b/src/MenuManager.h
@@ -64,7 +64,6 @@ private:
 
 	SDL_Surface *icons;
 
-	PowerManager *powers;
 	StatBlock *stats;
 	CampaignManager *camp;
 
@@ -90,7 +89,7 @@ private:
 	void handleKeyboardNavigation();
 
 public:
-	MenuManager(PowerManager *powers, StatBlock *stats, CampaignManager *camp, ItemManager *items);
+	MenuManager(StatBlock *stats, CampaignManager *camp, ItemManager *items);
 	MenuManager(const MenuManager &copy); // not implemented
 	~MenuManager();
 	void logic();

--- a/src/MenuPowers.cpp
+++ b/src/MenuPowers.cpp
@@ -46,12 +46,11 @@ MenuPowers *MenuPowers::getInstance() {
 }
 
 
-MenuPowers::MenuPowers(StatBlock *_stats, PowerManager *_powers, SDL_Surface *_icons) {
+MenuPowers::MenuPowers(StatBlock *_stats, SDL_Surface *_icons) {
 
 	int id;
 
 	stats = _stats;
-	powers = _powers;
 	icons = _icons;
 
 	overlay_disabled = NULL;
@@ -226,7 +225,7 @@ void MenuPowers::loadGraphics() {
 	}
 	for (unsigned int i=0; i<slots.size(); i++) {
 
-		slots[i] = new WidgetSlot(icons, powers->powers[power_cell[i].id].icon);
+		slots[i] = new WidgetSlot(icons, PowerManager::instance->powers[power_cell[i].id].icon);
 		slots[i]->pos.x = power_cell[i].pos.x;
 		slots[i]->pos.y = power_cell[i].pos.y;
 		tablist.add(slots[i]);
@@ -313,7 +312,7 @@ int MenuPowers::click(Point mouse) {
 		int active_tab = tabControl->getActiveTab();
 		for (unsigned i=0; i<power_cell.size(); i++) {
 			if (isWithin(slots[i]->pos, mouse) && (power_cell[i].tab == active_tab)) {
-				if (requirementsMet(power_cell[i].id) && !powers->powers[power_cell[i].id].passive) return power_cell[i].id;
+				if (requirementsMet(power_cell[i].id) && !PowerManager::instance->powers[power_cell[i].id].passive) return power_cell[i].id;
 				else return 0;
 			}
 		}
@@ -322,7 +321,7 @@ int MenuPowers::click(Point mouse) {
 	else {
 		for (unsigned i=0; i<power_cell.size(); i++) {
 			if (isWithin(slots[i]->pos, mouse)) {
-				if (requirementsMet(power_cell[i].id) && !powers->powers[power_cell[i].id].passive) return power_cell[i].id;
+				if (requirementsMet(power_cell[i].id) && !PowerManager::instance->powers[power_cell[i].id].passive) return power_cell[i].id;
 				else return 0;
 			}
 		}
@@ -366,7 +365,7 @@ bool MenuPowers::unlockClick(Point mouse) {
 void MenuPowers::logic() {
 	short points_used = 0;
 	for (unsigned i=0; i<power_cell.size(); i++) {
-		if (powers->powers[power_cell[i].id].passive) {
+		if (PowerManager::instance->powers[power_cell[i].id].passive) {
 			bool unlocked_power = find(stats->powers_list.begin(), stats->powers_list.end(), power_cell[i].id) != stats->powers_list.end();
 			vector<int>::iterator it = find(stats->powers_passive.begin(), stats->powers_passive.end(), power_cell[i].id);
 			if (it != stats->powers_passive.end()) {
@@ -381,7 +380,7 @@ void MenuPowers::logic() {
 				power_cell[i].passive_on = true;
 				// for passives without special triggers, we need to trigger them here
 				if (stats->effects.triggered_others)
-					powers->activateSinglePassive(stats, power_cell[i].id);
+					PowerManager::instance->activateSinglePassive(stats, power_cell[i].id);
 			}
 		}
 		if (power_cell[i].requires_point &&
@@ -489,15 +488,15 @@ TooltipData MenuPowers::checkTooltip(Point mouse) {
 		if ((tabs_count > 1) && (tabControl->getActiveTab() != power_cell[i].tab)) continue;
 
 		if (isWithin(slots[i]->pos, mouse)) {
-			tip.addText(powers->powers[power_cell[i].id].name);
-			if (powers->powers[power_cell[i].id].passive) tip.addText("Passive");
-			tip.addText(powers->powers[power_cell[i].id].description);
+			tip.addText(PowerManager::instance->powers[power_cell[i].id].name);
+			if (PowerManager::instance->powers[power_cell[i].id].passive) tip.addText("Passive");
+			tip.addText(PowerManager::instance->powers[power_cell[i].id].description);
 
-			if (powers->powers[power_cell[i].id].requires_physical_weapon)
+			if (PowerManager::instance->powers[power_cell[i].id].requires_physical_weapon)
 				tip.addText(msg->get("Requires a physical weapon"));
-			else if (powers->powers[power_cell[i].id].requires_mental_weapon)
+			else if (PowerManager::instance->powers[power_cell[i].id].requires_mental_weapon)
 				tip.addText(msg->get("Requires a mental weapon"));
-			else if (powers->powers[power_cell[i].id].requires_offense_weapon)
+			else if (PowerManager::instance->powers[power_cell[i].id].requires_offense_weapon)
 				tip.addText(msg->get("Requires an offense weapon"));
 
 
@@ -582,23 +581,23 @@ TooltipData MenuPowers::checkTooltip(Point mouse) {
 
 			// Required Power Tooltip
 			if ((power_cell[i].requires_power != 0) && !(requirementsMet(power_cell[i].requires_power))) {
-				tip.addText(msg->get("Requires Power: %s", powers->powers[power_cell[i].requires_power].name), color_penalty);
+				tip.addText(msg->get("Requires Power: %s", PowerManager::instance->powers[power_cell[i].requires_power].name), color_penalty);
 			}
 			else if ((power_cell[i].requires_power != 0) && (requirementsMet(power_cell[i].requires_power))) {
-				tip.addText(msg->get("Requires Power: %s", powers->powers[power_cell[i].requires_power].name));
+				tip.addText(msg->get("Requires Power: %s", PowerManager::instance->powers[power_cell[i].requires_power].name));
 			}
 
 			// add mana cost
-			if (powers->powers[power_cell[i].id].requires_mp > 0) {
-				tip.addText(msg->get("Costs %d MP", powers->powers[power_cell[i].id].requires_mp));
+			if (PowerManager::instance->powers[power_cell[i].id].requires_mp > 0) {
+				tip.addText(msg->get("Costs %d MP", PowerManager::instance->powers[power_cell[i].id].requires_mp));
 			}
 			// add health cost
-			if (powers->powers[power_cell[i].id].requires_hp > 0) {
-				tip.addText(msg->get("Costs %d HP", powers->powers[power_cell[i].id].requires_hp));
+			if (PowerManager::instance->powers[power_cell[i].id].requires_hp > 0) {
+				tip.addText(msg->get("Costs %d HP", PowerManager::instance->powers[power_cell[i].id].requires_hp));
 			}
 			// add cooldown time
-			if (powers->powers[power_cell[i].id].cooldown > 0) {
-				tip.addText(msg->get("Cooldown: %d seconds", powers->powers[power_cell[i].id].cooldown / MAX_FRAMES_PER_SEC));
+			if (PowerManager::instance->powers[power_cell[i].id].cooldown > 0) {
+				tip.addText(msg->get("Cooldown: %d seconds", PowerManager::instance->powers[power_cell[i].id].cooldown / MAX_FRAMES_PER_SEC));
 			}
 
 			return tip;

--- a/src/MenuPowers.h
+++ b/src/MenuPowers.h
@@ -82,7 +82,6 @@ public:
 class MenuPowers : public Menu {
 private:
 	StatBlock *stats;
-	PowerManager *powers;
 	std::vector<Power_Menu_Cell> power_cell;
 
 	SDL_Surface *background;
@@ -119,7 +118,7 @@ private:
 
 public:
 	static MenuPowers *getInstance();
-	MenuPowers(StatBlock *_stats, PowerManager *_powers, SDL_Surface *_icons);
+	MenuPowers(StatBlock *_stats, SDL_Surface *_icons);
 	~MenuPowers();
 	void update();
 	void logic();

--- a/src/NPC.cpp
+++ b/src/NPC.cpp
@@ -43,7 +43,7 @@ std::vector<SoundManager::SoundID> vox_quests;
 std::vector<std::vector<Event_Component> > dialog;
 
 NPC::NPC(MapRenderer *_map, ItemManager *_items)
-	: Entity(NULL,_map)
+	: Entity(_map)
 	, items(_items)
 	, name("")
 	, gfx("")

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -55,6 +55,8 @@ PowerManager::PowerManager()
 	loadPowers();
 }
 
+PowerManager* PowerManager::instance;
+
 void PowerManager::loadPowers() {
 	FileParser infile;
 	if (!infile.open("powers/powers.txt", true, false))

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -317,6 +317,8 @@ public:
 
 class PowerManager {
 private:
+    PowerManager();
+	~PowerManager();
 
 	MapCollision *collider;
 
@@ -340,8 +342,9 @@ private:
 	void payPowerCost(int power_index, StatBlock *src_stats);
 
 public:
-	PowerManager();
-	~PowerManager();
+	static void init(){PowerManager::instance = new PowerManager();};
+	static void finalize(){delete PowerManager::instance;};
+	static PowerManager* instance;
 
 	std::string log_msg;
 

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -288,11 +288,11 @@ void GameStatePlay::loadGame() {
 						fprintf(stderr, "Hotkey power on position %d has negative id, skipping\n", i);
 						hotkeys[i] = 0;
 					}
-					else if ((unsigned)hotkeys[i] > powers->powers.size()-1) {
-						fprintf(stderr, "Hotkey power id (%d) out of bounds 1-%d, skipping\n", hotkeys[i], (int)powers->powers.size());
+					else if ((unsigned)hotkeys[i] > PowerManager::instance->powers.size()-1) {
+						fprintf(stderr, "Hotkey power id (%d) out of bounds 1-%d, skipping\n", hotkeys[i], (int)PowerManager::instance->powers.size());
 						hotkeys[i] = 0;
 					}
-					else if (hotkeys[i] != 0 && powers->powers[hotkeys[i]].name == "") {
+					else if (hotkeys[i] != 0 && PowerManager::instance->powers[hotkeys[i]].name == "") {
 						fprintf(stderr, "Hotkey power with id=%d, found on position %d does not exist, skipping\n", hotkeys[i], i);
 						hotkeys[i] = 0;
 					}


### PR DESCRIPTION
This is an implementation of https://github.com/clintbellanger/flare-engine/issues/621 for the PowerManager class. Basically it slightly simplifies the way that other classes access the PowerManager class by removing the need to store local references to the class instance and passing duplicate data around between the classes.

This is applicable for all classes for which there will only be one instance e.g. Avatar, EnemyManager etc but I'm just showing it here for PowerManager so that it can be reviewed. If its found to be agreeable, it would be implemented for all of those other classes as well. I would estimate about 200 lines of code removed as a result, with an ongoing benefit for future development.

My only critique of the code is that "PowerManager::instance" is more long winded to type than "powers", but perhaps there's a way to shorten it.

Thoughts?
