### PR TITLE
Add a configuration option to use only hardware mouse cursor

### DIFF
--- a/mods/default/menus/config.txt
+++ b/mods/default/menus/config.txt
@@ -27,6 +27,7 @@ combat_text=352,40,384,32
 show_fps=352,72,384,64
 colorblind=352,104,384,96
 show_hotkeys=352,136,384,128
+hardware_cursor=352,168,384,160
 
 [input]
 joystick_device=64,16,32,32

--- a/src/CursorManager.cpp
+++ b/src/CursorManager.cpp
@@ -17,6 +17,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "CursorManager.h"
 #include "FileParser.h"
+#include "Settings.h"
 #include "SharedResources.h"
 #include "UtilsParsing.h"
 
@@ -62,6 +63,11 @@ CursorManager::~CursorManager() {
 }
 
 void CursorManager::logic() {
+	if (HARDWARE_CURSOR) {
+		inpt->showCursor();
+		return;
+	}
+
 	cursor_current = NULL;
 	offset_current = NULL;
 
@@ -77,6 +83,8 @@ void CursorManager::logic() {
 }
 
 void CursorManager::render() {
+	if (HARDWARE_CURSOR) return;
+
 	if (cursor_current != NULL) {
 		if (offset_current != NULL) {
 			cursor_current->setDest(inpt->mouse.x+offset_current->x, inpt->mouse.y+offset_current->y);
@@ -90,6 +98,8 @@ void CursorManager::render() {
 }
 
 void CursorManager::setCursor(CURSOR_TYPE type) {
+	if (HARDWARE_CURSOR) return;
+
 	if (type == CURSOR_INTERACT && !cursor_interact.graphicsIsNull()) {
 		inpt->hideCursor();
 		cursor_current = &cursor_interact;

--- a/src/GameStateConfig.cpp
+++ b/src/GameStateConfig.cpp
@@ -117,6 +117,8 @@ void GameStateConfig::init() {
 	show_hotkeys_lb = new WidgetLabel();
 	colorblind_cb = new WidgetCheckBox("images/menus/buttons/checkbox_default.png");
 	colorblind_lb = new WidgetLabel();
+	hardware_cursor_cb = new WidgetCheckBox("images/menus/buttons/checkbox_default.png");
+	hardware_cursor_lb = new WidgetLabel();
 	music_volume_sl = new WidgetSlider("images/menus/buttons/slider_default.png");
 	music_volume_lb = new WidgetLabel();
 	sound_volume_sl = new WidgetSlider("images/menus/buttons/slider_default.png");
@@ -236,6 +238,7 @@ void GameStateConfig::init() {
 	tablist.add(show_fps_cb);
 	tablist.add(show_hotkeys_cb);
 	tablist.add(colorblind_cb);
+	tablist.add(hardware_cursor_cb);
 	tablist.add(language_lstb);
 
 	tablist.add(enable_joystick_cb);
@@ -323,6 +326,9 @@ void GameStateConfig::readConfig () {
 			}
 			else if (infile.key == "colorblind") {
 				placeLabeledCheckbox( colorblind_lb, colorblind_cb, x1, y1, x2, y2, msg->get("Colorblind Mode"), 2);
+			}
+			else if (infile.key == "hardware_cursor") {
+				placeLabeledCheckbox( hardware_cursor_lb, hardware_cursor_cb, x1, y1, x2, y2, msg->get("Hardware mouse cursor"), 2);
 			}
 			//sliders
 			else if (infile.key == "music_volume") {
@@ -655,6 +661,8 @@ void GameStateConfig::update () {
 	else show_hotkeys_cb->unCheck();
 	if (COLORBLIND) colorblind_cb->Check();
 	else colorblind_cb->unCheck();
+	if (HARDWARE_CURSOR) hardware_cursor_cb->Check();
+	else hardware_cursor_cb->unCheck();
 
 	std::stringstream list_mode;
 	unsigned int resolutions = getVideoModes();
@@ -879,6 +887,10 @@ void GameStateConfig::logic () {
 		else if (colorblind_cb->checkClick()) {
 			if (colorblind_cb->isChecked()) COLORBLIND=true;
 			else COLORBLIND=false;
+		}
+		else if (hardware_cursor_cb->checkClick()) {
+			if (hardware_cursor_cb->isChecked()) HARDWARE_CURSOR=true;
+			else HARDWARE_CURSOR=false;
 		}
 	}
 	// tab 3 (input)

--- a/src/GameStateConfig.h
+++ b/src/GameStateConfig.h
@@ -53,7 +53,7 @@ public:
 	void    render  ();
 
 private:
-	int optiontab[135];
+	int optiontab[137];
 	Rect frame;
 	std::vector<Rect> video_modes;
 
@@ -111,6 +111,8 @@ private:
 	WidgetLabel         * show_fps_lb;
 	WidgetCheckBox      * show_hotkeys_cb;
 	WidgetLabel         * show_hotkeys_lb;
+	WidgetCheckBox      * hardware_cursor_cb;
+	WidgetLabel         * hardware_cursor_lb;
 	WidgetCheckBox      * colorblind_cb;
 	WidgetLabel         * colorblind_lb;
 	WidgetSlider        * music_volume_sl;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -69,7 +69,8 @@ ConfigEntry config[] = {
 	{ "no_mouse",         &typeid(NO_MOUSE),        "0",   &NO_MOUSE,        "make using mouse secondary, give full control to keyboard. 1 enable, 0 disable."},
 	{ "show_fps",         &typeid(SHOW_FPS),        "0",   &SHOW_FPS,        "show frames per second. 1 enable, 0 disable."},
 	{ "show_hotkeys",     &typeid(SHOW_HOTKEYS),    "1",   &SHOW_HOTKEYS,    "show hotkeys names on power bar. 1 enable, 0 disable."},
-	{ "colorblind",       &typeid(COLORBLIND),      "0",   &COLORBLIND,      "enable colorblind tooltips. 1 enable, 0 disable"}
+	{ "colorblind",       &typeid(COLORBLIND),      "0",   &COLORBLIND,      "enable colorblind tooltips. 1 enable, 0 disable"},
+	{ "hardware_cursor",  &typeid(HARDWARE_CURSOR), "0",   &HARDWARE_CURSOR, "use the system mouse cursor. 1 enable, 0 disable"}
 };
 const int config_size = sizeof(config) / sizeof(ConfigEntry);
 
@@ -191,6 +192,7 @@ bool ENABLE_ALLY_COLLISION_AI;
 bool ENABLE_ALLY_COLLISION;
 int CURRENCY_ID;
 float INTERACT_RANGE;
+bool HARDWARE_CURSOR = false;
 
 /**
  * Set system paths

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -134,6 +134,7 @@ extern bool ENABLE_ALLY_COLLISION_AI;
 extern bool ENABLE_ALLY_COLLISION;
 extern int CURRENCY_ID;
 extern float INTERACT_RANGE;
+extern bool HARDWARE_CURSOR;
 
 // Tile Settings
 extern float UNITS_PER_PIXEL_X;


### PR DESCRIPTION
Fixes #981

The setting is found on the Interface tab of the config menu and is off
by default.
