### PR TITLE
Don't increase ref count when loading exisiting sounds

### DIFF
--- a/src/SoundManager.cpp
+++ b/src/SoundManager.cpp
@@ -225,7 +225,8 @@ void SoundManager::play(SoundManager::SoundID sid, std::string channel, Point po
 	}
 
 	// Let playback own a reference to prevent unloading playbacked sound.
-	it->second->refCnt++;
+	if (!loop)
+		it->second->refCnt++;
 
 	Mix_ChannelFinished(&channel_finished);
 	int c = Mix_PlayChannel(-1, it->second->chunk, (loop ? -1 : 0));


### PR DESCRIPTION
Fixes #760

The ref count for sounds is supposed to be 1 (representing the chunk
itself) + the number of playing instances. Increasing the ref count when
loading duplicate sounds caused a bug that prevented sounds that were
loaded in such a way from being unloaded.
