### PR TITLE
Spawn power attribute spawn_level

### DIFF
--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -195,8 +195,8 @@ void EnemyManager::handleSpawn() {
 		e->stats.summoned_power_index = espawn.summon_power_index;
 
 		if(espawn.summoner != NULL){
-            e->stats.summoner = espawn.summoner;
-            espawn.summoner->summons.push_back(&(e->stats));
+			e->stats.summoner = espawn.summoner;
+			espawn.summoner->summons.push_back(&(e->stats));
 		}
 
 		e->type = espawn.type;
@@ -219,36 +219,36 @@ void EnemyManager::handleSpawn() {
 
 		//Set level
 		if(e->stats.summoned_power_index != 0){
-            if(powers->powers[e->stats.summoned_power_index].spawn_level_mode == SPAWN_LEVEL_MODE_FIXED)
-                e->stats.level = powers->powers[e->stats.summoned_power_index].spawn_level_qty;
+			if(powers->powers[e->stats.summoned_power_index].spawn_level_mode == SPAWN_LEVEL_MODE_FIXED)
+				e->stats.level = powers->powers[e->stats.summoned_power_index].spawn_level_qty;
 
-            if(powers->powers[e->stats.summoned_power_index].spawn_level_mode == SPAWN_LEVEL_MODE_LEVEL){
-                if(e->stats.summoner != NULL && powers->powers[e->stats.summoned_power_index].spawn_level_every != 0){
-                    e->stats.level = powers->powers[e->stats.summoned_power_index].spawn_level_qty
-                        * (e->stats.summoner->level / powers->powers[e->stats.summoned_power_index].spawn_level_every);
-                }
-            }
+			if(powers->powers[e->stats.summoned_power_index].spawn_level_mode == SPAWN_LEVEL_MODE_LEVEL){
+				if(e->stats.summoner != NULL && powers->powers[e->stats.summoned_power_index].spawn_level_every != 0){
+					e->stats.level = powers->powers[e->stats.summoned_power_index].spawn_level_qty
+							* (e->stats.summoner->level / powers->powers[e->stats.summoned_power_index].spawn_level_every);
+				}
+			}
 
-            if(powers->powers[e->stats.summoned_power_index].spawn_level_mode == SPAWN_LEVEL_MODE_STAT){
-                if(e->stats.summoner != NULL && powers->powers[e->stats.summoned_power_index].spawn_level_every != 0){
-                    int stat_val = 0;
-                    if(powers->powers[e->stats.summoned_power_index].spawn_level_stat == SPAWN_LEVEL_STAT_DEFENSE)
-                        stat_val = e->stats.summoner->get_defense();
-                    if(powers->powers[e->stats.summoned_power_index].spawn_level_stat == SPAWN_LEVEL_STAT_OFFENSE)
-                        stat_val = e->stats.summoner->get_offense();
-                    if(powers->powers[e->stats.summoned_power_index].spawn_level_stat == SPAWN_LEVEL_STAT_MENTAL)
-                        stat_val = e->stats.summoner->get_mental();
-                    if(powers->powers[e->stats.summoned_power_index].spawn_level_stat == SPAWN_LEVEL_STAT_PHYSICAL)
-                        stat_val = e->stats.summoner->get_physical();
+			if(powers->powers[e->stats.summoned_power_index].spawn_level_mode == SPAWN_LEVEL_MODE_STAT){
+				if(e->stats.summoner != NULL && powers->powers[e->stats.summoned_power_index].spawn_level_every != 0){
+					int stat_val = 0;
+					if(powers->powers[e->stats.summoned_power_index].spawn_level_stat == SPAWN_LEVEL_STAT_DEFENSE)
+						stat_val = e->stats.summoner->get_defense();
+					if(powers->powers[e->stats.summoned_power_index].spawn_level_stat == SPAWN_LEVEL_STAT_OFFENSE)
+						stat_val = e->stats.summoner->get_offense();
+					if(powers->powers[e->stats.summoned_power_index].spawn_level_stat == SPAWN_LEVEL_STAT_MENTAL)
+						stat_val = e->stats.summoner->get_mental();
+					if(powers->powers[e->stats.summoned_power_index].spawn_level_stat == SPAWN_LEVEL_STAT_PHYSICAL)
+						stat_val = e->stats.summoner->get_physical();
 
-                    e->stats.level = powers->powers[e->stats.summoned_power_index].spawn_level_qty
-                        * (stat_val / powers->powers[e->stats.summoned_power_index].spawn_level_every);
-                }
-            }
+					e->stats.level = powers->powers[e->stats.summoned_power_index].spawn_level_qty
+							* (stat_val / powers->powers[e->stats.summoned_power_index].spawn_level_every);
+				}
+			}
 
-            if(e->stats.level < 1) e->stats.level = 1;
+			if(e->stats.level < 1) e->stats.level = 1;
 
-            e->stats.applyEffects();
+			e->stats.applyEffects();
 		}
 
 		if(mapr->collider.is_valid_position(espawn.pos.x, espawn.pos.y, e->stats.movement_type, false) || !e->stats.hero_ally) {

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -371,14 +371,14 @@ void PowerManager::loadPowers() {
 				if(powers[input_id].spawn_level_mode != SPAWN_LEVEL_MODE_FIXED) {
 					powers[input_id].spawn_level_every = eatFirstInt(infile.val,',');
 
-                    if(powers[input_id].spawn_level_mode == SPAWN_LEVEL_MODE_STAT) {
-                        std::string stat = eatFirstString(infile.val,',');
-                        if (stat == "physical") powers[input_id].spawn_level_stat = SPAWN_LEVEL_STAT_PHYSICAL;
-                        else if (stat == "mental") powers[input_id].spawn_level_stat = SPAWN_LEVEL_STAT_MENTAL;
-                        else if (stat == "offense") powers[input_id].spawn_level_stat = SPAWN_LEVEL_STAT_OFFENSE;
-                        else if (stat == "defense") powers[input_id].spawn_level_stat = SPAWN_LEVEL_STAT_DEFENSE;
-                        else fprintf(stderr, "unknown spawn_level_stat %s\n", stat.c_str());
-                    }
+					if(powers[input_id].spawn_level_mode == SPAWN_LEVEL_MODE_STAT) {
+						std::string stat = eatFirstString(infile.val,',');
+						if (stat == "physical") powers[input_id].spawn_level_stat = SPAWN_LEVEL_STAT_PHYSICAL;
+						else if (stat == "mental") powers[input_id].spawn_level_stat = SPAWN_LEVEL_STAT_MENTAL;
+						else if (stat == "offense") powers[input_id].spawn_level_stat = SPAWN_LEVEL_STAT_OFFENSE;
+						else if (stat == "defense") powers[input_id].spawn_level_stat = SPAWN_LEVEL_STAT_DEFENSE;
+						else fprintf(stderr, "unknown spawn_level_stat %s\n", stat.c_str());
+					}
 				}
 			}
 		}

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -311,9 +311,9 @@ public:
 		, spawn_limit_every(1)
 		, spawn_limit_stat(SPAWN_LIMIT_STAT_MENTAL)
 		, spawn_level_mode(SPAWN_LEVEL_MODE_DEFAULT)
-	    , spawn_level_qty(0)
-	    , spawn_level_every(0)
-	    , spawn_level_stat(SPAWN_LEVEL_STAT_MENTAL)
+		, spawn_level_qty(0)
+		, spawn_level_every(0)
+		, spawn_level_stat(SPAWN_LEVEL_STAT_MENTAL)
 	{}
 
 };


### PR DESCRIPTION
Allows a spawn to use the default enemy level, specify a specific level, use a level based on the summoners level or use a level based on the summoners stat points. Follows the same format as spawn_limit
