### PR TITLE
Corrections to ally collision

### DIFF
--- a/src/BehaviorAlly.cpp
+++ b/src/BehaviorAlly.cpp
@@ -30,6 +30,7 @@ void BehaviorAlly::findTarget() {
 		mapr->collider.unblock(e->stats.pos.x, e->stats.pos.y);
 		e->stats.pos.x = pc->stats.pos.x;
 		e->stats.pos.y = pc->stats.pos.y;
+		mapr->collider.block(e->stats.pos.x, e->stats.pos.y, true);
 		hero_dist = 0;
 	}
 
@@ -123,8 +124,11 @@ void BehaviorAlly::checkMoveStateStance() {
 
 void BehaviorAlly::checkMoveStateMove() {
 	//if close enough to hero, stop miving
-	if(hero_dist < ALLY_FOLLOW_DISTANCE_STOP && !e->stats.in_combat && !fleeing) {
-		e->newState(ENEMY_STANCE);
+	if((hero_dist < ALLY_FOLLOW_DISTANCE_STOP && !e->stats.in_combat && !fleeing)
+        || (target_dist < e->stats.melee_range && e->stats.in_combat && !fleeing)
+        || (move_to_safe_dist && target_dist >= e->stats.threat_range/2)) {
+            e->newState(ENEMY_STANCE);
+            move_to_safe_dist = false;
 	}
 
 	// try to continue moving

--- a/src/BehaviorStandard.cpp
+++ b/src/BehaviorStandard.cpp
@@ -468,7 +468,7 @@ void BehaviorStandard::checkMoveStateStance() {
 
 void BehaviorStandard::checkMoveStateMove() {
 	// close enough to the hero or is at a safe distance
-	if ((hero_dist < e->stats.melee_range) || (move_to_safe_dist && hero_dist >= e->stats.threat_range/2)) {
+	if ((target_dist < e->stats.melee_range && !fleeing) || (move_to_safe_dist && target_dist >= e->stats.threat_range/2)) {
 		e->newState(ENEMY_STANCE);
 		move_to_safe_dist = false;
 	}

--- a/src/MapCollision.cpp
+++ b/src/MapCollision.cpp
@@ -130,8 +130,11 @@ bool MapCollision::is_valid_tile(int tile_x, int tile_y, MOVEMENTTYPE movement_t
 	// outside the map isn't valid
 	if (is_outside_map(tile_x,tile_y)) return false;
 
-	if(is_hero && colmap[tile_x][tile_y] == BLOCKS_ENEMIES && !ENABLE_ALLY_COLLISION)
-		return true;
+	if(is_hero){
+        if(colmap[tile_x][tile_y] == BLOCKS_ENEMIES && !ENABLE_ALLY_COLLISION) return true;
+	}
+    else
+        if(colmap[tile_x][tile_y] == BLOCKS_ENEMIES) return false;
 
 	// occupied by an entity isn't valid
 	if (colmap[tile_x][tile_y] == BLOCKS_ENTITIES) return false;


### PR DESCRIPTION
Fixes an issue preventing an ally from blocking an enemy or ally.

Fixes an issue with no block being created for an ally.

Fixes an issue with allies and enemies moving towards its target even when already within melee range.
