### PR TITLE
Implement "allow_movement" for dialog

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -55,7 +55,8 @@ Avatar::Avatar()
 	, attacking (false)
 	, drag_walking(false)
 	, respawn(false)
-	, close_menus(false) {
+	, close_menus(false)
+	, allow_movement(true) {
 
 	init();
 
@@ -252,7 +253,10 @@ void Avatar::loadStepFX(const string& stepname) {
 
 
 bool Avatar::pressing_move() {
-	if (MOUSE_MOVE) {
+	if (!allow_movement) {
+		return false;
+	}
+	else if (MOUSE_MOVE) {
 		return inpt->pressing[MAIN1];
 	}
 	else {

--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -133,6 +133,7 @@ public:
 	bool newLevelNotification;
 	bool respawn;
 	bool close_menus;
+	bool allow_movement;
 	std::vector<int> hero_cooldown;
 };
 

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -692,6 +692,7 @@ void GameStatePlay::checkNPCInteraction() {
 
 			menu->talker->npc = npcs->npcs[npc_id];
 			menu->talker->chooseDialogNode(menu->npc->selected_dialog_node);
+			pc->allow_movement = npcs->npcs[npc_id]->checkMovement(menu->npc->selected_dialog_node);
 
 			menu->closeAll();
 			menu->talker->visible = true;
@@ -724,6 +725,10 @@ void GameStatePlay::checkNPCInteraction() {
 		eventDialogOngoing = false;
 	}
 
+	// reset movement restrictions when we're not in dialog
+	if (!menu->talker->visible) {
+		pc->allow_movement = true;
+	}
 }
 
 void GameStatePlay::checkStash() {

--- a/src/NPC.cpp
+++ b/src/NPC.cpp
@@ -93,6 +93,9 @@ void NPC::load(const string& npc_id, int hero_level) {
 				else if (infile.key == "group") {
 					e.s = infile.val;
 				}
+				else if (infile.key == "allow_movement") {
+					e.s = infile.val;
+				}
 				else {
 					EventManager::loadEventComponent(infile, NULL, &e);
 				}
@@ -309,6 +312,17 @@ std::string NPC::getDialogTopic(unsigned int dialog_node) {
 	}
 
 	return "";
+}
+
+/**
+ * Check if the hero can move during this dialog branch
+ */
+bool NPC::checkMovement(unsigned int dialog_node) {
+	for (unsigned int i=0; i<dialog[dialog_node].size(); i++) {
+		if (dialog[dialog_node][i].type == "allow_movement")
+			return toBool(dialog[dialog_node][i].s);
+	}
+	return true;
 }
 
 /**

--- a/src/NPC.h
+++ b/src/NPC.h
@@ -47,6 +47,7 @@ public:
 	bool playSound(int type, int id=-1);
 	void getDialogNodes(std::vector<int> &result);
 	std::string getDialogTopic(unsigned int dialog_node);
+	bool checkMovement(unsigned int dialog_node);
 	bool processDialog(unsigned int dialog_node, unsigned int& event_cursor);
 	void processEvent(unsigned int dialog_node, unsigned int cursor);
 	virtual Renderable getRender();


### PR DESCRIPTION
Setting `allow_movement=false` in a [dialog] section will prevent the
hero from moving during the discussion. By default, this value is true,
meaning existing behavior is used.
