### PR TITLE
Fix segfault when there's no render device when exiting the game

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,7 +174,8 @@ static void cleanup() {
 
 	Mix_CloseAudio();
 
-	render_device->destroyContext();
+	if (render_device)
+		render_device->destroyContext();
 	delete render_device;
 
 	SDL_Quit();


### PR DESCRIPTION
This would happen when using the --help or --version command line flags.
