### PR TITLE
Removed dead initialization (found by clang-analyzer)

### DIFF
--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -722,7 +722,7 @@ void GameStatePlay::checkNPCInteraction() {
 
 void GameStatePlay::checkStash() {
 	int max_interact_distance = 4;
-	int interact_distance = max_interact_distance+1;
+	int interact_distance;
 
 	if (mapr->stash) {
 		// If triggered, open the stash and inventory menus


### PR DESCRIPTION
After being initialized, the value is recalculated on line 739 without being used in the mean time.
