### PR TITLE
Prevent excessive is_valid_position() calls during positive x/y sliding

### DIFF
--- a/src/MapCollision.cpp
+++ b/src/MapCollision.cpp
@@ -142,7 +142,7 @@ bool MapCollision::move(float &x, float &y, float _step_x, float _step_y, MOVEME
 			// find next interesting value, which is either the whole step, or the transition to the next tile
 			step_x = min((float)ceil(x) - x, _step_x);
 			// if we are standing on the edge of a tile (ceil(x) - x == 0), we need to look one tile ahead
-			if (step_x == 0) step_x	= min(1.f, _step_x);
+			if (step_x <= MIN_TILE_GAP) step_x = min(1.f, _step_x);
 		} else if (_step_x < 0) {
 			step_x = max((float)floor(x) - x, _step_x);
 			if (step_x == 0) step_x = max(-1.f, _step_x);
@@ -151,7 +151,7 @@ bool MapCollision::move(float &x, float &y, float _step_x, float _step_y, MOVEME
 		float step_y = 0;
 		if (_step_y > 0) {
 			step_y = min((float)ceil(y) - y, _step_y);
-			if (step_y == 0) step_y	= min(1.f, _step_y);
+			if (step_y <= MIN_TILE_GAP) step_y = min(1.f, _step_y);
 		} else if (_step_y < 0) {
 			step_y = max((float)floor(y) - y, _step_y);
 			if (step_y == 0) step_y	= max(-1.f, _step_y);

--- a/src/MapCollision.h
+++ b/src/MapCollision.h
@@ -55,6 +55,10 @@ typedef enum {
 	MOVEMENT_INTANGIBLE = 2 // can move through BLOCKS_ALL (e.g. walls)
 } MOVEMENTTYPE;
 
+// this value is used to determine the greatest possible position within a tile before transitioning to the next tile
+// so if an entity has a position of (1-MIN_TILE_GAP, 0) and moves to the east, they will move to (1,0)
+const float MIN_TILE_GAP = 0.001;
+
 class MapCollision {
 private:
 


### PR DESCRIPTION
When we were using integer units for positions within tiles, it was easy
to determine the point right before the next tile. If we had 512 units
per tile, 511 would be the point before the next tile. Figuring out this
point isn't easy with floating point positions, since the number that
comes before 1.0 goes on for quite a bit.

This commit places a limit on how small steps can get when attempting to
slide along a surface in a positive direction (aka east or south). I did
some testing with perf while looking at is_valid_position(). Without the
patch, about 49.76% of cycles were dedicated to that function. With the
patch, only 0.17% of cycles were used.
