### PR TITLE
Loading the hero_options file is done across mods amendingly 

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -141,7 +141,7 @@ void Avatar::loadLayerDefinitions() {
 
 	FileParser infile;
 	// @CLASS Avatar|Description of engine/hero_options.txt
-	if (infile.open("engine/hero_options.txt")) {
+	if (infile.open("engine/hero_options.txt", true, false)) {
 		while(infile.next()) {
 			infile.val = infile.val + ',';
 

--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -158,7 +158,7 @@ GameStateLoad::GameStateLoad() : GameState() {
 
 	// get displayable types list
 	bool found_layer = false;
-	if (infile.open("engine/hero_options.txt")) {
+	if (infile.open("engine/hero_options.txt", true, false)) {
 		while(infile.next()) {
 			infile.val = infile.val + ',';
 

--- a/src/GameStateNew.cpp
+++ b/src/GameStateNew.cpp
@@ -213,7 +213,7 @@ void GameStateNew::loadPortrait(const string& portrait_filename) {
  */
 void GameStateNew::loadOptions(const string& filename) {
 	FileParser fin;
-	if (!fin.open("engine/" + filename)) return;
+	if (!fin.open("engine/" + filename, true, false)) return;
 
 	while (fin.next()) {
 		if (fin.key == "option") {


### PR DESCRIPTION
This enables custom hero portraits easily added via a mod, which just
extends the hero_options file by a line and adding a portrait.

Once this is in, have a look at https://github.com/stefanbeller/flare-engine/tree/customportrait
