### PR TITLE
Fix namespace clash with ::round()

### DIFF
--- a/src/Hazard.cpp
+++ b/src/Hazard.cpp
@@ -92,17 +92,17 @@ void Hazard::logic() {
 		activeAnimation->advanceFrame();
 
 	// handle movement
-	if (!(round(speed.x) == 0 && round(speed.y) == 0)) {
+	if (!(float_round(speed.x) == 0 && float_round(speed.y) == 0)) {
 		pos.x += speed.x;
 		pos.y += speed.y;
 
 		// very simplified collider, could skim around corners
 		// or even pass through thin walls if speed > tilesize
-		if (collider->is_wall(round(pos.x), round(pos.y))) {
+		if (collider->is_wall(float_round(pos.x), float_round(pos.y))) {
 			lifespan = 0;
 			hit_wall = true;
 
-			if (collider->is_outside_map(round(pos.x) >> TILE_SHIFT, round(pos.y) >> TILE_SHIFT))
+			if (collider->is_outside_map(float_round(pos.x) >> TILE_SHIFT, float_round(pos.y) >> TILE_SHIFT))
 				remove_now = true;
 		}
 	}
@@ -141,8 +141,8 @@ void Hazard::addEntity(Entity *ent) {
 void Hazard::addRenderable(vector<Renderable> &r, vector<Renderable> &r_dead) {
 	if (delay_frames == 0 && activeAnimation) {
 		Renderable re = activeAnimation->getCurrentFrame(animationKind);
-		re.map_pos.x = round(pos.x);
-		re.map_pos.y = round(pos.y);
+		re.map_pos.x = float_round(pos.x);
+		re.map_pos.y = float_round(pos.y);
 		(floor ? r_dead : r).push_back(re);
 	}
 }

--- a/src/MapCollision.cpp
+++ b/src/MapCollision.cpp
@@ -249,7 +249,7 @@ bool MapCollision::line_check(int x1, int y1, int x2, int y2, int check_type, MO
 		for (int i=0; i<steps; i++) {
 			x += step_x;
 			y += step_y;
-			if (is_wall(round(x), round(y)))
+			if (is_wall(float_round(x), float_round(y)))
 				return false;
 		}
 	}
@@ -257,7 +257,7 @@ bool MapCollision::line_check(int x1, int y1, int x2, int y2, int check_type, MO
 		for (int i=0; i<steps; i++) {
 			x += step_x;
 			y += step_y;
-			if (!is_valid_position(round(x), round(y), movement_type, false))
+			if (!is_valid_position(float_round(x), float_round(y), movement_type, false))
 				return false;
 		}
 	}

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -26,14 +26,14 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 using namespace std;
 
 
-int round(float f) {
+int float_round(float f) {
 	return (int)(f + 0.5);
 }
 
 Point round(FPoint fp) {
 	Point result;
-	result.x = round(fp.x);
-	result.y = round(fp.y);
+	result.x = float_round(fp.x);
+	result.y = float_round(fp.y);
 	return result;
 }
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -82,7 +82,7 @@ public:
 };
 
 // Utility Functions
-int round(float f);
+int float_round(float f);
 Point round(FPoint fp);
 Point screen_to_map(int x, int y, int camx, int camy);
 Point map_to_screen(int x, int y, int camx, int camy);


### PR DESCRIPTION
round() defined in Utils.h/Utils.cpp conflicts with ::round() from <cmath>
