### PR TITLE
Check inventory stacks for slots with a quantity of 0 during save/load

### DIFF
--- a/src/ItemStorage.cpp
+++ b/src/ItemStorage.cpp
@@ -245,6 +245,19 @@ bool ItemStorage::contain(int item) {
 	return false;
 }
 
+/**
+ * Clear slots that contain an item, but have a quantity of 0
+ */
+void ItemStorage::clean() {
+	for (int i=0; i<slot_number; i++) {
+		if (storage[i].item > 0 && storage[i].quantity < 1) {
+			fprintf(stderr,"Removing item with id %d, which has a quantity of 0\n",storage[i].item);
+			storage[i].item = 0;
+			storage[i].quantity = 0;
+		}
+	}
+}
+
 ItemStorage::~ItemStorage() {
 	delete[] storage;
 }

--- a/src/ItemStorage.h
+++ b/src/ItemStorage.h
@@ -49,6 +49,7 @@ public:
 	bool remove(int item);
 	void sort();
 	void clear();
+	void clean();
 
 	bool full(int item);
 	int count(int item);

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -534,7 +534,10 @@ void MenuInventory::activate(Point position) {
  * @param slot Slot number where it will try to store the item
  */
 void MenuInventory::add(ItemStack stack, int area, int slot, bool play_sound) {
-	if (stack.quantity > 0 && play_sound)
+	if (stack.quantity < 1)
+		return;
+
+	if (play_sound)
 		items->playSound(stack.item);
 
 	if (stack.item != 0) {

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -52,6 +52,10 @@ void GameStatePlay::saveGame() {
 	// game slots are currently 1-4
 	if (game_slot == 0) return;
 
+	// remove items with zero quantity from inventory
+	menu->inv->inventory[EQUIPMENT].clean();
+	menu->inv->inventory[CARRIED].clean();
+
 	ofstream outfile;
 
 	stringstream ss;
@@ -309,6 +313,10 @@ void GameStatePlay::loadGame() {
 
 	menu->inv->inventory[EQUIPMENT].fillEquipmentSlots();
 	menu->inv->addCurrency(currency);
+
+	// remove items with zero quantity from inventory
+	menu->inv->inventory[EQUIPMENT].clean();
+	menu->inv->inventory[CARRIED].clean();
 
 	// Load stash
 	loadStash();


### PR DESCRIPTION
This fixes a stack of 0 gold being added to the player's inventoty in
flare-game.
