### PR TITLE
Move damage and absorb calculations to StatBlock

### DIFF
--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -768,10 +768,6 @@ void MenuInventory::applyEquipment(ItemStack *equipped) {
 	}
 	stats->powers_list_items.clear();
 
-	// the default for weapons/absorb are not added to equipped items
-	// later this function they are applied if the defaults aren't met
-	stats->calcBaseDmgAndAbs();
-
 	// reset wielding vars
 	stats->wielding_physical = false;
 	stats->wielding_mental = false;
@@ -783,24 +779,6 @@ void MenuInventory::applyEquipment(ItemStack *equipped) {
 	applyItemStats(equipped);
 	applyItemSetBonuses(equipped);
 
-	// increase damage and absorb to minimum amounts
-	if (stats->dmg_melee_min < stats->dmg_melee_min_default)
-		stats->dmg_melee_min = stats->dmg_melee_min_default;
-	if (stats->dmg_melee_max < stats->dmg_melee_max_default)
-		stats->dmg_melee_max = stats->dmg_melee_max_default;
-	if (stats->dmg_ranged_min < stats->dmg_ranged_min_default)
-		stats->dmg_ranged_min = stats->dmg_ranged_min_default;
-	if (stats->dmg_ranged_max < stats->dmg_ranged_max_default)
-		stats->dmg_ranged_max = stats->dmg_ranged_max_default;
-	if (stats->dmg_ment_min < stats->dmg_ment_min_default)
-		stats->dmg_ment_min = stats->dmg_ment_min_default;
-	if (stats->dmg_ment_max < stats->dmg_ment_max_default)
-		stats->dmg_ment_max = stats->dmg_ment_max_default;
-	if (stats->absorb_min < stats->absorb_min_default)
-		stats->absorb_min = stats->absorb_min_default;
-	if (stats->absorb_max < stats->absorb_max_default)
-		stats->absorb_max = stats->absorb_max_default;
-
 	// update stat display
 	stats->refresh_stats = true;
 }
