### PR TITLE
Move resolution confirm box to a separate game state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ Set (FLARE_SOURCES
 	./src/GameStateTitle.cpp
 	./src/GameStateLoad.cpp
 	./src/GameStatePlay.cpp
+	./src/GameStateResolution.cpp
 	./src/GameStateNew.cpp
 	./src/GameSwitcher.cpp
 	./src/GetText.cpp

--- a/src/GameStateConfig.h
+++ b/src/GameStateConfig.h
@@ -67,11 +67,11 @@ private:
 	bool getLanguagesList(void);
 	int getLanguagesNumber(void);
 	void init();
+	void cleanup();
 	void readConfig();
 	void update();
 	void setDefaultResolution();
 	void refreshFont();
-	bool applyVideoSettings(int width, int height);
 	void enableMods();
 	void disableMods();
 	bool setMods();
@@ -149,7 +149,6 @@ private:
 	WidgetScrollBox     * input_scrollbox;
 	MenuConfirm         * input_confirm;
 	MenuConfirm         * defaults_confirm;
-	MenuConfirm         * resolution_confirm;
 
 	WidgetTooltip       * tip;
 	TooltipData         tip_buf;
@@ -160,9 +159,9 @@ private:
 	SDL_Rect scrollpane;
 	SDL_Color scrollpane_color;
 	int scrollpane_contents;
-	int old_view_w;
-	int old_view_h;
-	int resolution_confirm_ticks;
+	bool fullscreen;
+	bool hwsurface;
+	bool doublebuf;
 	int input_confirm_ticks;
 };
 

--- a/src/GameStateResolution.cpp
+++ b/src/GameStateResolution.cpp
@@ -1,0 +1,182 @@
+/*
+Copyright © 2014 Justin Jacobs
+
+This file is part of FLARE.
+
+FLARE is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+FLARE is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+FLARE.  If not, see http://www.gnu.org/licenses/
+*/
+
+#include "CommonIncludes.h"
+#include "FileParser.h"
+#include "GameStateConfig.h"
+#include "GameStateResolution.h"
+#include "GameStateTitle.h"
+#include "MenuConfirm.h"
+#include "Settings.h"
+#include "SharedResources.h"
+#include "UtilsParsing.h"
+
+GameStateResolution::GameStateResolution(int width, int height, bool fullscreen, bool hwsurface, bool doublebuf)
+	: GameState()
+	, confirm(NULL)
+	, confirm_align("")
+	, confirm_ticks(0)
+	, old_w(VIEW_W)
+	, old_h(VIEW_H)
+	, old_fullscreen(fullscreen)
+	, old_hwsurface(hwsurface)
+	, old_doublebuf(doublebuf)
+	, new_w(width)
+	, new_h(height)
+	, initialized(false)
+{
+}
+
+void GameStateResolution::logic() {
+	if (!initialized) {
+		initialized = true;
+
+		// Apply the new resolution
+		// if it fails, don't create the dialog box (this will make the game continue straight to the title screen)
+		if (compareVideoSettings() && applyVideoSettings(new_w, new_h))
+			confirm = new MenuConfirm(msg->get("OK"),msg->get("Use this resolution?"));
+
+		if (confirm) {
+			// Load the MenuConfirm positions and alignments from menus/menus.txt
+			FileParser infile;
+			if (infile.open("menus/menus.txt")) {
+				int menu_index = -1;
+				while (infile.next()) {
+					if (infile.key == "id") {
+						if (infile.val == "confirm") menu_index = 0;
+						else menu_index = -1;
+					}
+
+					if (menu_index == -1)
+						continue;
+
+					if (infile.key == "layout") {
+						infile.val = infile.val + ',';
+						confirm_area.x = eatFirstInt(infile.val, ',');
+						confirm_area.y = eatFirstInt(infile.val, ',');
+						confirm_area.w = eatFirstInt(infile.val, ',');
+						confirm_area.h = eatFirstInt(infile.val, ',');
+					}
+
+					if (infile.key == "align") {
+						confirm_align = infile.val;
+					}
+				}
+				infile.close();
+			}
+
+			confirm->visible = true;
+			confirm->window_area = confirm_area;
+			confirm->alignment = confirm_align;
+			confirm->align();
+			confirm->update();
+
+			confirm_ticks = MAX_FRAMES_PER_SEC * 10;
+		}
+		else {
+			delete requestedGameState;
+			requestedGameState = new GameStateTitle();
+			return;
+		}
+	}
+
+	if (confirm) {
+		confirm->logic();
+
+		if (confirm_ticks > 0) confirm_ticks--;
+
+		if (confirm->confirmClicked) {
+			saveSettings();
+			delete requestedGameState;
+			requestedGameState = new GameStateTitle();
+		}
+		else if (confirm->cancelClicked || confirm_ticks == 0) {
+			cleanup();
+			FULLSCREEN = old_fullscreen;
+			HWSURFACE = old_hwsurface;
+			DOUBLEBUF = old_doublebuf;
+			if (applyVideoSettings(old_w, old_h)) {
+				saveSettings();
+			}
+			delete requestedGameState;
+			requestedGameState = new GameStateConfig();
+		}
+	}
+	else {
+		delete requestedGameState;
+		requestedGameState = new GameStateTitle();
+	}
+}
+
+void GameStateResolution::render() {
+	if (confirm)
+		confirm->render();
+}
+
+/**
+ * Tries to apply the selected video settings, reverting back to the old settings upon failure
+ */
+bool GameStateResolution::applyVideoSettings(int width, int height) {
+	if (MIN_VIEW_W > width && MIN_VIEW_H > height) {
+		fprintf (stderr, "A mod is requiring a minimum resolution of %dx%d\n", MIN_VIEW_W, MIN_VIEW_H);
+		if (width < MIN_VIEW_W) width = MIN_VIEW_W;
+		if (height < MIN_VIEW_H) height = MIN_VIEW_H;
+	}
+
+	// Attempt to apply the new settings
+	int status = render_device->createContext(width, height);
+
+	// If the new settings fail, revert to the old ones
+	if (status == -1) {
+		fprintf (stderr, "Error during SDL_SetVideoMode: %s\n", SDL_GetError());
+		render_device->createContext(VIEW_W, VIEW_H);
+		return false;
+
+	}
+	else {
+
+		// If the new settings succeed, adjust the view area
+		VIEW_W = width;
+		VIEW_W_HALF = width/2;
+		VIEW_H = height;
+		VIEW_H_HALF = height/2;
+
+		return true;
+	}
+}
+
+/**
+ * Checks if the video settings have changed
+ * Returns true if they have, otherwise returns false
+ */
+bool GameStateResolution::compareVideoSettings() {
+	return (!(old_w == new_w && old_h == new_h) ||
+			 FULLSCREEN != old_fullscreen ||
+			 HWSURFACE != old_hwsurface ||
+			 DOUBLEBUF != old_doublebuf);
+}
+
+void GameStateResolution::cleanup() {
+	if (confirm) {
+		delete confirm;
+		confirm = NULL;
+	}
+}
+
+GameStateResolution::~GameStateResolution() {
+	cleanup();
+}

