### PR TITLE
Menu powers hidden depending on quest status

### DIFF
--- a/src/MenuPowers.cpp
+++ b/src/MenuPowers.cpp
@@ -152,10 +152,10 @@ MenuPowers::MenuPowers(StatBlock *_stats, SDL_Surface *_icons) {
 				power_cell.back().requires_power = eatFirstInt(infile.val, ',');
 			}
 			else if (infile.key == "visible_requires_status") {
-				power_cell.back().visible_requires_status = eatFirstString(infile.val, ',');
+				power_cell.back().visible_requires_status.push_back(eatFirstString(infile.val, ','));
 			}
 			else if (infile.key == "visible_requires_not") {
-				power_cell.back().visible_requires_not = eatFirstString(infile.val, ',');
+				power_cell.back().visible_requires_not.push_back(eatFirstString(infile.val, ','));
 			}
 
 		}
@@ -677,7 +677,7 @@ void MenuPowers::renderPowers(int tab_num) {
 
 bool MenuPowers::powerIsVisible(short power_index) {
 
-    // power_index can be 0 during recursive call if requires_power is not defined.
+	// power_index can be 0 during recursive call if requires_power is not defined.
 	// Power with index 0 doesn't exist and is always enabled
 	if (power_index == 0) return true;
 
@@ -687,19 +687,15 @@ bool MenuPowers::powerIsVisible(short power_index) {
 	// If we didn't find power in power_menu, than it has no requirements
 	if (id == -1) return true;
 
-    if(power_cell[id].visible_requires_status != "")
-    {
-        if(!camp->checkStatus(power_cell[id].visible_requires_status))
-            return false;
-    }
+	for (unsigned i = 0; i < power_cell[id].visible_requires_status.size(); ++i)
+		if (!camp->checkStatus(power_cell[id].visible_requires_status[i]))
+			return false;
 
-    if(power_cell[id].visible_requires_not != "")
-    {
-        if(camp->checkStatus(power_cell[id].visible_requires_not))
-            return false;
-    }
+	for (unsigned i = 0; i < power_cell[id].visible_requires_not.size(); ++i)
+		if (camp->checkStatus(power_cell[id].visible_requires_not[i]))
+			return false;
 
-    return true;
+	return true;
 }
 
 

--- a/src/MenuPowers.h
+++ b/src/MenuPowers.h
@@ -53,27 +53,24 @@ public:
 	short requires_power;
 	bool requires_point;
 	bool passive_on;
-	std::string visible_requires_status;
-	std::string visible_requires_not;
-	Power_Menu_Cell() {
-		id = -1;
-		tab = 0;
-		pos.x = 0;
-		pos.y = 0;
-		requires_mentdef = 0;
-		requires_mentoff = 0;
-		requires_physoff = 0;
-		requires_physdef = 0;
-		requires_defense = 0;
-		requires_offense = 0;
-		requires_physical = 0;
-		requires_mental = 0;
-		requires_level = 0;
-		requires_power = 0;
-		requires_point = false;
-		passive_on = false;
-		visible_requires_status = "";
-		visible_requires_not = "";
+	std::vector<std::string> visible_requires_status;
+	std::vector<std::string> visible_requires_not;
+	Power_Menu_Cell()
+		: id(-1)
+		, tab(0)
+		, requires_physoff(0)
+		, requires_physdef(0)
+		, requires_mentoff(0)
+		, requires_mentdef(0)
+		, requires_defense(0)
+		, requires_offense(0)
+		, requires_physical(0)
+		, requires_mental(0)
+		, requires_level(0)
+		, requires_power(0)
+		, requires_point(false)
+		, passive_on(false)
+	{
 	}
 };
 


### PR DESCRIPTION
Attributes visible_requires_status and visible_requires_not for menu powers. This allows a power to be hidden until 'unlocked' by a quest completion.
