### PR TITLE
requires_status and requires_not_status for map enemies

### DIFF
--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -142,6 +142,21 @@ void EnemyManager::handleNewMap () {
 			continue;
 		}
 
+
+		bool status_reqs_met = true;
+		//if the status requirements arent met, dont load the enemy
+		for(unsigned int i = 0; i < me.requires_status.size(); i++){
+            if (!camp->checkStatus(me.requires_status[i]))
+                status_reqs_met = false;
+		}
+		for(unsigned int i = 0; i < me.requires_not_status.size(); i++){
+            if (camp->checkStatus(me.requires_not_status[i]))
+                status_reqs_met = false;
+		}
+		if(!status_reqs_met)
+            continue;
+
+
 		Enemy *e = getEnemyPrototype(me.type);
 
 		e->stats.waypoints = me.waypoints;

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -195,6 +195,12 @@ void Map::loadEnemy(FileParser &infile) {
 		enemies.back().wander_area.w = toInt(infile.nextValue()) + 0.5;
 		enemies.back().wander_area.h = toInt(infile.nextValue()) + 0.5;
 	}
+	// @ATTR enemy.requires_status|string|Status required for enemy load
+	else if (infile.key == "requires_status")
+        enemies.back().requires_status.push_back(infile.nextValue());
+    // @ATTR enemy.requires_not_status|string|Status required to be missing for enemy load
+	else if (infile.key == "requires_not_status")
+        enemies.back().requires_not_status.push_back(infile.nextValue());
 }
 
 void Map::loadEnemyGroup(FileParser &infile, Map_Group *group) {

--- a/src/Map.h
+++ b/src/Map.h
@@ -125,6 +125,8 @@ public:
 	bool hero_ally;
 	int summon_power_index;
 	StatBlock* summoner;
+	std::vector<std::string> requires_status;
+	std::vector<std::string> requires_not_status;
 
 	Map_Enemy(std::string _type="", FPoint _pos=FPoint())
 	 : type(_type)
@@ -135,6 +137,8 @@ public:
 	 , hero_ally(false)
 	 , summon_power_index(0)
 	 , summoner(NULL)
+	 , requires_status()
+	 , requires_not_status()
 	{
 		wander_area.x = 0;
 		wander_area.y = 0;


### PR DESCRIPTION
allows to prevent loading a map enemy depending on quest status
