### PR TITLE
Define maximum level by xp table size instead of parameter

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -476,7 +476,7 @@ void Avatar::logic(int actionbar_power, bool restrictPowerUse) {
 	}
 
 	// check level up
-	if (stats.xp >= stats.xp_table[stats.level] && stats.level < stats.level_max) {
+	if (stats.level < (int)stats.xp_table.size() && stats.xp >= stats.xp_table[stats.level]) {
 		stats.level_up = true;
 		stats.level++;
 		stringstream ss;

--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -457,7 +457,7 @@ void MenuCharacter::refreshStats() {
 
 	cstat[CSTAT_LEVEL].tip.clear();
 	cstat[CSTAT_LEVEL].tip.addText(msg->get("XP: %d", stats->xp));
-	if (stats->level < stats->level_max) {
+	if (stats->level < (int)stats->xp_table.size()) {
 		cstat[CSTAT_LEVEL].tip.addText(msg->get("Next: %d", stats->xp_table[stats->level]));
 	}
 

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -58,7 +58,6 @@ StatBlock::StatBlock()
 	, name("")
 	, sfx_prefix("")
 	, level(0)
-	, level_max(32)
 	, xp(0)
 	, level_up(false)
 	, check_title(false)
@@ -621,16 +620,11 @@ void StatBlock::loadHeroStats() {
 		else if (infile.key == "cooldown_hit") {
 			cooldown_hit = value;
 		}
-		else if (infile.key == "max_level") {
-			level_max = value;
-		}
 	}
 	infile.close();
 	if (max_points_per_stat == 0) max_points_per_stat = max_spendable_stat_points / 4 + 1;
 	statsLoaded = true;
 
-	// Load the XP table as well
-	xp_table.resize(level_max, std::numeric_limits<int>::max());
 	if (!infile.open("engine/xp_table.txt"))
 		return;
 

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -126,7 +126,6 @@ public:
 	std::string sfx_prefix;
 
 	int level;
-	int level_max; // hero only
 	unsigned long xp;
 	std::vector<unsigned long> xp_table;
 	bool level_up;


### PR DESCRIPTION
I think this improves #780 even more, as it reduces the required config options, but learns the maximum level from the  actual xp level table.
