### PR TITLE
Move the player's max level to a config file

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -476,7 +476,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 	}
 
 	// check level up
-	if (stats.xp >= stats.xp_table[stats.level] && stats.level < MAX_CHARACTER_LEVEL) {
+	if (stats.xp >= stats.xp_table[stats.level] && stats.level < stats.level_max) {
 		stats.level_up = true;
 		stats.level++;
 		stringstream ss;

--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -457,7 +457,7 @@ void MenuCharacter::refreshStats() {
 
 	cstat[CSTAT_LEVEL].tip.clear();
 	cstat[CSTAT_LEVEL].tip.addText(msg->get("XP: %d", stats->xp));
-	if (stats->level < MAX_CHARACTER_LEVEL) {
+	if (stats->level < stats->level_max) {
 		cstat[CSTAT_LEVEL].tip.addText(msg->get("Next: %d", stats->xp_table[stats->level]));
 	}
 

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -70,9 +70,6 @@ const int ENEMY_JOIN_COMBAT = 14;
 // final shared states
 const int ENEMY_POWER = 15; // enemy performing a power. anim/sfx based on power
 
-
-const int MAX_CHARACTER_LEVEL = 32;
-
 class EnemyLoot {
 public:
 	int id;
@@ -129,8 +126,9 @@ public:
 	std::string sfx_prefix;
 
 	int level;
+	int level_max; // hero only
 	unsigned long xp;
-	unsigned long xp_table[MAX_CHARACTER_LEVEL+1];
+	std::vector<unsigned long> xp_table;
 	bool level_up;
 	bool check_title;
 	int stat_points_per_level;


### PR DESCRIPTION
Use `max_level=` in `engine/stats.txt`. The default is still 32.
