### PR TITLE
Don't free Image surfaces when copying/destroying Sprite objects

### DIFF
--- a/src/GameStateConfig.cpp
+++ b/src/GameStateConfig.cpp
@@ -1304,6 +1304,7 @@ void GameStateConfig::scanKey(int button) {
 }
 
 GameStateConfig::~GameStateConfig() {
+	background.clearGraphics();
 	tip_buf.clear();
 	delete tip;
 	delete tabControl;

--- a/src/GameStateCutscene.cpp
+++ b/src/GameStateCutscene.cpp
@@ -34,7 +34,7 @@ Scene::Scene() : frame_counter(0)
 }
 
 Scene::~Scene() {
-
+	art.clearGraphics();
 	delete caption_box;
 	while(!components.empty()) {
 		components.pop();

--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -618,6 +618,11 @@ void GameStateLoad::render() {
 }
 
 GameStateLoad::~GameStateLoad() {
+	background.clearGraphics();
+	selection.clearGraphics();
+	portrait_border.clearGraphics();
+	portrait.clearGraphics();
+
 	delete button_exit;
 	delete button_action;
 	delete button_alternate;

--- a/src/GameStateNew.cpp
+++ b/src/GameStateNew.cpp
@@ -369,6 +369,8 @@ std::string GameStateNew::getClassTooltip(int index) {
 }
 
 GameStateNew::~GameStateNew() {
+	portrait_image.clearGraphics();
+	portrait_border.clearGraphics();
 	delete button_exit;
 	delete button_create;
 	delete button_next;

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -979,6 +979,8 @@ Avatar *GameStatePlay::getAvatar() const {
 }
 
 GameStatePlay::~GameStatePlay() {
+	loading_bg.clearGraphics();
+
 	delete quests;
 	delete npcs;
 	delete hazards;

--- a/src/GameStateTitle.cpp
+++ b/src/GameStateTitle.cpp
@@ -157,6 +157,7 @@ void GameStateTitle::render() {
 }
 
 GameStateTitle::~GameStateTitle() {
+	logo.clearGraphics();
 	delete button_play;
 	delete button_cfg;
 	delete button_credits;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -33,6 +33,7 @@ Menu::Menu()
 }
 
 Menu::~Menu() {
+	background.clearGraphics();
 }
 
 void Menu::align() {

--- a/src/MenuActionBar.cpp
+++ b/src/MenuActionBar.cpp
@@ -518,6 +518,9 @@ void MenuActionBar::resetSlots() {
 }
 
 MenuActionBar::~MenuActionBar() {
+	emptyslot.clearGraphics();
+	disabled.clearGraphics();
+	attention.clearGraphics();
 	for (unsigned i = 0; i < 16; i++)
 		delete labels[i];
 

--- a/src/MenuActiveEffects.cpp
+++ b/src/MenuActiveEffects.cpp
@@ -125,4 +125,5 @@ void MenuActiveEffects::render() {
 }
 
 MenuActiveEffects::~MenuActiveEffects() {
+	timer.clearGraphics();
 }

--- a/src/MenuEnemy.cpp
+++ b/src/MenuEnemy.cpp
@@ -140,4 +140,5 @@ void MenuEnemy::render() {
 }
 
 MenuEnemy::~MenuEnemy() {
+	bar_hp.clearGraphics();
 }

--- a/src/MenuItemStorage.cpp
+++ b/src/MenuItemStorage.cpp
@@ -204,6 +204,7 @@ void MenuItemStorage::highlightClear() {
 }
 
 MenuItemStorage::~MenuItemStorage() {
+	highlight_image.clearGraphics();
 	delete[] highlight;
 	for (unsigned i=0; i<slots.size(); i++)
 		delete slots[i];

--- a/src/MenuNPCActions.cpp
+++ b/src/MenuNPCActions.cpp
@@ -400,5 +400,6 @@ void MenuNPCActions::render() {
 }
 
 MenuNPCActions::~MenuNPCActions() {
+	action_menu.clearGraphics();
 }
 

--- a/src/MenuPowers.cpp
+++ b/src/MenuPowers.cpp
@@ -667,7 +667,12 @@ void MenuPowers::generatePowerDescription(TooltipData* tip, int slot_num, const 
 }
 
 MenuPowers::~MenuPowers() {
-	for (unsigned int i=0; i<tree_surf.size(); i++) tree_surf[i].clearGraphics();
+	powers_unlock.clearGraphics();
+	overlay_disabled.clearGraphics();
+
+	for (unsigned int i=0; i<tree_surf.size(); i++) {
+		tree_surf[i].clearGraphics();
+	}
 	for (unsigned int i=0; i<slots.size(); i++) {
 		delete slots.at(i);
 		delete upgradeButtons.at(i);

--- a/src/MenuStatBar.cpp
+++ b/src/MenuStatBar.cpp
@@ -155,5 +155,6 @@ void MenuStatBar::render() {
 }
 
 MenuStatBar::~MenuStatBar() {
+	bar.clearGraphics();
 	delete label;
 }

--- a/src/MenuTalker.cpp
+++ b/src/MenuTalker.cpp
@@ -334,6 +334,7 @@ string MenuTalker::parseLine(const string &line) {
 }
 
 MenuTalker::~MenuTalker() {
+	portrait.clearGraphics();
 	delete label_name;
 	delete textbox;
 	delete advanceButton;

--- a/src/NPC.cpp
+++ b/src/NPC.cpp
@@ -408,6 +408,8 @@ bool NPC::isDialogType(const std::string &type) {
 }
 
 NPC::~NPC() {
+	portrait.clearGraphics();
+
 	if (gfx != "") {
 		anim->decreaseCount(gfx);
 	}

--- a/src/SDLRenderDevice.cpp
+++ b/src/SDLRenderDevice.cpp
@@ -31,41 +31,23 @@ using namespace std;
 
 Sprite::Sprite(const Sprite& other) {
 	local_frame = other.local_frame;
+	sprite = other.sprite;
 	src = other.src;
 	offset = other.offset;
 	dest = other.dest;
-
-	// Warning: Some graphics APIs don't support deep copying image data
-	// So we'll make sure image data is deleted here
-	if (sprite.surface != NULL) {
-		SDL_FreeSurface(sprite.surface);
-		fprintf(stderr, "Warning: Copying Sprite object is not supported\n");
-	}
-	sprite.surface = NULL;
 }
 
 Sprite& Sprite::operator=(const Sprite& other) {
 	local_frame = other.local_frame;
+	sprite = other.sprite;
 	src = other.src;
 	offset = other.offset;
 	dest = other.dest;
-
-	// Warning: Some graphics APIs don't support deep copying image data
-	// So we'll make sure image data is deleted here
-	if (sprite.surface != NULL) {
-		SDL_FreeSurface(sprite.surface);
-		fprintf(stderr, "Warning: Assignment operator for Sprite object is not supported\n");
-	}
-	sprite.surface = NULL;
 
 	return *this;
 }
 
 Sprite::~Sprite() {
-	if (sprite.surface != NULL) {
-		SDL_FreeSurface(sprite.surface);
-		sprite.surface = NULL;
-	}
 }
 
 /**
@@ -90,12 +72,10 @@ void Sprite::setGraphics(Image s, bool setClipToFull) {
 }
 
 Image* Sprite::getGraphics() {
-
 	return &sprite;
 }
 
 bool Sprite::graphicsIsNull() {
-
 	return (sprite.surface == NULL);
 }
 
@@ -107,7 +87,6 @@ bool Sprite::graphicsIsNull() {
  * graphics resources.
  */
 void Sprite::clearGraphics() {
-
 	if (sprite.surface != NULL) {
 		SDL_FreeSurface(sprite.surface);
 		sprite.surface = NULL;
@@ -211,6 +190,9 @@ int SDLRenderDevice::createContext(int width, int height) {
 	}
 
 	// Add Window Titlebar Icon
+	if (titlebar_icon) {
+		SDL_FreeSurface(titlebar_icon);
+	}
 	titlebar_icon = IMG_Load(mods->locate("images/logo/icon.png").c_str());
 	SDL_WM_SetIcon(titlebar_icon, NULL);
 
@@ -235,9 +217,14 @@ int SDLRenderDevice::createContext(int width, int height) {
 		is_initialized = true;
 	}
 
-	// Window title
-	const char* title = msg->get(WINDOW_TITLE).c_str();
-	SDL_WM_SetCaption(title, title);
+	if (is_initialized) {
+		// Window title
+		const char* title = msg->get(WINDOW_TITLE).c_str();
+		SDL_WM_SetCaption(title, title);
+
+		// Icons
+		loadIcons();
+	}
 
 	return (screen != NULL ? 0 : -1);
 }
@@ -535,8 +522,11 @@ void SDLRenderDevice::commitFrame() {
 }
 
 void SDLRenderDevice::destroyContext() {
-	SDL_FreeSurface(titlebar_icon);
-	SDL_FreeSurface(screen);
+	icons.clearGraphics();
+	if (titlebar_icon)
+		SDL_FreeSurface(titlebar_icon);
+	if (screen)
+		SDL_FreeSurface(screen);
 
 	return;
 }

--- a/src/TileSet.cpp
+++ b/src/TileSet.cpp
@@ -152,4 +152,5 @@ void TileSet::logic() {
 }
 
 TileSet::~TileSet() {
+	sprites.clearGraphics();
 }

--- a/src/WidgetButton.cpp
+++ b/src/WidgetButton.cpp
@@ -185,6 +185,7 @@ TooltipData WidgetButton::checkTooltip(Point mouse) {
 }
 
 WidgetButton::~WidgetButton() {
+	buttons.clearGraphics();
 	tip_buf.clear();
 	delete tip;
 }

--- a/src/WidgetCheckBox.cpp
+++ b/src/WidgetCheckBox.cpp
@@ -55,6 +55,7 @@ void WidgetCheckBox::activate() {
 }
 
 WidgetCheckBox::~WidgetCheckBox () {
+	cb.clearGraphics();
 }
 
 void WidgetCheckBox::Check () {

--- a/src/WidgetInput.cpp
+++ b/src/WidgetInput.cpp
@@ -174,5 +174,6 @@ bool WidgetInput::checkClick() {
 }
 
 WidgetInput::~WidgetInput() {
+	background.clearGraphics();
 }
 

--- a/src/WidgetLabel.cpp
+++ b/src/WidgetLabel.cpp
@@ -240,4 +240,5 @@ void WidgetLabel::refresh() {
 }
 
 WidgetLabel::~WidgetLabel() {
+	renderable.clearGraphics();
 }

--- a/src/WidgetListBox.cpp
+++ b/src/WidgetListBox.cpp
@@ -523,6 +523,7 @@ bool WidgetListBox::getPrev() {
 }
 
 WidgetListBox::~WidgetListBox() {
+	listboxs.clearGraphics();
 	delete[] values;
 	delete[] tooltips;
 	delete[] vlabels;

--- a/src/WidgetScrollBar.cpp
+++ b/src/WidgetScrollBar.cpp
@@ -173,5 +173,6 @@ void WidgetScrollBar::refresh(int x, int y, int h, int val, int max) {
 }
 
 WidgetScrollBar::~WidgetScrollBar() {
+	scrollbars.clearGraphics();
 }
 

--- a/src/WidgetScrollBox.cpp
+++ b/src/WidgetScrollBox.cpp
@@ -45,6 +45,7 @@ WidgetScrollBox::WidgetScrollBox(int width, int height) {
 }
 
 WidgetScrollBox::~WidgetScrollBox() {
+	contents.clearGraphics();
 	delete scrollbar;
 }
 

--- a/src/WidgetSlider.cpp
+++ b/src/WidgetSlider.cpp
@@ -55,6 +55,7 @@ WidgetSlider::WidgetSlider (const string  & fname)
 }
 
 WidgetSlider::~WidgetSlider () {
+	sl.clearGraphics();
 }
 
 

--- a/src/WidgetSlot.cpp
+++ b/src/WidgetSlot.cpp
@@ -195,4 +195,6 @@ void WidgetSlot::renderSelection() {
 }
 
 WidgetSlot::~WidgetSlot() {
+	slot_selected.clearGraphics();
+	slot_checked.clearGraphics();
 }

--- a/src/WidgetTabControl.cpp
+++ b/src/WidgetTabControl.cpp
@@ -49,6 +49,8 @@ WidgetTabControl::WidgetTabControl(int amount)
  * Class destructor.
  */
 WidgetTabControl::~WidgetTabControl() {
+	activeTabSurface.clearGraphics();
+	inactiveTabSurface.clearGraphics();
 	delete[] titles;
 	delete[] tabs;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,6 @@ static void init() {
 		exit(1);
 	}
 
-	render_device->loadIcons();
 	// Set Gamma
 	if (CHANGE_GAMMA)
 		render_device->setGamma(GAMMA);


### PR DESCRIPTION
This fixes some bugs where surfaces were getting freed early due to STL
container operations. This let's free Sprite graphics when (and only when)
we are done with them. This is how we originally did things; it's just
abstracted through RenderDevice now.

Also in this commit, I have moved the loading of the icons Sprite to
createContext(), similar to what was done in the SDL2 port.