@@ -808,18 +786,24 @@ void MenuInventory::applyEquipment(ItemStack *equipped) {
 void MenuInventory::applyItemStats(ItemStack *equipped) {
 	const vector<Item> &pc_items = items->items;
 
+	// reset additional values
+	stats->dmg_melee_min_add = stats->dmg_melee_max_add = 0;
+	stats->dmg_ment_min_add = stats->dmg_ment_max_add = 0;
+	stats->dmg_ranged_min_add = stats->dmg_ranged_max_add = 0;
+	stats->absorb_min_add = stats->absorb_max_add = 0;
+
 	// apply stats from all items
 	for (int i=0; i<MAX_EQUIPPED; i++) {
 		int item_id = equipped[i].item;
 		const Item &item = pc_items[item_id];
 
 		// apply base stats
-		stats->dmg_melee_min += item.dmg_melee_min;
-		stats->dmg_melee_max += item.dmg_melee_max;
-		stats->dmg_ranged_min += item.dmg_ranged_min;
-		stats->dmg_ranged_max += item.dmg_ranged_max;
-		stats->dmg_ment_min += item.dmg_ment_min;
-		stats->dmg_ment_max += item.dmg_ment_max;
+		stats->dmg_melee_min_add += item.dmg_melee_min;
+		stats->dmg_melee_max_add += item.dmg_melee_max;
+		stats->dmg_ranged_min_add += item.dmg_ranged_min;
+		stats->dmg_ranged_max_add += item.dmg_ranged_max;
+		stats->dmg_ment_min_add += item.dmg_ment_min;
+		stats->dmg_ment_max_add += item.dmg_ment_max;
 
 		// TODO: add a separate wielding stat to items
 		// e.g. we might want a ring that gives bonus ranged damage but
@@ -844,8 +828,8 @@ void MenuInventory::applyItemStats(ItemStack *equipped) {
 		}
 
 		// apply absorb bonus
-		stats->absorb_min += item.abs_min;
-		stats->absorb_max += item.abs_max;
+		stats->absorb_min_add += item.abs_min;
+		stats->absorb_max_add += item.abs_max;
 
 		// apply various bonuses
 		unsigned bonus_counter = 0;

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -103,6 +103,14 @@ StatBlock::StatBlock()
 	, dmg_ranged_max(4)
 	, absorb_min(0)
 	, absorb_max(0)
+	, dmg_melee_min_add(0)
+	, dmg_melee_max_add(0)
+	, dmg_ment_min_add(0)
+	, dmg_ment_max_add(0)
+	, dmg_ranged_min_add(0)
+	, dmg_ranged_max_add(0)
+	, absorb_min_add(0)
+	, absorb_max_add(0)
 	, speed(14)
 	, dspeed(10)
 	, wielding_physical(false)
@@ -441,11 +449,32 @@ void StatBlock::calcBaseDmgAndAbs() {
 	int off0 = get_offense() -1;
 	int def0 = get_defense() -1;
 
-	dmg_melee_min = dmg_melee_max = bonus_per_physical * phys0;
-	dmg_ment_min = dmg_ment_max = bonus_per_mental * ment0;
-	dmg_ranged_min = dmg_ranged_max = bonus_per_offense * off0;
-	absorb_min = absorb_max = bonus_per_defense * def0;
+	dmg_melee_min = (bonus_per_physical * phys0) + dmg_melee_min_add;
+	dmg_melee_max = (bonus_per_physical * phys0) + dmg_melee_max_add;
+	dmg_ment_min = (bonus_per_mental * ment0) + dmg_ment_min_add;
+	dmg_ment_max = (bonus_per_mental * ment0) + dmg_ment_max_add;
+	dmg_ranged_min = (bonus_per_offense * off0) + dmg_ranged_min_add;
+	dmg_ranged_max = (bonus_per_offense * off0) + dmg_ranged_max_add;
+	absorb_min = (bonus_per_defense * def0) + absorb_min_add;
+	absorb_max = (bonus_per_defense * def0) + absorb_max_add;
 
+	// increase damage and absorb to minimum amounts
+	if (dmg_melee_min < dmg_melee_min_default)
+		dmg_melee_min = dmg_melee_min_default;
+	if (dmg_melee_max < dmg_melee_max_default)
+		dmg_melee_max = dmg_melee_max_default;
+	if (dmg_ranged_min < dmg_ranged_min_default)
+		dmg_ranged_min = dmg_ranged_min_default;
+	if (dmg_ranged_max < dmg_ranged_max_default)
+		dmg_ranged_max = dmg_ranged_max_default;
+	if (dmg_ment_min < dmg_ment_min_default)
+		dmg_ment_min = dmg_ment_min_default;
+	if (dmg_ment_max < dmg_ment_max_default)
+		dmg_ment_max = dmg_ment_max_default;
+	if (absorb_min < absorb_min_default)
+		absorb_min = absorb_min_default;
+	if (absorb_max < absorb_max_default)
+		absorb_max = absorb_max_default;
 }
 
 /**
@@ -463,6 +492,12 @@ void StatBlock::recalc_alt() {
 
 	if (hero) {
 		// calculate primary stats
+		// refresh the character menu if there has been a change
+		if (get_physical() != physical_character + effects.bonus_physical ||
+			get_mental() != mental_character + effects.bonus_mental ||
+			get_offense() != offense_character + effects.bonus_offense ||
+			get_defense() != defense_character + effects.bonus_defense) refresh_stats = true;
+
 		offense_additional = effects.bonus_offense;
 		defense_additional = effects.bonus_defense;
 		physical_additional = effects.bonus_physical;
@@ -471,6 +506,9 @@ void StatBlock::recalc_alt() {
 		int ment0 = get_mental() -1;
 		int off0 = get_offense() -1;
 		int def0 = get_defense() -1;
+
+		// calculate damage and absorb from base stats + item additions
+		calcBaseDmgAndAbs();
 
 		// calculate other stats
 		maxhp = hp_base + (hp_per_level * lev0) + (hp_per_physical * phys0) + effects.bonus_hp + (effects.bonus_hp_percent * (hp_base + (hp_per_level * lev0) + (hp_per_physical * phys0)) / 100);

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -211,6 +211,15 @@ public:
 	int absorb_min;
 	int absorb_max;
 
+	int dmg_melee_min_add;
+	int dmg_melee_max_add;
+	int dmg_ment_min_add;
+	int dmg_ment_max_add;
+	int dmg_ranged_min_add;
+	int dmg_ranged_max_add;
+	int absorb_min_add;
+	int absorb_max_add;
+
 	int speed;
 	int dspeed;
 


### PR DESCRIPTION
Fixes #472 

The planned StatBlock refactoring would not have fixed this issue by itself, so I decided to fix this before that gets done. When refactoring the StatBlock, the `*_add` variables I added here will probably become `effects.bonus[*]`.
