### PR TITLE
Only use one trim() function in UtilsParsing

### DIFF
--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -94,7 +94,7 @@ bool FileParser::next() {
 	while (current_index < filenames.size()) {
 		while (infile.good()) {
 
-			line = getLine(infile);
+			line = trim(getLine(infile));
 
 			// skip ahead if this line is empty
 			if (line.length() == 0) continue;

--- a/src/FontEngine.cpp
+++ b/src/FontEngine.cpp
@@ -191,7 +191,7 @@ Point FontEngine::calc_size(const std::string& text_with_newlines, int width) {
 	}
 
 	height = height + getLineHeight();
-	builder.str(trim(builder.str(), ' ')); //removes whitespace that shouldn't be included in the size
+	builder.str(trim(builder.str())); //removes whitespace that shouldn't be included in the size
 	if (calc_width(builder.str()) > max_width) max_width = calc_width(builder.str());
 
 	Point size;

--- a/src/UtilsParsing.cpp
+++ b/src/UtilsParsing.cpp
@@ -44,23 +44,16 @@ bool isInt(const string& s) {
 	return true;
 }
 
-/**
- * trim: remove leading and trailing c from s
- */
-string trim(const string& s, char c) {
-	if (s.length() == 0) return "";
+string trim(string s, const string& delimiters) {
+	return trim_left_inplace(trim_right_inplace(s, delimiters), delimiters);
+}
 
-	unsigned int first = 0;
-	unsigned int last = s.length()-1;
+string trim_left_inplace(string s, const string& delimiters) {
+	return s.erase(0, s.find_first_not_of(delimiters));
+}
 
-	while (s.at(first) == c && first < s.length()-1) {
-		first++;
-	}
-	while (s.at(last) == c && last >= first && last > 0) {
-		last--;
-	}
-	if (first <= last) return s.substr(first,last-first+1);
-	return "";
+string trim_right_inplace(string s, const string& delimiters) {
+	return s.erase(s.find_last_not_of(delimiters) + 1);
 }
 
 /**
@@ -97,8 +90,8 @@ void parse_key_pair(const string& s, string &key, string &val) {
 	}
 	key = s.substr(0, separator);
 	val = s.substr(separator+1, s.length());
-	key = trim(key, ' ');
-	val = trim(val, ' ');
+	key = trim(key);
+	val = trim(val);
 }
 
 /**
@@ -253,18 +246,6 @@ unsigned long toUnsignedLong(const string& s, unsigned long  default_value) {
 	if (!(stringstream(s) >> result))
 		result = default_value;
 	return result;
-}
-
-string &trim_right_inplace(string &s, const string& delimiters = " \f\n\r\t\v") {
-	return s.erase(s.find_last_not_of(delimiters) + 1);
-}
-
-string& trim_left_inplace(string &s, const string& delimiters = " \f\n\r\t\v" ) {
-	return s.erase(0, s.find_first_not_of(delimiters));
-}
-
-string &trim(string &s, const string& delimiters = " \f\n\r\t\v") {
-	return trim_left_inplace(trim_right_inplace(s, delimiters), delimiters);
 }
 
 bool toBool(std::string value) {

--- a/src/UtilsParsing.h
+++ b/src/UtilsParsing.h
@@ -25,7 +25,9 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include <typeinfo>
 
 bool isInt(const std::string& s);
-std::string trim(const std::string& s, char c);
+std::string trim(std::string s, const std::string& delimiters = " \f\n\r\t\v");
+std::string trim_left_inplace(std::string s, const std::string& delimiters = " \f\n\r\t\v");
+std::string trim_right_inplace(std::string s, const std::string& delimiters = " \f\n\r\t\v");
 int parse_duration(const std::string& s);
 std::string parse_section_title(const std::string& s);
 void parse_key_pair(const std::string& s, std::string& key, std::string& val);


### PR DESCRIPTION
Closes #728

Also, use trim on the entire line in FileParser::next() so that sections
and comments can have whitespace around them.
