### PR TITLE
Block Powers menu when transformed

### DIFF
--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -581,9 +581,8 @@ void GameStatePlay::checkNotifications() {
 		menu->act->requires_attention[MENU_LOG] = true;
 	}
 
-	// if the player is transformed into a creature, don't show notifications for some menus
-	if (!pc->stats.humanoid) {
-		menu->act->requires_attention[MENU_CHARACTER] = false;
+	// if the player is transformed into a creature, don't notifications for the powers menu
+	if (pc->stats.transformed) {
 		menu->act->requires_attention[MENU_POWERS] = false;
 	}
 }

--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -528,7 +528,7 @@ void MenuCharacter::logic() {
 	int spent = stats->physical_character + stats->mental_character + stats->offense_character + stats->defense_character -4;
 	skill_points = (stats->level * stats->stat_points_per_level) - spent;
 
-	if (stats->hp > 0 && spent < (stats->level * stats->stat_points_per_level) && spent < stats->max_spendable_stat_points && stats->humanoid ) {
+	if (stats->hp > 0 && spent < (stats->level * stats->stat_points_per_level) && spent < stats->max_spendable_stat_points) {
 		if (stats->physical_character < stats->max_points_per_stat && show_upgrade[0]) {
 			upgradeButton[0]->enabled = true;
 			tablist.add(upgradeButton[0]);

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -551,7 +551,7 @@ void MenuManager::logic() {
 	}
 
 	// powers menu toggle
-	if (((inpt->pressing[POWERS] && !key_lock && !mouse_dragging && !keyboard_dragging) || clicking_powers) && stats->humanoid) {
+	if (((inpt->pressing[POWERS] && !key_lock && !mouse_dragging && !keyboard_dragging) || clicking_powers) && !stats->transformed) {
 		key_lock = true;
 		if (pow->visible) {
 			snd->play(pow->sfx_close);


### PR DESCRIPTION
Closes #734

Also allows for upgrading in MenuCharacter regardless of transform state.
