### PR TITLE
Don't try to center NPCs on a tile twice

### DIFF
--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -86,8 +86,8 @@ void NPCManager::handleNewMap() {
 
 		NPC *npc = new NPC();
 		npc->load(mn.id, stats->level);
-		npc->pos.x = mn.pos.x + 0.5f;
-		npc->pos.y = mn.pos.y + 0.5f;
+		npc->pos.x = mn.pos.x;
+		npc->pos.y = mn.pos.y;
 
 		npc->stock.sort();
 		npcs.push_back(npc);


### PR DESCRIPTION
Loading in Map.cpp now handles this correctly, so we don't need to do it
here.
