### PR TITLE
don't miss brief button clicks or other inputs

### DIFF
--- a/src/InputState.cpp
+++ b/src/InputState.cpp
@@ -47,6 +47,7 @@ InputState::InputState(void)
 
 	for (int key=0; key<key_count; key++) {
 		pressing[key] = false;
+		un_press[key] = false;
 		lock[key] = false;
 	}
 
@@ -242,13 +243,17 @@ void InputState::handle(bool dump_event) {
 
 	inkeys = "";
 
-	// mouse-wheel up/down presses normally happen within a single event window
-	// in order to properly read these events in game logic, we delay the resetting
-	// of their state (done here) until the next frame
-	while (!wheel_binds.empty()) {
-		pressing[wheel_binds.back()] = false;
-		lock[wheel_binds.back()] = false;
-		wheel_binds.pop_back();
+	// sometimes buttons are pressed and released in a single event window.
+	// in order to properly read these events in game logic, we delay the
+	// resetting of their states (done here) until the next frame. this
+	// loop also resets the states of other inputs that are no longer being
+	// pressed. (joysticks are a little more complex.)
+	for (int key=0; key < key_count; key++) {
+		if (un_press[key] == true) {
+			pressing[key] = false;
+			un_press[key] = false;
+			lock[key] = false;
+		}
 	}
 
 	/* Check for events */
@@ -289,6 +294,7 @@ void InputState::handle(bool dump_event) {
 					for (int key=0; key<key_count; key++) {
 						if (event.button.button == binding[key] || event.button.button == binding_alt[key]) {
 							pressing[key] = true;
+							un_press[key] = false;
 						}
 					}
 				}
@@ -297,11 +303,10 @@ void InputState::handle(bool dump_event) {
 				for (int key=0; key<key_count; key++) {
 					if ((scroll_up && (binding[key] == SDL_BUTTON_WHEELUP || binding_alt[key] == SDL_BUTTON_WHEELUP)) ||
 					    (scroll_down && (binding[key] == SDL_BUTTON_WHEELDOWN || binding_alt[key] == SDL_BUTTON_WHEELDOWN))) {
-						wheel_binds.push_back(key);
+						un_press[key] = true;
 					}
 					else if (event.button.button == binding[key] || event.button.button == binding_alt[key]) {
-						pressing[key] = false;
-						lock[key] = false;
+						un_press[key] = true;
 					}
 				}
 				last_button = event.button.button;
@@ -310,14 +315,14 @@ void InputState::handle(bool dump_event) {
 				for (int key=0; key<key_count; key++) {
 					if (event.key.keysym.sym == binding[key] || event.key.keysym.sym == binding_alt[key]) {
 						pressing[key] = true;
+						un_press[key] = false;
 					}
 				}
 				break;
 			case SDL_KEYUP:
 				for (int key=0; key<key_count; key++) {
 					if (event.key.keysym.sym == binding[key] || event.key.keysym.sym == binding_alt[key]) {
-						pressing[key] = false;
-						lock[key] = false;
+						un_press[key] = true;
 					}
 				}
 				last_key = event.key.keysym.sym;
@@ -331,17 +336,14 @@ void InputState::handle(bool dump_event) {
 				if(JOYSTICK_DEVICE == event.jhat.which && ENABLE_JOYSTICK) {
 					switch (event.jhat.value) {
 						case SDL_HAT_CENTERED:
-							pressing[UP] = false;
-							lock[UP] = false;
-							pressing[DOWN] = false;
-							lock[DOWN] = false;
-							pressing[LEFT] = false;
-							lock[LEFT] = false;
-							pressing[RIGHT] = false;
-							lock[RIGHT] = false;
+							un_press[UP] = true;
+							un_press[DOWN] = true;
+							un_press[LEFT] = true;
+							un_press[RIGHT] = true;
 							break;
 						case SDL_HAT_UP:
 							pressing[UP] = true;
+							un_press[UP] = false;
 							pressing[DOWN] = false;
 							lock[DOWN] = false;
 							pressing[LEFT] = false;
@@ -353,6 +355,7 @@ void InputState::handle(bool dump_event) {
 							pressing[UP] = false;
 							lock[UP] = false;
 							pressing[DOWN] = true;
+							un_press[DOWN] = false;
 							pressing[LEFT] = false;
 							lock[LEFT] = false;
 							pressing[RIGHT] = false;
@@ -364,6 +367,7 @@ void InputState::handle(bool dump_event) {
 							pressing[DOWN] = false;
 							lock[DOWN] = false;
 							pressing[LEFT] = true;
+							un_press[LEFT] = false;
 							pressing[RIGHT] = false;
 							lock[RIGHT] = false;
 							break;
@@ -375,12 +379,15 @@ void InputState::handle(bool dump_event) {
 							pressing[LEFT] = false;
 							lock[LEFT] = false;
 							pressing[RIGHT] = true;
+							un_press[RIGHT] = false;
 							break;
 						case SDL_HAT_LEFTUP:
 							pressing[UP] = true;
+							un_press[UP] = false;
 							pressing[DOWN] = false;
 							lock[DOWN] = false;
 							pressing[LEFT] = true;
+							un_press[LEFT] = false;
 							pressing[RIGHT] = false;
 							lock[RIGHT] = false;
 							break;
@@ -388,25 +395,31 @@ void InputState::handle(bool dump_event) {
 							pressing[UP] = false;
 							lock[UP] = false;
 							pressing[DOWN] = true;
+							un_press[DOWN] = false;
 							pressing[LEFT] = true;
+							un_press[LEFT] = false;
 							pressing[RIGHT] = false;
 							lock[RIGHT] = false;
 							break;
 						case SDL_HAT_RIGHTUP:
 							pressing[UP] = true;
+							un_press[UP] = false;
 							pressing[DOWN] = false;
 							lock[DOWN] = false;
 							pressing[LEFT] = false;
 							lock[LEFT] = false;
 							pressing[RIGHT] = true;
+							un_press[RIGHT] = false;
 							break;
 						case SDL_HAT_RIGHTDOWN:
 							pressing[UP] = false;
 							lock[UP] = false;
 							pressing[DOWN] = true;
+							un_press[DOWN] = false;
 							pressing[LEFT] = false;
 							lock[LEFT] = false;
 							pressing[RIGHT] = true;
+							un_press[RIGHT] = false;
 							break;
 					}
 				}
@@ -416,6 +429,7 @@ void InputState::handle(bool dump_event) {
 					for (int key=0; key<key_count; key++) {
 						if (event.jbutton.button == binding_joy[key]) {
 							pressing[key] = true;
+							un_press[key] = false;
 						}
 					}
 				}
@@ -424,8 +438,7 @@ void InputState::handle(bool dump_event) {
 				if(JOYSTICK_DEVICE == event.jbutton.which && ENABLE_JOYSTICK) {
 					for (int key=0; key<key_count; key++) {
 						if (event.jbutton.button == binding_joy[key]) {
-							pressing[key] = false;
-							lock[key] = false;
+							un_press[key] = true;
 						}
 					}
 				}
@@ -465,12 +478,14 @@ void InputState::handle(bool dump_event) {
 			if(joyHasMovedX == 0) {
 				if(!joyReverseAxisX) {
 					pressing[LEFT] = true;
+					un_press[LEFT] = false;
 					pressing[RIGHT] = false;
 					lock[RIGHT] = false;
 					joyLastPosX = JOY_POS_LEFT;
 				}
 				else {
 					pressing[RIGHT] = true;
+					un_press[RIGHT] = false;
 					pressing[LEFT] = false;
 					lock[LEFT] = false;
 					joyLastPosX = JOY_POS_RIGHT;
@@ -492,12 +507,14 @@ void InputState::handle(bool dump_event) {
 			if(joyHasMovedX == 0) {
 				if(!joyReverseAxisX) {
 					pressing[RIGHT] = true;
+					un_press[RIGHT] = false;
 					pressing[LEFT] = false;
 					lock[LEFT] = false;
 					joyLastPosX = JOY_POS_RIGHT;
 				}
 				else {
 					pressing[LEFT] = true;
+					un_press[LEFT] = false;
 					pressing[RIGHT] = false;
 					lock[RIGHT] = false;
 					joyLastPosX = JOY_POS_LEFT;
@@ -506,10 +523,8 @@ void InputState::handle(bool dump_event) {
 			}
 		}
 		if((joyAxisXval >= -JOY_DEADZONE) && (joyAxisXval < JOY_DEADZONE)) {
-			pressing[LEFT] = false;
-			lock[LEFT] = false;
-			pressing[RIGHT] = false;
-			lock[RIGHT] = false;
+			un_press[LEFT] = true;
+			un_press[RIGHT] = true;
 			joyHasMovedX = 0;
 			joyLastPosX = JOY_POS_CENTER;
 		}
@@ -529,12 +544,14 @@ void InputState::handle(bool dump_event) {
 			if(joyHasMovedY == 0) {
 				if(!joyReverseAxisY) {
 					pressing[UP] = true;
+					un_press[UP] = false;
 					pressing[DOWN] = false;
 					lock[DOWN] = false;
 					joyLastPosY = JOY_POS_UP;
 				}
 				else {
 					pressing[DOWN] = true;
+					un_press[DOWN] = false;
 					pressing[UP] = false;
 					lock[UP] = false;
 					joyLastPosY = JOY_POS_DOWN;
@@ -556,12 +573,14 @@ void InputState::handle(bool dump_event) {
 			if(joyHasMovedY == 0) {
 				if(!joyReverseAxisY) {
 					pressing[DOWN] = true;
+					un_press[DOWN] = false;
 					pressing[UP] = false;
 					lock[UP] = false;
 					joyLastPosY = JOY_POS_DOWN;
 				}
 				else {
 					pressing[UP] = true;
+					un_press[UP] = false;
 					pressing[DOWN] = false;
 					lock[DOWN] = false;
 					joyLastPosY = JOY_POS_UP;
@@ -570,10 +589,8 @@ void InputState::handle(bool dump_event) {
 			}
 		}
 		if((joyAxisYval >= -JOY_DEADZONE) && (joyAxisYval < JOY_DEADZONE)) {
-			pressing[UP] = false;
-			lock[UP] = false;
-			pressing[DOWN] = false;
-			lock[DOWN] = false;
+			un_press[UP] = true;
+			un_press[DOWN] = true;
 			joyHasMovedY = 0;
 			joyLastPosY = JOY_POS_CENTER;
 		}

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -68,9 +68,6 @@ const int ACTIONBAR_USE = 28;
  */
 
 class InputState {
-private:
-	std::vector<int> wheel_binds;
-
 public:
 	static const int key_count = 29;
 	int binding[key_count];
@@ -106,6 +103,9 @@ public:
 	bool scroll_up;
 	bool scroll_down;
 	bool lock_scroll;
+
+private:
+	bool un_press[key_count];
 };
 
 #endif


### PR DESCRIPTION
mouse clicks, scroll motions, key presses, and joystick motions that are
activated then de-activated very quickly are now active for at least one
logical frame, so that they are not missed.

Fixes #1048

i did not test this on a joystick, as i don't have one. i tested scrolling, and it works as in the master branch. i tested keyboard and mouse clicking in various situations, such as holding the mouse button while running, etc.

<h5>edge-cases:</h5>

i didn't use the <code>wheel_binds</code> variable and loop because there are some edge cases where it wouldn't work. if one was holding a button, and then released and re-pressed it in an event window, then the long term result would appear that the button had been released.

by using <code>un_press</code>, the key will appear over the long term as if the button is still held, in that edge case. in the following frame, it will look like it was never lifted. that's not excellent, but getting a quick release and re-pressing of a key is much harder than a quick pressing and releasing. (because with the fast click, the finger can bounce off of the fully-pressed button.)

this issue would not be relevant with menu buttons. i only see it being relevant during battle if #146 is resolved. in that case, the effect of a single moment of ceased attack, if you time the release right, would be to move exactly where you were just attacking. in that case, you would need some lightening fingers to achieve that edge case.
