### PR TITLE
NPC requires_status and requires_not

### DIFF
--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -225,17 +225,20 @@ void Map::loadEnemyGroup(FileParser &infile, Map_Group *group) {
 }
 
 void Map::loadNPC(FileParser &infile) {
+	std::string s;
 	if (infile.key == "type") {
 		// @ATTR npc.type|string|Type of NPC
 		npcs.back().id = infile.val;
 	}
 	if (infile.key == "requires_status") {
-		// @ATTR npc.requires_status|string|Status required for NPC load
-		npcs.back().requires_status = infile.val;
+		// @ATTR npc.requires_status|string|Status required for NPC load. There can be multiple states, separated by comma
+		while ( (s = infile.nextValue()) != "")
+			npcs.back().requires_status.push_back(s);
 	}
-	if (infile.key == "requires_not") {
-		// @ATTR npc.requires_not|string|Status required to be missing for NPC load
-		npcs.back().requires_not = infile.val;
+	if (infile.key == "requires_not_status") {
+		// @ATTR npc.requires_not|string|Status required to be missing for NPC load. There can be multiple states, separated by comma
+		while ( (s = infile.nextValue()) != "")
+			npcs.back().requires_not_status.push_back(s);
 	}
 	else if (infile.key == "location") {
 		// @ATTR npc.location|[x(integer), y(integer)]|Location of NPC

--- a/src/Map.h
+++ b/src/Map.h
@@ -55,14 +55,14 @@ class Map_NPC {
 public:
 	std::string id;
 	Point pos;
-	std::string requires_status;
-	std::string requires_not;
+	std::vector<std::string> requires_status;
+	std::vector<std::string> requires_not_status;
 
 	Map_NPC()
 	: id("")
 	, pos()
-	, requires_status("")
-	, requires_not("")
+	, requires_status()
+	, requires_not_status()
 	{}
 };
 

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -76,17 +76,13 @@ void NPCManager::handleNewMap() {
 		mn = mapr->npcs.front();
 		mapr->npcs.pop();
 
-        if(mn.requires_status != "")
-        {
-            //if the requires ststus is not present, dont load the npc
-            if(!camp->checkStatus(mn.requires_status))
-                continue;
-        }
-        if(mn.requires_not != "")
-        {
-            if(camp->checkStatus(mn.requires_not))
-                continue;
-        }
+		for (unsigned i = 0; i < mn.requires_status.size(); ++i)
+			if (!camp->checkStatus(mn.requires_status[i]))
+				continue;
+
+		for (unsigned i = 0; i < mn.requires_not_status.size(); ++i)
+			if (camp->checkStatus(mn.requires_not_status[i]))
+				continue;
 
 		NPC *npc = new NPC();
 		npc->load(mn.id, stats->level);


### PR DESCRIPTION
Allows status requirements for loading of an NPC on a map. These are added to the npc in the map file. This provides the ability to relocate npcs with story progression.
