### PR TITLE
ItemManager: Remove unused constant

### DIFF
--- a/src/ItemManager.h
+++ b/src/ItemManager.h
@@ -46,8 +46,6 @@ const int ITEM_QUALITY_NORMAL = 1;
 const int ITEM_QUALITY_HIGH = 2;
 const int ITEM_QUALITY_EPIC = 3;
 
-const int ITEM_MAX_BONUSES = 8;
-
 class LootAnimation {
 public:
 	std::string name;


### PR DESCRIPTION
It is obsolete since 83a2ad11d6
(2012-08-15, Item: replace arrays by vector.)

Signed-off-by: Stefan Beller stefanbeller@googlemail.com
