### PR TITLE
Fix party buff issue

### DIFF
--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -231,7 +231,7 @@ void EnemyManager::handleSpawn() {
 
 		//now apply post effects to the spawned enemy
 		if(e->stats.summoned_power_index > 0)
-			powers->effect(&e->stats, e->stats.summoned_power_index,e->stats.hero_ally ? SOURCE_TYPE_HERO : SOURCE_TYPE_ENEMY);
+			powers->effect(&e->stats, (espawn.summoner != NULL ? espawn.summoner : &e->stats), e->stats.summoned_power_index, e->stats.hero_ally ? SOURCE_TYPE_HERO : SOURCE_TYPE_ENEMY);
 
 		//apply party passives
 		//synchronise tha party passives in the pc stat block with the passives in the allies stat blocks
@@ -266,7 +266,7 @@ void EnemyManager::handlePartyBuff() {
 
 		for (unsigned int i=0; i < enemies.size(); i++) {
 			if(enemies[i]->stats.hero_ally && enemies[i]->stats.hp > 0 && (buff_power->buff_party_power_id == 0 || buff_power->buff_party_power_id == enemies[i]->stats.summoned_power_index)) {
-				powers->effect(&enemies[i]->stats,power_index,SOURCE_TYPE_HERO);
+				powers->effect(&enemies[i]->stats, &pc->stats, power_index,SOURCE_TYPE_HERO);
 			}
 		}
 	}

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -281,8 +281,8 @@ bool Entity::takeHit(const Hazard &h) {
 	// after effects
 	if (stats.hp > 0 && dmg > 0) {
 
-		if (h.mod_power > 0) powers->effect(&stats, h.mod_power,h.source_type);
-		powers->effect(&stats, h.power_index,h.source_type);
+		if (h.mod_power > 0) powers->effect(&stats, h.src_stats, h.mod_power,h.source_type);
+		powers->effect(&stats, h.src_stats, h.power_index,h.source_type);
 
 		if (!stats.effects.immunity) {
 			if (stats.effects.forced_move) {

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -589,7 +589,7 @@ void PowerManager::buff(int power_index, StatBlock *src_stats, Point target) {
 	// handle all other effects
 	if (powers[power_index].buff || (powers[power_index].buff_party && src_stats->hero_ally)) {
 		int source_type = src_stats->hero ? SOURCE_TYPE_HERO : (src_stats->hero_ally ? SOURCE_TYPE_ALLY : SOURCE_TYPE_ENEMY);
-		effect(src_stats, power_index, source_type);
+		effect(src_stats, src_stats, power_index, source_type);
 	}
 
 	if (powers[power_index].buff_party && !powers[power_index].passive) {
@@ -632,7 +632,7 @@ void PowerManager::playSound(int power_index, StatBlock *src_stats) {
 		snd->play(sfx[powers[power_index].sfx_index]);
 }
 
-bool PowerManager::effect(StatBlock *src_stats, int power_index, int source_type) {
+bool PowerManager::effect(StatBlock *src_stats, StatBlock *caster_stats, int power_index, int source_type) {
 	for (unsigned i=0; i<powers[power_index].post_effects.size(); i++) {
 
 		int effect_index = powers[power_index].post_effects[i].id;
@@ -643,9 +643,9 @@ bool PowerManager::effect(StatBlock *src_stats, int power_index, int source_type
 			if (powers[effect_index].effect_type == "shield") {
 				// charge shield to max ment weapon damage * damage multiplier
 				if(powers[power_index].mod_damage_mode == STAT_MODIFIER_MODE_MULTIPLY)
-					magnitude = src_stats->get(STAT_DMG_MENT_MAX) * powers[power_index].mod_damage_value_min / 100;
+					magnitude = caster_stats->get(STAT_DMG_MENT_MAX) * powers[power_index].mod_damage_value_min / 100;
 				else if(powers[power_index].mod_damage_mode == STAT_MODIFIER_MODE_ADD)
-					magnitude = src_stats->get(STAT_DMG_MENT_MAX) + powers[power_index].mod_damage_value_min;
+					magnitude = caster_stats->get(STAT_DMG_MENT_MAX) + powers[power_index].mod_damage_value_min;
 				else if(powers[power_index].mod_damage_mode == STAT_MODIFIER_MODE_ABSOLUTE)
 					magnitude = randBetween(powers[power_index].mod_damage_value_min, powers[power_index].mod_damage_value_max);
 
@@ -653,7 +653,7 @@ bool PowerManager::effect(StatBlock *src_stats, int power_index, int source_type
 			}
 			else if (powers[effect_index].effect_type == "heal") {
 				// heal for ment weapon damage * damage multiplier
-				magnitude = randBetween(src_stats->get(STAT_DMG_MENT_MIN), src_stats->get(STAT_DMG_MENT_MAX));
+				magnitude = randBetween(caster_stats->get(STAT_DMG_MENT_MIN), caster_stats->get(STAT_DMG_MENT_MAX));
 
 				if(powers[power_index].mod_damage_mode == STAT_MODIFIER_MODE_MULTIPLY)
 					magnitude = magnitude * powers[power_index].mod_damage_value_min / 100;

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -341,7 +341,7 @@ public:
 	bool canUsePower(unsigned id) const;
 	bool hasValidTarget(int power_index, StatBlock *src_stats, Point target);
 	bool spawn(const std::string& enemy_type, Point target);
-	bool effect(StatBlock *src_stats, int power_index, int source_type);
+	bool effect(StatBlock *src_stats, StatBlock *caster_stats, int power_index, int source_type);
 	void activatePassives(StatBlock *src_stats);
 	void activateSinglePassive(StatBlock *src_stats, int id);
 	int getIdFromTag(std::string tag);


### PR DESCRIPTION
Shield and Heal buffs don't work propely when casting on party members because the target StatBlok is used to calculate the buff magnitude. Changed so that it uses the casters StatBlock instead.
