### PR TITLE
Allow hero name and class to be used in dialog

### DIFF
--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -121,7 +121,7 @@ void GameStatePlay::resetGame() {
 	loadStash();
 
 	// Finalize new character settings
-	menu->talker->setHero(pc->stats.name, pc->stats.gfx_portrait);
+	menu->talker->setHero(pc->stats.name, pc->stats.character_class, pc->stats.gfx_portrait);
 	pc->loadSounds();
 }
 

--- a/src/MenuTalker.cpp
+++ b/src/MenuTalker.cpp
@@ -226,7 +226,7 @@ void MenuTalker::createBuffer() {
 
 	label_name->set(who);
 
-	line = npc->dialog[dialog_node][event_cursor].s;
+	line = parseLine(npc->dialog[dialog_node][event_cursor].s);
 
 	// render dialog text to the scrollbox buffer
 	Point line_size = font->calc_size(line,textbox->pos.w-(text_offset.x*2));
@@ -293,11 +293,26 @@ void MenuTalker::render() {
 	}
 }
 
-void MenuTalker::setHero(const string& name, const string& portrait_filename) {
+void MenuTalker::setHero(const string& name, const string& class_name, const string& portrait_filename) {
 	hero_name = name;
+	hero_class = msg->get(class_name);
 
 	SDL_FreeSurface(portrait);
 	portrait = loadGraphicSurface("images/portraits/" + portrait_filename + ".png", "Couldn't load portrait");
+}
+
+string MenuTalker::parseLine(const string &line) {
+	string new_line = line;
+
+	// name
+	size_t index = new_line.find("%N");
+	if (index != string::npos) new_line = new_line.replace(index, 2, hero_name);
+
+	// class
+	index = new_line.find("%C");
+	if (index != string::npos) new_line.replace(index, 2, hero_class);
+
+	return new_line;
 }
 
 MenuTalker::~MenuTalker() {

--- a/src/MenuTalker.h
+++ b/src/MenuTalker.h
@@ -37,10 +37,13 @@ class WidgetScrollBox;
 
 class MenuTalker : public Menu {
 private:
+	std::string parseLine(const std::string &line);
+
 	MenuManager *menu;
 
 	SDL_Surface *portrait;
 	std::string hero_name;
+	std::string hero_class;
 
 	int dialog_node;
 	unsigned int event_cursor;
@@ -73,7 +76,7 @@ public:
 	void update();
 	void logic();
 	void render();
-	void setHero(const std::string& name, const std::string& portrait_filename);
+	void setHero(const std::string& name, const std::string& class_name, const std::string& portrait_filename);
 	void createBuffer();
 
 	bool vendor_visible;

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -349,7 +349,7 @@ void GameStatePlay::loadGame() {
 	pc->stats.direction = 6;
 
 	// set up MenuTalker for this hero
-	menu->talker->setHero(pc->stats.name, pc->stats.gfx_portrait);
+	menu->talker->setHero(pc->stats.name, pc->stats.character_class, pc->stats.gfx_portrait);
 
 	// load sounds (gender specific)
 	pc->loadSounds();


### PR DESCRIPTION
Closes #727

When creating dialog, use %N to substitute the player's name, and %C to
substitute the player's class.
