### PR TITLE
In NO_MOUSE mode avoid using mouse.

### DIFF
--- a/src/GameStateConfig.cpp
+++ b/src/GameStateConfig.cpp
@@ -923,7 +923,11 @@ void GameStateConfig::logic () {
 	// tab 3 (input)
 	else if (active_tab == 3 && !defaults_confirm->visible) {
 		if (mouse_move_cb->checkClick()) {
-			if (mouse_move_cb->isChecked()) MOUSE_MOVE=true;
+			if (mouse_move_cb->isChecked()) {
+				MOUSE_MOVE=true;
+				no_mouse_cb->unCheck();
+				NO_MOUSE=false;
+			}
 			else MOUSE_MOVE=false;
 		}
 		else if (mouse_aim_cb->checkClick()) {
@@ -939,6 +943,8 @@ void GameStateConfig::logic () {
 				NO_MOUSE=true;
 				mouse_aim_cb->unCheck();
 				MOUSE_AIM=false;
+				mouse_move_cb->unCheck();
+				MOUSE_MOVE=false;
 			}
 			else NO_MOUSE=false;
 		}

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -206,7 +206,7 @@ void GameStatePlay::checkLoot() {
 	}
 
 	// Pickup with mouse click
-	if (inpt->pressing[MAIN1] && !inpt->lock[MAIN1]) {
+	if (inpt->pressing[MAIN1] && !inpt->lock[MAIN1] && !NO_MOUSE) {
 
 		pickup = loot->checkPickup(inpt->mouse, mapr->cam, pc->stats.pos, menu->inv);
 		if (pickup.item > 0) {
@@ -600,7 +600,7 @@ void GameStatePlay::checkNPCInteraction() {
 	int interact_distance = max_interact_distance+1;
 
 	// check for clicking on an NPC
-	if (inpt->pressing[MAIN1] && !inpt->lock[MAIN1]) {
+	if (inpt->pressing[MAIN1] && !inpt->lock[MAIN1] && !NO_MOUSE) {
 		npc_click = npcs->checkNPCClick(inpt->mouse, mapr->cam);
 		if (npc_click != -1) npc_id = npc_click;
 	}
@@ -628,7 +628,7 @@ void GameStatePlay::checkNPCInteraction() {
 
 	if (npc_id != -1 && ((npc_click != -1 && interact_distance < max_interact_distance && pc->stats.alive && pc->stats.humanoid) || eventPendingDialog)) {
 
-		if (inpt->pressing[MAIN1]) inpt->lock[MAIN1] = true;
+		if (inpt->pressing[MAIN1] && !NO_MOUSE) inpt->lock[MAIN1] = true;
 		if (inpt->pressing[ACCEPT]) inpt->lock[ACCEPT] = true;
 
 		menu->npc->setNPC(npcs->npcs[npc_id]);


### PR DESCRIPTION
This is more like code improvement, not bug fixing. In NO_MOUSE mode we should not get unexpected behavior when trying to use mouse on Desctop PC with mouse.

In NO_MOUSE mode we should disable mouse usage.
1. Don't allow enabling "move using mouse" and "disable mouse" in the same time.
2. Don't allow interraction with NPC using mouse. Anyway we will be unable to select NPC quest from quests menu using mouse.
3. We still can use mouse buttons as hotkeys, but user will redefine hotkeys from config menu.

During testing I found one bug: in NO_MOUSE mode we can't se NPC name. @dorkster told me he will look into this.
