### PR TITLE
Simplify checkNPCInteraction and improve MenuManager's closeAll()

### DIFF
--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -473,9 +473,7 @@ void MenuManager::logic() {
 	// only allow the vendor window to be open if the inventory is open
 	if (vendor->visible && !(inv->visible)) {
 		snd->play(vendor->sfx_close);
-		closeLeft();
-		if (vendor->talker_visible && !(inv->visible))
-			closeRight();
+		closeAll();
 	}
 
 	if (!inpt->pressing[INVENTORY] && !inpt->pressing[POWERS] && !inpt->pressing[CHARACTER] && !inpt->pressing[LOG])
@@ -1321,33 +1319,28 @@ void MenuManager::handleKeyboardTooltips() {
 }
 
 void MenuManager::closeAll() {
-	if (!mouse_dragging && !keyboard_dragging) {
-		closeLeft();
-		closeRight();
-		vendor->talker_visible = false;
-	}
+	closeLeft();
+	closeRight();
 }
 
 void MenuManager::closeLeft() {
-	if (!mouse_dragging && !keyboard_dragging) {
-		chr->visible = false;
-		log->visible = false;
-		vendor->visible = false;
-		talker->visible = false;
-		exit->visible = false;
-		stash->visible = false;
-		npc->visible = false;
-	}
+	resetDrag();
+	chr->visible = false;
+	log->visible = false;
+	vendor->visible = false;
+	talker->visible = false;
+	exit->visible = false;
+	stash->visible = false;
+	npc->visible = false;
 }
 
 void MenuManager::closeRight() {
-	if (!mouse_dragging && !keyboard_dragging) {
-		inv->visible = false;
-		pow->visible = false;
-		talker->visible = false;
-		exit->visible = false;
-		npc->visible = false;
-	}
+	resetDrag();
+	inv->visible = false;
+	pow->visible = false;
+	talker->visible = false;
+	exit->visible = false;
+	npc->visible = false;
 }
 
 bool MenuManager::isDragging() {

--- a/src/MenuManager.h
+++ b/src/MenuManager.h
@@ -82,7 +82,6 @@ private:
 
 	void handleKeyboardNavigation();
 	void dragAndDropWithKeyboard();
-	void resetDrag();
 	void splitStack(ItemStack stack);
 
 public:
@@ -95,6 +94,7 @@ public:
 	void closeAll();
 	void closeLeft();
 	void closeRight();
+	void resetDrag();
 
 	std::vector<Menu*> menus;
 	MenuInventory *inv;

--- a/src/MenuTalker.cpp
+++ b/src/MenuTalker.cpp
@@ -48,7 +48,6 @@ MenuTalker::MenuTalker(MenuManager *_menu)
 	, font_dialog("font_regular")
 	, color_normal(font->getColor("menu_normal"))
 	, npc(NULL)
-	, vendor_visible(false)
 	, advanceButton(new WidgetButton("images/menus/buttons/right.png"))
 	, closeButton(new WidgetButton("images/menus/buttons/button_x.png")) {
 

--- a/src/MenuTalker.h
+++ b/src/MenuTalker.h
@@ -79,8 +79,6 @@ public:
 	void setHero(const std::string& name, const std::string& class_name, const std::string& portrait_filename);
 	void createBuffer();
 
-	bool vendor_visible;
-
 	WidgetButton *advanceButton;
 	WidgetButton *closeButton;
 };

--- a/src/MenuVendor.cpp
+++ b/src/MenuVendor.cpp
@@ -46,8 +46,7 @@ MenuVendor::MenuVendor(StatBlock *_stats)
 	, activetab(VENDOR_BUY)
 	, color_normal(font->getColor("menu_normal"))
 	, npc(NULL)
-	, buyback_stock()
-	, talker_visible(false) {
+	, buyback_stock() {
 	background.setGraphics(render_device->loadGraphicSurface("images/menus/vendor.png"));
 
 	tabControl->setTabTitle(VENDOR_BUY,msg->get("Inventory"));

--- a/src/MenuVendor.h
+++ b/src/MenuVendor.h
@@ -76,7 +76,6 @@ public:
 
 	int getRowsCount();
 
-	bool talker_visible;
 	Rect slots_area;
 
 	TabList tablist;


### PR DESCRIPTION
A lot of the code in GameStatePlay::checkNPCInteraction() was from when
I added a Trader button to MenuTalker. That button has since been
replaced with the more flexible MenuNPCActions, so the code is not
needed anymore.

As for MenuManager, I changed closeAll() (including closeLeft() and
closeRight()) to work even when we're dragging something. Now, the
behavior is to return whatever we were dragging and _then_ close the
menu(s). This should prevent dragging things when they shouldn't be
dragged.
