### PR TITLE
Cumulative bonus XP

### DIFF
--- a/src/CampaignManager.cpp
+++ b/src/CampaignManager.cpp
@@ -42,6 +42,7 @@ CampaignManager::CampaignManager()
 	, currency(NULL)
 	, hero(NULL)
 	, quest_update(true)
+	, bonus_xp(0.0)
 {}
 
 void CampaignManager::clearAll() {
@@ -156,7 +157,9 @@ void CampaignManager::rewardCurrency(int amount) {
 }
 
 void CampaignManager::rewardXP(int amount, bool show_message) {
-	hero->xp += (amount * (100 + hero->get(STAT_XP_GAIN))) / 100;
+	bonus_xp += (amount * (100.0 + hero->get(STAT_XP_GAIN))) / 100.0;
+	hero->xp += (int)bonus_xp;
+	bonus_xp -= (int)bonus_xp;
 	hero->refresh_stats = true;
 	if (show_message) addMsg(msg->get("You receive %d XP.", amount));
 }

--- a/src/CampaignManager.h
+++ b/src/CampaignManager.h
@@ -61,6 +61,7 @@ public:
 	StatBlock *hero;
 
 	bool quest_update;
+	float bonus_xp;		// Fractional XP points not yet awarded (e.g. killing 1 XP enemies with a +25% ring)
 };
 
 


### PR DESCRIPTION
Fixes the rounding issue where the +25% XP ring gives no real gain
on kills of less that 4 XP (e.g. level 1 enemies).
