### PR TITLE
Do not segfault on faulty tile ids, but warn.

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -170,6 +170,18 @@ int MapRenderer::load(std::string fname) {
 
 	tset.load(this->tileset);
 
+	bool corrupted = false;
+	for (unsigned i = 0; i < layers.size(); ++i)
+		for (int x = 0; x < w; ++x)
+			for (int y = 0; y < h; ++y)
+				if (layers[i][x][y] >= tset.tiles.size())
+					layers[i][x][y] = 0, corrupted = true;
+
+	if (corrupted) {
+		fprintf(stderr, "Tileset or Map corrupted. A tile has a larger id than the tileset allows.\n");
+		fprintf(stderr, "Remove offending tile.\n");
+	}
+
 	// some events automatically trigger when the map loads
 	// e.g. change map state based on campaign status
 	executeOnLoadEvents();


### PR DESCRIPTION
Found when starting a way older version of poly with the current engine.
