### PR TITLE
Allow setting MENUS_PAUSE via config file

### DIFF
--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -601,10 +601,8 @@ void MenuManager::logic() {
 		}
 	}
 
-	if (MENUS_PAUSE) {
-		pause = (inv->visible || pow->visible || chr->visible || log->visible || vendor->visible || talker->visible || npc->visible);
-	}
 	menus_open = (inv->visible || pow->visible || chr->visible || log->visible || vendor->visible || talker->visible || npc->visible);
+	pause = (MENUS_PAUSE && menus_open) || exit->visible;
 
 	if (stats->alive) {
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -467,6 +467,8 @@ void loadMiscSettings() {
 			}
 			else if (infile.key == "interact_range")
 				INTERACT_RANGE = toFloat(infile.val);
+			else if (infile.key == "menus_pause")
+				MENUS_PAUSE = toBool(infile.val);
 
 		}
 		infile.close();


### PR DESCRIPTION
In addition, always pause when the exit menu is visible, regardless of
MENUS_PAUSE's value.
