### PR TITLE
Add a script to generate the source releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,6 @@ mods/default/languages/xgettext.py export-ignore
 # regenerating the wiki pages
 extract_xml.sh export-ignore
 wiki.xslt export-ignore
+
+# the script to generate tar balls
+distribution/create_release_tarball.sh

--- a/distribution/create_release_tarball.sh
+++ b/distribution/create_release_tarball.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# get the name from the git tag:
+name=$(git describe --tags)
+# go into the root of the repository
+cd $(git rev-parse --show-toplevel)
+
+# create the tarball
+filename=flare-engine-${name}.tar.gz
+git archive --format=tar.gz --prefix=flare-engine-${name}/ HEAD > ${filename}
+
+echo "Released to $(git rev-parse --show-toplevel)/${filename}"


### PR DESCRIPTION
We sometimes have issues such as #961, where distribution packages are annoyed by some inconsistencies within the source release tar ball.

This pull request adds a script below the distribution folder, which can produce release tarballs deterministically without such stray files.
