### PR TITLE
Suppress error message when engine/mouse_cursor.txt can't be opened

### DIFF
--- a/src/CursorManager.cpp
+++ b/src/CursorManager.cpp
@@ -26,7 +26,7 @@ CursorManager::CursorManager()
 	, offset_current(NULL)
 {
 	FileParser infile;
-	if (infile.open("engine/mouse_cursor.txt")) {
+	if (infile.open("engine/mouse_cursor.txt", true, true, "")) {
 		while (infile.next()) {
 			infile.val = infile.val + ',';
 


### PR DESCRIPTION
Modded mouse cursors is an optional feature, so we don't need to display
a message if we don't have it.
