### PR TITLE
Allow translating default hero names

### DIFF
--- a/src/GameStateNew.cpp
+++ b/src/GameStateNew.cpp
@@ -224,7 +224,7 @@ void GameStateNew::loadOptions(const string& filename) {
 			base.push_back(fin.nextValue());
 			head.push_back(fin.nextValue());
 			portrait.push_back(fin.nextValue());
-			name.push_back(fin.nextValue());
+			name.push_back(msg->get(fin.nextValue()));
 		}
 	}
 	fin.close();

--- a/src/MenuPowers.cpp
+++ b/src/MenuPowers.cpp
@@ -528,7 +528,7 @@ TooltipData MenuPowers::checkTooltip(Point mouse) {
 			if (!power_cell[i].upgrades.empty()) {
 				short next_level = nextLevel(i);
 				if (next_level != -1) {
-					tip.addText(msg->get("\nNext Level:"));
+					tip.addText("\n" + msg->get("Next Level:"));
 					generatePowerDescription(&tip, next_level, upgrade);
 				}
 			}


### PR DESCRIPTION
(See http://opengameart.org/forumtopic/untranslated-untranslatable-strings)

Also, I moved the newline outside of the "Next Level:" string in Power
tooltips. This is because it messed up po/pot generation.