--- a/src/GameStateResolution.h
+++ b/src/GameStateResolution.h
@@ -1,0 +1,52 @@
+/*
+Copyright © 2014 Justin Jacobs
+
+This file is part of FLARE.
+
+FLARE is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+FLARE is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+FLARE.  If not, see http://www.gnu.org/licenses/
+*/
+
+#pragma once
+#ifndef GAMESTATERESOLUTION_H
+#define GAMESTATERESOLUTION_H
+
+#include "GameState.h"
+
+class MenuConfirm;
+
+class GameStateResolution : public GameState {
+private:
+	bool applyVideoSettings(int width, int height);
+	bool compareVideoSettings();
+	void cleanup();
+	MenuConfirm *confirm;
+	SDL_Rect confirm_area;
+	std::string confirm_align;
+	int confirm_ticks;
+	int old_w;
+	int old_h;
+	bool old_fullscreen;
+	bool old_hwsurface;
+	bool old_doublebuf;
+	int new_w;
+	int new_h;
+	bool initialized;
+
+public:
+	GameStateResolution(int width, int height, bool fullscreen, bool hwsurface, bool doublebuf);
+	~GameStateResolution();
+	void logic();
+	void render();
+};
+
+#endif
+

--- a/src/GameSwitcher.cpp
+++ b/src/GameSwitcher.cpp
@@ -106,10 +106,12 @@ void GameSwitcher::logic() {
 }
 
 void GameSwitcher::showFPS(int fps) {
-	if (!SHOW_FPS) return;
-	string sfps = toString(typeid(fps), &fps) + string(" fps");
-	label_fps->set(fps_position.x, fps_position.y, JUSTIFY_LEFT, VALIGN_TOP, sfps, fps_color);
-	label_fps->render();
+	if (SHOW_FPS) {
+		if (!label_fps) label_fps = new WidgetLabel();
+		string sfps = toString(typeid(fps), &fps) + string(" fps");
+		label_fps->set(fps_position.x, fps_position.y, JUSTIFY_LEFT, VALIGN_TOP, sfps, fps_color);
+		label_fps->render();
+	}
 }
 
 void GameSwitcher::loadFPS() {
@@ -152,6 +154,11 @@ void GameSwitcher::loadFPS() {
 		fps_position.y += VIEW_H-h;
 	}
 
+	// Delete the label object if it exists (we'll recreate this with showFPS())
+	if (label_fps) {
+		delete label_fps;
+		label_fps = NULL;
+	}
 }
 
 void GameSwitcher::render() {


### PR DESCRIPTION
These changes allow us to use graphics APIs that need to free all
surfaces/textures before changing resolution.
