### PR TITLE
Try to keep a constant game speed when rendering can't keep up

### DIFF
--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -17,13 +17,12 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "GameState.h"
 
-GameState::GameState() {
-
-	requestedGameState = NULL;
-
-	exitRequested = false;
-	hasMusic = false;
-	reload_music = false;
+GameState::GameState()
+	: hasMusic(false)
+	, reload_music(false)
+	, load_counter(0)
+	, requestedGameState(NULL)
+	, exitRequested(false) {
 }
 
 GameState* GameState::getRequestedGameState() {

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -35,6 +35,8 @@ public:
 	bool hasMusic;
 	bool reload_music;
 
+	int load_counter;
+
 protected:
 
 	GameState* requestedGameState;

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -108,6 +108,7 @@ GameStatePlay::GameStatePlay()
  */
 void GameStatePlay::resetGame() {
 	mapr->load("maps/spawn.txt");
+	load_counter++;
 	camp->clearAll();
 	pc->init();
 	pc->stats.currency = 0;
@@ -263,6 +264,7 @@ void GameStatePlay::checkTeleport() {
 			mapr->executeOnMapExitEvents();
 			showLoading();
 			mapr->load(teleport_mapname);
+			load_counter++;
 			enemies->handleNewMap();
 			hazards->handleNewMap();
 			loot->handleNewMap();

--- a/src/GameSwitcher.cpp
+++ b/src/GameSwitcher.cpp
@@ -86,6 +86,7 @@ void GameSwitcher::logic() {
 	if (newState != NULL) {
 		delete currentState;
 		currentState = newState;
+		currentState->load_counter++;
 
 		// reload the fps meter position
 		loadFPS();
@@ -162,6 +163,15 @@ void GameSwitcher::loadFPS() {
 		delete label_fps;
 		label_fps = NULL;
 	}
+}
+
+bool GameSwitcher::isLoadingFrame() {
+	if (currentState->load_counter > 0) {
+		currentState->load_counter--;
+		return true;
+	}
+
+	return false;
 }
 
 void GameSwitcher::render() {

--- a/src/GameSwitcher.h
+++ b/src/GameSwitcher.h
@@ -61,6 +61,7 @@ public:
 
 	void loadMusic();
 	void loadFPS();
+	bool isLoadingFrame();
 	void logic();
 	void render();
 	void showFPS(int fps);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,14 +147,13 @@ static void mainLoop (bool debug_event) {
 		int prev_ticks = now_ticks;
 
 		while (now_ticks > logic_ticks && loops < MAX_FRAMES_PER_SEC) {
-			// This is a bit of a hack to compensate for when a frame takes too long.
-			// It's mostly used for frames where loading game resources takes place,
-			// which typically take longer than two seconds due to disk i/o.
-			// This has a side effect of disabling frame skipping when we go above this
-			// threshold. However, if we were skipping that many frames, the game would
-			// be hard to play, so we accept the slowdown here.
-			if (now_ticks - logic_ticks > delay*2) {
-				logic_ticks = now_ticks-delay*2;
+			// Frames where data loading happens (GameState switching and map loading)
+			// take a long time, so our loop here will think that the game "lagged" and
+			// try to compensate. To prevent this compensation, we mark those frames as
+			// "loading frames" and update the logic ticker without actually executing logic.
+			if (gswitch->isLoadingFrame()) {
+				logic_ticks = now_ticks;
+				break;
 			}
 
 			SDL_PumpEvents();


### PR DESCRIPTION
Fixes #985

This should handle 99.9% of slow-down, where logic would happen slower in
realtime. The 0.1% of cases where slow-down can still happen is when the
time for a frame to complete goes over a certain threshold (e.g. frames
where we load game data; this is explained more in the source comments).
