### PR TITLE
Fix crash when on empty or invalid map.

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -505,17 +505,17 @@ void MapRenderer::renderOrthoFrontObjects(std::vector<Renderable> &r) {
 
 	short int startj = max(0, upperleft.y);
 	short int starti = max(0, upperleft.x);
-	const short max_tiles_width =  min(w, static_cast<short int>(starti + (VIEW_W / TILE_W) + 2 * tset.max_size_x));
+	const short max_tiles_width  = min(w, static_cast<short int>(starti + (VIEW_W / TILE_W) + 2 * tset.max_size_x));
 	const short max_tiles_height = min(h, static_cast<short int>(startj + (VIEW_H / TILE_H) + 2 * tset.max_size_y));
 
-	while (r_cursor != r_end && (r_cursor->map_pos.y) < startj)
+	while (r_cursor != r_end && (int)(r_cursor->map_pos.y) < startj)
 		++r_cursor;
 
 	if (index_objectlayer >= layers.size())
 		return;
 
 	maprow *objectlayer = layers[index_objectlayer];
-	for (j = startj; j<max_tiles_height; j++) {
+	for (j = startj; j < max_tiles_height; j++) {
 		Point p = map_to_screen(starti, j, shakycam.x, shakycam.y);
 		p = center_tile(p);
 		for (i = starti; i<max_tiles_width; i++) {
@@ -527,14 +527,14 @@ void MapRenderer::renderOrthoFrontObjects(std::vector<Renderable> &r) {
 			}
 			p.x += TILE_W;
 
-			while (r_cursor != r_end && (r_cursor->map_pos.y) == j && (r_cursor->map_pos.x) < i)
+			while (r_cursor != r_end && (int)(r_cursor->map_pos.y) == j && (int)(r_cursor->map_pos.x) < i) // implicit floor
 				++r_cursor;
 
 			// some renderable entities go in this layer
-			while (r_cursor != r_end && (r_cursor->map_pos.y) == j && (r_cursor->map_pos.x) == i)
+			while (r_cursor != r_end && (int)(r_cursor->map_pos.y) == j && (int)(r_cursor->map_pos.x) == i) // implicit floor
 				drawRenderable(r_cursor++);
 		}
-		while (r_cursor != r_end && (r_cursor->map_pos.y) <= j)
+		while (r_cursor != r_end && (int)(r_cursor->map_pos.y) <= j) // implicit floor
 			++r_cursor;
 	}
 }


### PR DESCRIPTION
When being on an invalid map, you used to get back to the initial spawning
point. This seems to have broken on a rewrite of the MapRenderer rendering
the object layer.

Signed-off-by: Stefan Beller stefanbeller@googlemail.com
