### PR TITLE
Restrict Entity movement to a multiple of UNITS_PER_PIXEL_*

### DIFF
--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -134,8 +134,12 @@ bool Entity::move() {
 	if (stats.effects.speed == 0) return false;
 
 	float speed = stats.speed * speedMultiplyer[stats.direction] * stats.effects.speed / 100;
-	float dx = speed * directionDeltaX[stats.direction];
-	float dy = speed * directionDeltaY[stats.direction];
+
+	// Here, we limit the speed to the nearest multiple of UNITS_PER_PIXEL_*
+	// By doing this, we make it possible for map_to_screen() to cleanly round the resulting position for rendering
+	// In short, it prevents the "jumping" corpses bug described in #968
+	float dx = round((speed * directionDeltaX[stats.direction]) / UNITS_PER_PIXEL_X) * UNITS_PER_PIXEL_X;
+	float dy = round((speed * directionDeltaY[stats.direction]) / UNITS_PER_PIXEL_Y) * UNITS_PER_PIXEL_Y;
 
 	bool full_move = mapr->collider.move(stats.pos.x, stats.pos.y, dx, dy, stats.movement_type, stats.hero);
 


### PR DESCRIPTION
Fixes #968

It's possible that we need to do something similar to this with Hazards.
However, I haven't noticed the bug's behavior with Hazards, so I left
them alone for now.
