### PR TITLE
Don't add default mod to list twice

### DIFF
--- a/src/ModManager.cpp
+++ b/src/ModManager.cpp
@@ -90,7 +90,7 @@ void ModManager::loadModList() {
 		if (starts_with == "#") continue;
 
 		// add the mod if it exists in the mods folder
-		if (find(mod_dirs.begin(), mod_dirs.end(), line) != mod_dirs.end()) {
+		if (find(mod_dirs.begin(), mod_dirs.end(), line) != mod_dirs.end() && line != FALLBACK_MOD) {
 			mod_list.push_back(line);
 			found_any_mod = true;
 		}


### PR DESCRIPTION
Should really fix #921. Default mods.txt in mods folder doesn't include fallback mod, but when we save mods list in settings folder we get it there. Don't add fallback mod twice when creating mods list  while reading directory structure.
