### PR TITLE
Add caption_margins to cutscenes

### DIFF
--- a/src/GameStateCutscene.h
+++ b/src/GameStateCutscene.h
@@ -61,7 +61,7 @@ private:
 public:
 	Scene();
 	~Scene();
-	bool logic();
+	bool logic(FPoint *caption_margins);
 	void render();
 
 	std::queue<SceneComponent> components;
@@ -74,6 +74,7 @@ private:
 	std::string dest_map;
 	Point dest_pos;
 	bool scale_graphics;
+	FPoint caption_margins;
 
 	std::queue<Scene> scenes;
 


### PR DESCRIPTION
Closes #850

Margins are calculated as a percentage of the screen size. The format is
`caption_margins=x,y`, where x controls the left/right margins and
y controls the bottom margin. The top margin is ignored since captions
are aligned to the bottom of the screen.
