### PR TITLE
Don't spawn multiple enemies on one tile

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -118,6 +118,9 @@ void MapRenderer::push_enemy_group(Map_Group g) {
 		else
 			allowed_misses--;
 	}
+	if (enemies_to_spawn)
+		fprintf(stderr, "Could not spawn all enemies in group at (x=%d,y=%d,w=%d,h=%d), %d missing\n",
+		g.pos.x, g.pos.y, g.area.x, g.area.y, enemies_to_spawn);
 }
 
 int MapRenderer::load(string filename) {


### PR DESCRIPTION
Having an enemy group defined here: (Definitely more enemies than there is space for them)
![bug1](https://f.cloud.github.com/assets/455868/496001/57e34e54-bbd7-11e2-85c6-12d3ca4aaaaa.png)
It looks like this: Multiple enemies on one tile.
![bug1a](https://f.cloud.github.com/assets/455868/496002/597d854a-bbd7-11e2-8705-2e09c273160a.png)

Resolved:
![bug1b](https://f.cloud.github.com/assets/455868/496004/5b565b3a-bbd7-11e2-8ff0-305bcb33974a.png)
