### PR TITLE
Check for default mod before searching mod directories

### DIFF
--- a/src/ModManager.cpp
+++ b/src/ModManager.cpp
@@ -90,12 +90,14 @@ void ModManager::loadModList() {
 		if (starts_with == "#") continue;
 
 		// add the mod if it exists in the mods folder
-		if (find(mod_dirs.begin(), mod_dirs.end(), line) != mod_dirs.end() && line != FALLBACK_MOD) {
-			mod_list.push_back(line);
-			found_any_mod = true;
-		}
-		else {
-			fprintf(stderr, "Mod \"%s\" not found, skipping\n", line.c_str());
+		if (line != FALLBACK_MOD) {
+			if (find(mod_dirs.begin(), mod_dirs.end(), line) != mod_dirs.end()) {
+				mod_list.push_back(line);
+				found_any_mod = true;
+			}
+			else {
+				fprintf(stderr, "Mod \"%s\" not found, skipping\n", line.c_str());
+			}
 		}
 	}
 	infile.close();


### PR DESCRIPTION
Prevents "Mod default not found, skipping" message.
