### PR TITLE
Rename class EnemyBehavior to EntityBehavior (for review/discussion only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ Set (FLARE_SOURCES
 	./src/CombatText.cpp
 	./src/EffectManager.cpp
 	./src/Enemy.cpp
-	./src/EnemyBehavior.cpp
+	./src/EntityBehavior.cpp
 	./src/EnemyGroupManager.cpp
 	./src/EnemyManager.cpp
 	./src/FileParser.cpp

--- a/src/BehaviorStandard.cpp
+++ b/src/BehaviorStandard.cpp
@@ -25,7 +25,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "StatBlock.h"
 #include "UtilsMath.h"
 
-BehaviorStandard::BehaviorStandard(Enemy *_e, EnemyManager *_em) : EnemyBehavior(_e, _em) {
+BehaviorStandard::BehaviorStandard(Enemy *_e, EnemyManager *_em) : EntityBehavior(_e, _em) {
 	los = false;
 	hero_dist = 0;
 	target_dist = 0;

--- a/src/BehaviorStandard.h
+++ b/src/BehaviorStandard.h
@@ -19,13 +19,13 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #ifndef BEHAVIOR_STANDARD_H
 #define BEHAVIOR_STANDARD_H
 
-#include "EnemyBehavior.h"
+#include "EntityBehavior.h"
 #include "Utils.h"
 
 class Enemy;
 class Point;
 
-class BehaviorStandard : public EnemyBehavior {
+class BehaviorStandard : public EntityBehavior {
 private:
 
 	// logic steps

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -26,7 +26,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "BehaviorStandard.h"
 #include "CampaignManager.h"
 #include "CommonIncludes.h"
-#include "EnemyBehavior.h"
+#include "EntityBehavior.h"
 #include "Enemy.h"
 #include "Hazard.h"
 #include "MapRenderer.h"

--- a/src/Enemy.h
+++ b/src/Enemy.h
@@ -31,7 +31,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include <queue>
 
-class EnemyBehavior;
+class EntityBehavior;
 class Hazard;
 class PowerManager;
 class MapRenderer;
@@ -55,7 +55,7 @@ public:
 	virtual Renderable getRender();
 
 	Hazard *haz;
-	EnemyBehavior *eb;
+	EntityBehavior *eb;
 	EnemyManager *enemies;
 
 	// other flags

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -23,7 +23,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "AnimationSet.h"
 #include "Animation.h"
 #include "SharedResources.h"
-#include "EnemyBehavior.h"
+#include "EntityBehavior.h"
 #include "BehaviorStandard.h"
 #include "BehaviorAlly.h"
 #include "Avatar.h"

--- a/src/EntityBehavior.cpp
+++ b/src/EntityBehavior.cpp
@@ -15,25 +15,17 @@ You should have received a copy of the GNU General Public License along with
 FLARE.  If not, see http://www.gnu.org/licenses/
 */
 
-/**
- * class EnemyBehavior
- *
- * Interface for enemy behaviors.
- * The behavior object is a component of Enemy.
- * Make AI decisions (movement, actions) for enemies.
- */
+#include "EntityBehavior.h"
 
-#include "EnemyBehavior.h"
-
-EnemyBehavior::EnemyBehavior(Enemy *_e, EnemyManager *_em) {
+EntityBehavior::EntityBehavior(Enemy *_e, EnemyManager *_em) {
 	e = _e;
 	enemies = _em;
 }
 
-void EnemyBehavior::logic() {
+void EntityBehavior::logic() {
 
 }
 
-EnemyBehavior::~EnemyBehavior() {
+EntityBehavior::~EntityBehavior() {
 
 }

--- a/src/EntityBehavior.h
+++ b/src/EntityBehavior.h
@@ -16,29 +16,28 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 */
 
 /**
- * class EnemyBehavior
+ * class EntityBehavior
  *
- * Interface for enemy behaviors.
- * The behavior object is a component of Enemy.
- * Make AI decisions (movement, actions) for enemies.
+ * Interface for entity behaviors.
+ * The behavior object is a component of Entities.
+ * Make AI decisions (movement, actions) for entities.
  */
 
-
 #pragma once
-#ifndef ENEMY_BEHAVIOR_H
-#define ENEMY_BEHAVIOR_H
+#ifndef ENTITY_BEHAVIOR_H
+#define ENTITY_BEHAVIOR_H
 
 #include "EnemyManager.h"
 
 class Enemy;
 
-class EnemyBehavior {
+class EntityBehavior {
 protected:
 	Enemy *e;
 	EnemyManager *enemies;
 public:
-	EnemyBehavior(Enemy *_e, EnemyManager *_em);
-	virtual ~EnemyBehavior();
+	EntityBehavior(Enemy *_e, EnemyManager *_em);
+	virtual ~EntityBehavior();
 	virtual void logic();
 };
 


### PR DESCRIPTION
The class BehaviorAlly is inheriting from BehaviorStandard, which itself
inherited from EnemyBehavior before.
As allies are no enemies, we should go with the broader term
EntityBehavior.

Technically speaking this abstract base class just works with enemy objects
and not on the abstract entity objects, which is missleading on the
technical side.
