### PR TITLE
Make WidgetSlot configurable to have continuous activation or not.

### DIFF
--- a/src/MenuActionBar.cpp
+++ b/src/MenuActionBar.cpp
@@ -64,6 +64,7 @@ MenuActionBar::MenuActionBar(PowerManager *_powers, StatBlock *_hero, SDL_Surfac
 
 	for (unsigned int i=0; i<12; i++) {
 		slots[i] = new WidgetSlot(icons, -1, ACTIONBAR);
+		slots[i]->continuous = true;
 		tablist.add(slots[i]);
 	}
 	for (unsigned int i=0; i<4; i++) {

--- a/src/WidgetSlot.cpp
+++ b/src/WidgetSlot.cpp
@@ -37,7 +37,8 @@ WidgetSlot::WidgetSlot(SDL_Surface *_icons, int _icon_id, int _ACTIVATE)
 	, ACTIVATE(_ACTIVATE)
 	, enabled(true)
 	, checked(false)
-	, pressed(false) {
+	, pressed(false)
+	, continuous(false) {
 	focusable = true;
 	pos.x = pos.y = 0;
 	pos.w = ICON_SIZE;
@@ -66,7 +67,7 @@ CLICK_TYPE WidgetSlot::checkClick(int x, int y) {
 	// disabled slots can't be clicked;
 	if (!enabled) return NO_CLICK;
 
-	if (pressed && checked && (inpt->lock[MAIN2] || inpt->lock[ACTIVATE])) return ACTIVATED;
+	if (continuous && pressed && checked && (inpt->lock[MAIN2] || inpt->lock[ACTIVATE])) return ACTIVATED;
 
 	// main button already in use, new click not allowed
 	if (inpt->lock[MAIN1]) return NO_CLICK;

--- a/src/WidgetSlot.h
+++ b/src/WidgetSlot.h
@@ -63,6 +63,7 @@ public:
 	bool enabled;
 	bool checked;
 	bool pressed;
+	bool continuous;	// allow holding key to keep slot activated
 };
 
 #endif


### PR DESCRIPTION
Fixes #681. Allow continuous activation only for 0-11 ActionBar slots.
