### PR TITLE
Reload icons after recreating render context

### DIFF
--- a/src/GameStateResolution.cpp
+++ b/src/GameStateResolution.cpp
@@ -43,10 +43,16 @@ GameStateResolution::GameStateResolution(int width, int height, bool fullscreen,
 void GameStateResolution::logic() {
 	if (!initialized) {
 		initialized = true;
+		bool settings_changed = compareVideoSettings();
+
+		// Clean up shared resources
+		if (settings_changed) {
+			icons.clearGraphics();
+		}
 
 		// Apply the new resolution
 		// if it fails, don't create the dialog box (this will make the game continue straight to the title screen)
-		if (compareVideoSettings() && applyVideoSettings(new_w, new_h))
+		if (settings_changed && applyVideoSettings(new_w, new_h))
 			confirm = new MenuConfirm(msg->get("OK"),msg->get("Use this resolution?"));
 
 		if (confirm) {
@@ -143,17 +149,17 @@ bool GameStateResolution::applyVideoSettings(int width, int height) {
 	if (status == -1) {
 		fprintf (stderr, "Error during SDL_SetVideoMode: %s\n", SDL_GetError());
 		render_device->createContext(VIEW_W, VIEW_H);
+		SharedResources::loadIcons();
 		return false;
 
 	}
 	else {
-
 		// If the new settings succeed, adjust the view area
 		VIEW_W = width;
 		VIEW_W_HALF = width/2;
 		VIEW_H = height;
 		VIEW_H_HALF = height/2;
-
+		SharedResources::loadIcons();
 		return true;
 	}
 }

--- a/src/SDLRenderDevice.cpp
+++ b/src/SDLRenderDevice.cpp
@@ -187,13 +187,10 @@ SDLRenderDevice::SDLRenderDevice()
 
 int SDLRenderDevice::createContext(int width, int height) {
 	if (is_initialized) {
-		SDL_FreeSurface(screen);
+		destroyContext();
 	}
 
 	// Add Window Titlebar Icon
-	if (titlebar_icon) {
-		SDL_FreeSurface(titlebar_icon);
-	}
 	titlebar_icon = IMG_Load(mods->locate("images/logo/icon.png").c_str());
 	SDL_WM_SetIcon(titlebar_icon, NULL);
 
@@ -532,7 +529,6 @@ void SDLRenderDevice::commitFrame() {
 }
 
 void SDLRenderDevice::destroyContext() {
-	icons.clearGraphics();
 	if (titlebar_icon)
 		SDL_FreeSurface(titlebar_icon);
 	if (screen)


### PR DESCRIPTION
Creating a new render context implies that we need to reload icons, since destroying the old render context causes the old icon surface to be freed.

P.S. @hean01, please don't push directly to master. We use pull requests as a chance to review each others code.
