### PR TITLE
Fix teleporting to spawn map when a map is missing

### DIFF
--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -253,11 +253,7 @@ void GameStatePlay::checkTeleport() {
 
 		map->collider.unblock(pc->stats.pos.x, pc->stats.pos.y);
 
-		if (map->teleportation) {
-			map->cam.x = pc->stats.pos.x = map->teleport_destination.x;
-			map->cam.y = pc->stats.pos.y = map->teleport_destination.y;
-		}
-		else {
+		if (!map->teleportation) {
 			map->cam.x = pc->stats.pos.x = pc->stats.teleport_destination.x;
 			map->cam.y = pc->stats.pos.y = pc->stats.teleport_destination.y;
 		}
@@ -271,10 +267,14 @@ void GameStatePlay::checkTeleport() {
 		}
 
 		// process intermap teleport
-		if (map->teleportation && map->teleport_mapname != "") {
+		// beware of infinite teleporting
+		while (map->teleportation && map->teleport_mapname != "") {
+			map->teleportation = false;
 			map->executeOnMapExitEvents();
 			showLoading();
 			map->load(map->teleport_mapname);
+			map->cam.x = pc->stats.pos.x = map->teleport_destination.x;
+			map->cam.y = pc->stats.pos.y = map->teleport_destination.y;
 			enemies->handleNewMap();
 			hazards->handleNewMap();
 			loot->handleNewMap();
@@ -324,7 +324,6 @@ void GameStatePlay::checkTeleport() {
 
 		map->collider.block(pc->stats.pos.x, pc->stats.pos.y, false);
 
-		map->teleportation = false;
 		pc->stats.teleportation = false; // teleport spell
 
 	}


### PR DESCRIPTION
Previously when a map was missing, the player would be teleported to the
spawn map. They'd be stuck there because the teleportation flag had been
set to false, since they already teleported once. This commit allows for
a sort of "chain teleporting", where we can keep doing intermap
teleports until reaching an endpoint.
