### PR TITLE
Complete attribute documentaion

### DIFF
--- a/mods/default/menus/fps.txt
+++ b/mods/default/menus/fps.txt
@@ -2,5 +2,5 @@
 # position is x,y,corner, where corner is any of the following:
 # top_left, top_right, bottom_left, bottom_right
 
-position=0,0,bottom_right
+position=0,0,bottomright
 color=255,255,255

--- a/src/AnimationSet.cpp
+++ b/src/AnimationSet.cpp
@@ -60,6 +60,7 @@ void AnimationSet::load() {
 	loaded = true;
 
 	FileParser parser;
+	// @CLASS Animation|Description of animations in animations/
 	if (!parser.open(name, true, true, "Error loading animation definition: " + name))
 		return;
 
@@ -92,6 +93,7 @@ void AnimationSet::load() {
 			compressed_loading = false;
 		}
 		if (parser.key == "image") {
+			// @ATTR image|string|Filename of sprite-sheet image.
 			if (sprite != NULL) {
 				printf("multiple images specified in %s, dragons be here!\n", name.c_str());
 				SDL_Quit();
@@ -101,28 +103,35 @@ void AnimationSet::load() {
 			sprite = loadTextureImage(parser.val);
 		}
 		else if (parser.key == "position") {
+			// @ATTR position|integer|Number of frames to the right to use as the first frame. Unpacked animations only.
 			position = toInt(parser.val);
 		}
 		else if (parser.key == "frames") {
+			// @ATTR frames|integer|The total number of frames
 			frames = toInt(parser.val);
 		}
 		else if (parser.key == "duration") {
+			// @ATTR duration|integer|The duration of each frame.
 			duration = toInt(parser.val);
 
 			// TEMP: if an animation is too fast, display one frame per fps anyway
 			if (duration < 1) duration=1;
 		}
 		else if (parser.key == "type")
+			// @ATTR type|[play_once, back_forth, looped]|How to loop (or not loop) this animation.
 			type = parser.val;
 		else if (parser.key == "render_size") {
+			// @ATTR render_size|w (integer), h (integer)|Width and height of animation.
 			render_size.x = toInt(parser.nextValue());
 			render_size.y = toInt(parser.nextValue());
 		}
 		else if (parser.key == "render_offset") {
+			// @ATTR render_offset|x (integer), y (integer)|Render x/y offset.
 			render_offset.x = toInt(parser.nextValue());
 			render_offset.y = toInt(parser.nextValue());
 		}
 		else if (parser.key == "active_frame") {
+			// @ATTR active_frame|[all:frame (integer), ...]|A list of frames marked as "active". Also, "all" can be used to mark all frames as active.
 			active_frames.clear();
 			string nv = parser.nextValue();
 			if (nv == "all") {
@@ -138,6 +147,7 @@ void AnimationSet::load() {
 			}
 		}
 		else if (parser.key == "frame") {
+			// @ATTR frame|index (integer), direction (integer), x (integer), y (integer), w (integer), h (integer), x offset (integer), y offset (integer)|A single frame of a compressed animation.
 			if (compressed_loading == false) { // first frame statement in section
 				newanim = new Animation(_name, type, sprite);
 				newanim->setup(frames, duration);

--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -67,10 +67,12 @@ Avatar::Avatar()
 	loadLayerDefinitions();
 
 	// load foot-step definitions
+	// @CLASS Avatar: Step sounds|Description of items/step_sounds.txt
 	FileParser infile;
 	if (infile.open("items/step_sounds.txt", true, true, "")) {
 		while (infile.next()) {
 			if (infile.key == "id") {
+				// @ATTR id|string|An identifier name for a set of step sounds.
 				step_def.push_back(Step_sfx());
 				step_def.back().id = infile.val;
 			}
@@ -78,6 +80,7 @@ Avatar::Avatar()
 			if (step_def.empty()) continue;
 
 			if (infile.key == "step") {
+				// @ATTR step|string|Filename of a step sound effect.
 				step_def.back().steps.push_back(infile.val);
 			}
 		}
@@ -144,7 +147,7 @@ void Avatar::loadLayerDefinitions() {
 	layer_reference_order = vector<string>();
 
 	FileParser infile;
-	// @CLASS Avatar|Description of engine/hero_layers.txt
+	// @CLASS Avatar: Hero layers|Description of engine/hero_layers.txt
 	if (infile.open("engine/hero_layers.txt")) {
 		while(infile.next()) {
 			if (infile.key == "layer") {

--- a/src/CursorManager.cpp
+++ b/src/CursorManager.cpp
@@ -31,9 +31,11 @@ CursorManager::CursorManager()
 	, offset_current(NULL) {
 	Image *graphics;
 	FileParser infile;
+	// @CLASS CursorManager|Description of engine/mouse_cursor.txt
 	if (infile.open("engine/mouse_cursor.txt", true, true, "")) {
 		while (infile.next()) {
 			if (infile.key == "normal") {
+				// @ATTR normal|string|Filename of an image for the normal cursor.
 				graphics = render_device->loadGraphicSurface(popFirstString(infile.val));
 				if (graphics) {
 					cursor_normal = graphics->createSprite();
@@ -42,6 +44,7 @@ CursorManager::CursorManager()
 				offset_normal = toPoint(infile.val);
 			}
 			else if (infile.key == "interact") {
+				// @ATTR interact|string|Filename of an image for the object interaction cursor.
 				graphics = render_device->loadGraphicSurface(popFirstString(infile.val));
 				if (graphics) {
 					cursor_interact = graphics->createSprite();
@@ -50,6 +53,7 @@ CursorManager::CursorManager()
 				offset_interact = toPoint(infile.val);
 			}
 			else if (infile.key == "talk") {
+				// @ATTR talk|string|Filename of an image for the NPC interaction cursor.
 				graphics = render_device->loadGraphicSurface(popFirstString(infile.val));
 				if (graphics) {
 					cursor_talk = graphics->createSprite();
@@ -58,6 +62,7 @@ CursorManager::CursorManager()
 				offset_talk = toPoint(infile.val);
 			}
 			else if (infile.key == "attack") {
+				// @ATTR attack|string|Filename of an image for the cursor when attacking enemies.
 				graphics = render_device->loadGraphicSurface(popFirstString(infile.val));
 				if (graphics) {
 					cursor_attack = graphics->createSprite();

--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -224,7 +224,7 @@ void EventManager::loadEventComponent(FileParser &infile, Event* evnt, Event_Com
 		e->s = msg->get(infile.val);
 	}
 	else if (infile.key == "shakycam") {
-		// @ATTR event.shakycam|integer|
+		// @ATTR event.shakycam|integer|Makes the camera shake for this duration.
 		e->x = toInt(infile.val);
 	}
 	else if (infile.key == "requires_status") {
@@ -393,11 +393,11 @@ void EventManager::loadEventComponent(FileParser &infile, Event* evnt, Event_Com
 		}
 	}
 	else if (infile.key == "stash") {
-		// @ATTR event.stash|string|
+		// @ATTR event.stash|string|Opens the Stash menu.
 		e->s = infile.val;
 	}
 	else if (infile.key == "npc") {
-		// @ATTR event.npc|string|
+		// @ATTR event.npc|string|Filename of an NPC to start dialog with.
 		e->s = infile.val;
 	}
 	else if (infile.key == "music") {
@@ -409,7 +409,7 @@ void EventManager::loadEventComponent(FileParser &infile, Event* evnt, Event_Com
 		e->s = infile.val;
 	}
 	else if (infile.key == "repeat") {
-		// @ATTR event.repeat|string|
+		// @ATTR event.repeat|string|Allows the event to be triggered again.
 		e->s = infile.val;
 	}
 	else {

--- a/src/FontEngine.cpp
+++ b/src/FontEngine.cpp
@@ -43,6 +43,7 @@ FontEngine::FontEngine()
 	}
 
 	// load the fonts
+	// @CLASS FontEngine: Font settings|Description of engine/font_settings.txt
 	FileParser infile;
 	if (infile.open("engine/font_settings.txt")) {
 		while (infile.next()) {
@@ -56,6 +57,7 @@ FontEngine::FontEngine()
 
 			FontStyle *style = &(font_styles.back());
 			if ((infile.key == "default" && style->path == "") || infile.key == LANGUAGE) {
+				// @ATTR $STYLE.default, $STYLE.$LANGUAGE|filename (string), point size (integer), blending (boolean)|Filename, point size, and blend mode of the font to use for this language. $STYLE can be something like "font_normal" or "font_bold". $LANGUAGE can be a 2-letter region code.
 				style->path = popFirstString(infile.val);
 				style->ptsize = popFirstInt(infile.val);
 				style->blend = toBool(popFirstString(infile.val));
@@ -77,6 +79,10 @@ FontEngine::FontEngine()
 	Color color;
 	if (infile.open("engine/font_colors.txt")) {
 		while (infile.next()) {
+			// @ATTR menu_normal, menu_bonus, menu_penalty, widget_normal, widget_disabled|r (integer), g (integer), b (integer)|Colors for menus and widgets
+			// @ATTR combat_givedmg, combat_takedmg, combat_crit, combat_buff, combat_miss|r (integer), g (integer), b (integer)|Colors for combat text
+			// @ATTR requirements_not_met, item_bonus, item_penalty, item_flavor|r (integer), g (integer), b (integer)|Colors for tooltips
+			// @ATTR item_$QUALITY|r (integer), g (integer), b (integer)|Colors for item quality. $QUALITY should match qualities used in items/items.txt
 			color_map[infile.key] = toRGB(infile.val);
 		}
 		infile.close();

--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -77,41 +77,50 @@ GameStateLoad::GameStateLoad() : GameState()
 	// Read positions from config file
 	FileParser infile;
 
+	// @CLASS GameStateLoad|Description of menus/gameload.txt
 	if (infile.open("menus/gameload.txt")) {
 		while (infile.next()) {
+			// @ATTR action_button|x (integer), y (integer)|Position of the "New Game"/"Load Game" button.
 			if (infile.key == "action_button") {
 				button_action->pos.x = popFirstInt(infile.val);
 				button_action->pos.y = popFirstInt(infile.val);
 			}
+			// @ATTR alternate_button|x (integer), y (integer)|Position of the "Delete Save" button.
 			else if (infile.key == "alternate_button") {
 				button_alternate->pos.x = popFirstInt(infile.val);
 				button_alternate->pos.y = popFirstInt(infile.val);
 			}
+			// @ATTR portrait|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the portrait image.
 			else if (infile.key == "portrait") {
 				portrait_dest = toRect(infile.val);
 				portrait_dest.x += (VIEW_W - FRAME_W) / 2;
 				portrait_dest.y += (VIEW_H - FRAME_H) / 2;
 			}
+			// @ATTR gameslot|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the first game slot.
 			else if (infile.key == "gameslot") {
 				gameslot_pos = toRect(infile.val);
 			}
+			// @ATTR preview|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the preview area in the first game slot. Only 'h' is used?
 			else if (infile.key == "preview") {
 				preview_pos = toRect(infile.val);
-				// label positions within each slot
 			}
+			// @ATTR name|label|The label for the hero's name. Position is relative to game slot position.
 			else if (infile.key == "name") {
 				name_pos = eatLabelInfo(infile.val);
 			}
+			// @ATTR level|label|The label for the hero's level. Position is relative to game slot position.
 			else if (infile.key == "level") {
 				level_pos = eatLabelInfo(infile.val);
 			}
+			// @ATTR map|label|The label for the hero's current location. Position is relative to game slot position.
 			else if (infile.key == "map") {
 				map_pos = eatLabelInfo(infile.val);
 			}
+			// @ATTR loading_label|label|The label for the "Entering game world..."/"Loading saved game..." text.
 			else if (infile.key == "loading_label") {
 				loading_pos = eatLabelInfo(infile.val);
-				// Position for the avatar preview image in each slot
 			}
+			// @ATTR sprite|x (integer), y (integer)|Position for the avatar preview image in each slot
 			else if (infile.key == "sprite") {
 				sprites_pos = toPoint(infile.val);
 			}

--- a/src/GameStateNew.cpp
+++ b/src/GameStateNew.cpp
@@ -87,42 +87,54 @@ GameStateNew::GameStateNew()
 	// Read positions from config file
 	FileParser infile;
 
+	// @CLASS GameStateNew: Layout|Description of menus/gamenew.txt
 	if (infile.open("menus/gamenew.txt")) {
 		while (infile.next()) {
+			// @ATTR button_prev|x (integer), y (integer)|Position of button to choose the previous preset hero.
 			if (infile.key == "button_prev") {
 				button_prev->pos.x = popFirstInt(infile.val);
 				button_prev->pos.y = popFirstInt(infile.val);
 			}
+			// @ATTR button_next|x (integer), y (integer)|Position of button to choose the next preset hero.
 			else if (infile.key == "button_next") {
 				button_next->pos.x = popFirstInt(infile.val);
 				button_next->pos.y = popFirstInt(infile.val);
 			}
+			// @ATTR button_permadeath|x (integer), y (integer)|Position of checkbox for toggling permadeath.
 			else if (infile.key == "button_permadeath") {
 				button_permadeath->pos.x = popFirstInt(infile.val);
 				button_permadeath->pos.y = popFirstInt(infile.val);
 			}
+			// @ATTR name_input|x (integer), y (integer)|Position of the hero name textbox.
 			else if (infile.key == "name_input") {
 				name_pos = toPoint(infile.val);
 			}
+			// @ATTR portrait_label|label|Label for the "Choose a Portrait" text.
 			else if (infile.key == "portrait_label") {
 				portrait_label = eatLabelInfo(infile.val);
 			}
+			// @ATTR name_label|label|Label for the "Choose a Name" text.
 			else if (infile.key == "name_label") {
 				name_label = eatLabelInfo(infile.val);
 			}
+			// @ATTR permadeath_label|label|Label for the "Permadeath?" text.
 			else if (infile.key == "permadeath_label") {
 				permadeath_label = eatLabelInfo(infile.val);
 			}
+			// @ATTR class_label|label|Label for the "Choose a Class" text.
 			else if (infile.key == "classlist_label") {
 				classlist_label = eatLabelInfo(infile.val);
 			}
+			// @ATTR portrait|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the portrait image.
 			else if (infile.key == "portrait") {
 				portrait_pos = toRect(infile.val);
 			}
+			// @ATTR class_list|x (integer), y (integer)|Position of the class list.
 			else if (infile.key == "class_list") {
 				class_list->pos.x = popFirstInt(infile.val);
 				class_list->pos.y = popFirstInt(infile.val);
 			}
+			// @ATTR show_classlist|boolean|Allows hiding the class list.
 			else if (infile.key == "show_classlist") {
 				show_classlist = toBool(infile.val);
 			}
@@ -227,9 +239,11 @@ void GameStateNew::loadPortrait(const string& portrait_filename) {
  */
 void GameStateNew::loadOptions(const string& filename) {
 	FileParser fin;
+	// @CLASS GameStateNew: Hero options|Description of engine/hero_options.txt
 	if (!fin.open("engine/" + filename, true, false)) return;
 
 	while (fin.next()) {
+		// @ATTR option|base (string), head (string), portrait (string), name (string)|A default body, head, portrait, and name for a hero.
 		if (fin.key == "option") {
 			base.push_back(fin.nextValue());
 			head.push_back(fin.nextValue());

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -408,6 +408,7 @@ void GameStatePlay::checkBook() {
 
 void GameStatePlay::loadTitles() {
 	FileParser infile;
+	// @CLASS GameStatePlay: Titles|Description of engine/titles.txt
 	if (infile.open("engine/titles.txt")) {
 		while (infile.next()) {
 			if (infile.new_section && infile.section == "title") {
@@ -417,11 +418,17 @@ void GameStatePlay::loadTitles() {
 
 			if (titles.empty()) continue;
 
+			// @ATTR title.title|string|The displayed title.
 			if (infile.key == "title") titles.back().title = infile.val;
+			// @ATTR title.level|integer|Requires level.
 			else if (infile.key == "level") titles.back().level = toInt(infile.val);
+			// @ATTR title.power|integer|Requires power.
 			else if (infile.key == "power") titles.back().power = toInt(infile.val);
+			// @ATTR title.requires_status|string|Requires status.
 			else if (infile.key == "requires_status") titles.back().requires_status = infile.val;
+			// @ATTR title.requires_not_status|string|Requires not status.
 			else if (infile.key == "requires_not_status") titles.back().requires_not = infile.val;
+			// @ATTR title.primary_stat|[physical, mental, offense, defense, physoff, physment, physdef, mentoff, offdef, mentdef]|Required primary stat.
 			else if (infile.key == "primary_stat") titles.back().primary_stat = infile.val;
 			else fprintf(stderr, "GameStatePlay: Unknown key value in title definitons: %s in file %s in section %s\n", infile.key.c_str(), infile.getFileName().c_str(), infile.section.c_str());
 		}

--- a/src/GameStateTitle.cpp
+++ b/src/GameStateTitle.cpp
@@ -42,11 +42,13 @@ GameStateTitle::GameStateTitle() : GameState() {
 	button_credits = new WidgetButton("images/menus/buttons/button_default.png");
 
 	FileParser infile;
+	// @CLASS GameStateTitle|Description of menus/gametitle.txt
 	if (infile.open("menus/gametitle.txt")) {
 		while (infile.next()) {
+			// @ATTR logo|filename (string), x (integer), y (integer), align (alignment)|Filename and position of the main logo image.
 			if (infile.key == "logo") {
-  			        Image *graphics;
-				graphics = render_device->loadGraphicSurface(popFirstString(infile.val), "");			       
+				Image *graphics;
+				graphics = render_device->loadGraphicSurface(popFirstString(infile.val), "");
 				if (graphics) {
 					Rect r;
  				        logo = graphics->createSprite();
@@ -61,21 +63,25 @@ GameStateTitle::GameStateTitle() : GameState() {
 					graphics->unref();
 				}
 			}
+			// @ATTR play_pos|x (integer), y (integer), align (alignment)|Position of the "Play Game" button.
 			else if (infile.key == "play_pos") {
 				button_play->pos.x = popFirstInt(infile.val);
 				button_play->pos.y = popFirstInt(infile.val);
 				alignToScreenEdge(popFirstString(infile.val), &(button_play->pos));
 			}
+			// @ATTR config_pos|x (integer), y (integer), align (alignment)|Position of the "Configuration" button.
 			else if (infile.key == "config_pos") {
 				button_cfg->pos.x = popFirstInt(infile.val);
 				button_cfg->pos.y = popFirstInt(infile.val);
 				alignToScreenEdge(popFirstString(infile.val), &(button_cfg->pos));
 			}
+			// @ATTR credits_pos|x (integer), y (integer), align (alignment)|Position of the "Credits" button.
 			else if (infile.key == "credits_pos") {
 				button_credits->pos.x = popFirstInt(infile.val);
 				button_credits->pos.y = popFirstInt(infile.val);
 				alignToScreenEdge(popFirstString(infile.val), &(button_credits->pos));
 			}
+			// @ATTR exit_pos|x (integer), y (integer), align (alignment)|Position of the "Exit Game" button.
 			else if (infile.key == "exit_pos") {
 				button_exit->pos.x = popFirstInt(infile.val);
 				button_exit->pos.y = popFirstInt(infile.val);

--- a/src/GameSwitcher.cpp
+++ b/src/GameSwitcher.cpp
@@ -69,8 +69,10 @@ void GameSwitcher::loadMusic() {
 
 		std::string music_filename = "";
 		FileParser infile;
+		// @CLASS GameSwitcher: Default music|Description of engine/default_music.txt
 		if (infile.open("engine/default_music.txt", true, true, "")) {
 			while (infile.next()) {
+				// @ATTR music|string|Filename of a music file to play during game states that don't already have music.
 				if (infile.key == "music") music_filename = infile.val;
 			}
 			infile.close();
@@ -133,13 +135,16 @@ void GameSwitcher::showFPS(int fps) {
 void GameSwitcher::loadFPS() {
 	// Load FPS rendering settings
 	FileParser infile;
+	// @CLASS GameSwitcher: FPS counter|Description of menus/fps.txt
 	if (infile.open("menus/fps.txt")) {
 		while(infile.next()) {
+			// @ATTR position|x (integer), y (integer), align (alignment)|Position of the fps counter.
 			if(infile.key == "position") {
 				fps_position.x = popFirstInt(infile.val);
 				fps_position.y = popFirstInt(infile.val);
 				fps_corner = popFirstString(infile.val);
 			}
+			// @ATTR color|r (integer), g (integer), b (integer)|Color of the fps counter text.
 			else if(infile.key == "color") {
 				fps_color = toRGB(infile.val);
 			}
@@ -149,22 +154,10 @@ void GameSwitcher::loadFPS() {
 
 	// this is a dummy string used to approximate the fps position when aligned to the right
 	font->setFont("font_regular");
-	int w = font->calc_width("00 fps");
-	int h = font->getLineHeight();
+	fps_position.w = font->calc_width("00 fps");
+	fps_position.h = font->getLineHeight();
 
-	if (fps_corner == "top_left") {
-		// relative to {0,0}, so no changes
-	}
-	else if (fps_corner == "top_right") {
-		fps_position.x += VIEW_W-w;
-	}
-	else if (fps_corner == "bottom_left") {
-		fps_position.y += VIEW_H-h;
-	}
-	else if (fps_corner == "bottom_right") {
-		fps_position.x += VIEW_W-w;
-		fps_position.y += VIEW_H-h;
-	}
+	alignToScreenEdge(fps_corner, &fps_position);
 
 	// Delete the label object if it exists (we'll recreate this with showFPS())
 	if (label_fps) {

--- a/src/GameSwitcher.h
+++ b/src/GameSwitcher.h
@@ -50,7 +50,7 @@ private:
 	GameState *currentState;
 
 	WidgetLabel *label_fps;
-	Point fps_position;
+	Rect fps_position;
 	Color fps_color;
 	std::string fps_corner;
 

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -143,17 +143,17 @@ void ItemManager::loadItems() {
 			// @ATTR name|string|Item name displayed on long and short tooltips.
 			items[id].name = msg->get(infile.val);
 		else if (infile.key == "flavor")
-			// @ATTR flavor|string|
+			// @ATTR flavor|string|A description of the item.
 			items[id].flavor = msg->get(infile.val);
 		else if (infile.key == "level")
-			// @ATTR level|integer|
+			// @ATTR level|integer|The item's level. Has no gameplay impact. (Deprecated?)
 			items[id].level = toInt(infile.val);
 		else if (infile.key == "icon") {
-			// @ATTR icon|integer|
+			// @ATTR icon|integer|An id for the icon to display for this item.
 			items[id].icon = toInt(infile.nextValue());
 		}
 		else if (infile.key == "book") {
-			// @ATTR book|string|
+			// @ATTR book|string|A book file to open when this item is activated.
 			items[id].book = infile.val;
 		}
 		else if (infile.key == "quality") {
@@ -170,6 +170,7 @@ void ItemManager::loadItems() {
 			items[id].type = infile.val;
 		}
 		else if (infile.key == "equip_flags") {
+			// @ATTR equip_flags|flag (string), ...|A comma separated list of flags to set when this item is equipped. See engine/equip_flags.txt.
 			std::string flag = popFirstString(infile.val);
 
 			while (flag != "") {
@@ -235,7 +236,7 @@ void ItemManager::loadItems() {
 			// @ATTR gfx|string|Graphics for the specific item.
 			items[id].gfx = infile.val;
 		else if (infile.key == "loot_animation") {
-			// @ATTR loot_animation|string|Specifies the loot animation for the item.
+			// @ATTR loot_animation|filename (string), min quantity (int), max quantity (int)|Specifies the loot animation for the item. The max quantity, or both quantity values, may be omitted.
 			LootAnimation la;
 			la.name = popFirstString(infile.val);
 			la.low = popFirstInt(infile.val);

--- a/src/LootManager.cpp
+++ b/src/LootManager.cpp
@@ -56,16 +56,8 @@ LootManager::LootManager(StatBlock *_hero)
 	// @CLASS Loot|Description of engine/loot.txt
 	if (infile.open("engine/loot.txt")) {
 		while (infile.next()) {
-			if (infile.key == "loot_animation") {
-				// @ATTR loot_animation|x(int), y(int), w(int), h(int)|
-				animation_pos = toRect(infile.val);
-			}
-			else if (infile.key == "loot_animation_offset") {
-				// @ATTR loot_animation_offset|x (integer), y (integer)|
-				animation_offset = toPoint(infile.val);
-			}
-			else if (infile.key == "tooltip_margin") {
-				// @ATTR tooltip_margin|integer|
+			if (infile.key == "tooltip_margin") {
+				// @ATTR tooltip_margin|integer|Vertical offset of the loot tooltip from the loot itself.
 				tooltip_margin = toInt(infile.val);
 			}
 			else if (infile.key == "autopickup_currency") {

--- a/src/LootManager.h
+++ b/src/LootManager.h
@@ -60,9 +60,6 @@ private:
 	// loot refers to ItemManager indices
 	std::vector<Loot> loot;
 
-	Rect animation_pos;
-	Point animation_offset;
-
 	// enemies which should drop loot, but didnt yet.
 	std::vector<const class Enemy*> enemiesDroppingLoot;
 

--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -159,7 +159,7 @@ void Map::loadLayer(FileParser &infile, maprow **current_layer) {
 
 void Map::loadEnemy(FileParser &infile) {
 	if (infile.key == "type") {
-		// @ATTR enemy.type|string|Enemy type
+		// @ATTR enemy.type|string|Filename of an enemy definition.
 		enemies.back().type = infile.val;
 	}
 	else if (infile.key == "location") {
@@ -204,7 +204,7 @@ void Map::loadEnemy(FileParser &infile) {
 
 void Map::loadEnemyGroup(FileParser &infile, Map_Group *group) {
 	if (infile.key == "type") {
-		// @ATTR enemygroup.type|string|Type of enemy group
+		// @ATTR enemygroup.type|string|The category of enemies that will spawn in this group.
 		group->category = infile.val;
 	}
 	else if (infile.key == "level") {
@@ -234,7 +234,7 @@ void Map::loadEnemyGroup(FileParser &infile, Map_Group *group) {
 void Map::loadNPC(FileParser &infile) {
 	std::string s;
 	if (infile.key == "type") {
-		// @ATTR npc.type|string|Type of NPC
+		// @ATTR npc.type|string|Filename of an NPC definition.
 		npcs.back().id = infile.val;
 	}
 	if (infile.key == "requires_status") {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -93,19 +93,24 @@ void Menu::align() {
  * When reading menu config files, we use this to set common variables
  */
 bool Menu::parseMenuKey(const std::string &key, const std::string &val) {
+	// @CLASS Menu|Description of menus in menus/
 	std::string value = val;
 
 	if (key == "pos") {
+		// @ATTR pos|x (integer), y (integer), w (integer), h (integer)|Menu position and dimensions
 		value = value + ',';
 		window_area = toRect(value);
 	}
 	else if (key == "align") {
+		// @ATTR align|alignment|Position relative to screen edges
 		alignment = value;
 	}
 	else if (key == "soundfx_open") {
+		// @ATTR soundfx_open|string|Filename of a sound to play when opening this menu.
 		sfx_open = snd->load(value, "Menu open tab");
 	}
 	else if (key == "soundfx_close") {
+		// @ATTR soundfx_close|string|Filename of a sound to play when closing this menu.
 		sfx_close = snd->load(value, "Menu close tab");
 	}
 	else {

--- a/src/MenuActionBar.cpp
+++ b/src/MenuActionBar.cpp
@@ -77,29 +77,55 @@ MenuActionBar::MenuActionBar(Avatar *_hero)
 	// Read data from config file
 	FileParser infile;
 
+	// @CLASS MenuActionBar|Description of menus/actionbar.txt
 	if (infile.open("menus/actionbar.txt")) {
 		while (infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
 				continue;
 
+			// numberArea
+			// @ATTR slot1|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 1.
 			if (infile.key == "slot1") slots[0]->pos = toRect(infile.val);
+			// @ATTR slot2|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 2.
 			else if (infile.key == "slot2") slots[1]->pos = toRect(infile.val);
+			// @ATTR slot3|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 3.
 			else if (infile.key == "slot3") slots[2]->pos = toRect(infile.val);
+			// @ATTR slot4|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 4.
 			else if (infile.key == "slot4") slots[3]->pos = toRect(infile.val);
+			// @ATTR slot5|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 5.
 			else if (infile.key == "slot5") slots[4]->pos = toRect(infile.val);
+			// @ATTR slot6|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 6.
 			else if (infile.key == "slot6") slots[5]->pos = toRect(infile.val);
+			// @ATTR slot7|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 7.
 			else if (infile.key == "slot7") slots[6]->pos = toRect(infile.val);
+			// @ATTR slot8|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 8.
 			else if (infile.key == "slot8") slots[7]->pos = toRect(infile.val);
+			// @ATTR slot9|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 9.
 			else if (infile.key == "slot9") slots[8]->pos = toRect(infile.val);
+			// @ATTR slot10|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 10.
 			else if (infile.key == "slot10") slots[9]->pos = toRect(infile.val);
+
+			// mouseArea
+			// @ATTR slot_M1|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 11.
 			else if (infile.key == "slot_M1") slots[10]->pos = toRect(infile.val);
+			// @ATTR slot_M2|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for slot 12.
 			else if (infile.key == "slot_M2") slots[11]->pos = toRect(infile.val);
+
+			// menuArea
+			// @ATTR char_menu|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for the Character menu button.
 			else if (infile.key == "char_menu") menus[MENU_CHARACTER]->pos = toRect(infile.val);
+			// @ATTR inv_menu|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for the Inventory menu button.
 			else if (infile.key == "inv_menu") menus[MENU_INVENTORY]->pos = toRect(infile.val);
+			// @ATTR powers_menu|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for the Powers menu button.
 			else if (infile.key == "powers_menu") menus[MENU_POWERS]->pos = toRect(infile.val);
+			// @ATTR log_menu|x (integer), y (integer), w (integer), h (integer)|Position and dimensions for the Log menu button.
 			else if (infile.key == "log_menu") menus[MENU_LOG]->pos = toRect(infile.val);
+
+			// @ATTR numberArea|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the area containing slots 1-10.
 			else if (infile.key == "numberArea") numberArea = toRect(infile.val);
+			// @ATTR mouseArea|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the area containing slots M1 and M2.
 			else if (infile.key == "mouseArea") mouseArea = toRect(infile.val);
+			// @ATTR menuArea|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the area containing the menu buttons.
 			else if (infile.key == "menuArea") menuArea = toRect(infile.val);
 		}
 		infile.close();

--- a/src/MenuActiveEffects.cpp
+++ b/src/MenuActiveEffects.cpp
@@ -41,11 +41,13 @@ MenuActiveEffects::MenuActiveEffects(StatBlock *_stats)
 	, orientation(false) { // horizontal
 	// Load config settings
 	FileParser infile;
+	// @CLASS MenuActiveEffects|Description of menus/activeeffects.txt
 	if(infile.open("menus/activeeffects.txt")) {
 		while(infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
 				continue;
 
+			// @ATTR orientation|boolean|True is vertical orientation; False is horizontal orientation.
 			if(infile.key == "orientation") {
 				orientation = toBool(infile.val);
 			}

--- a/src/MenuBook.cpp
+++ b/src/MenuBook.cpp
@@ -48,6 +48,7 @@ void MenuBook::loadBook() {
 	// Read data from config file
 	FileParser infile;
 
+	// @CLASS MenuBook|Description of books in books/
 	if (infile.open(book_name)) {
 		while (infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
@@ -55,12 +56,14 @@ void MenuBook::loadBook() {
 
 			infile.val = infile.val + ',';
 
+			// @ATTR close|x (integer), y (integer)|Position of the close button.
 			if(infile.key == "close") {
 				closeButton->pos.x = popFirstInt(infile.val);
 				closeButton->pos.y = popFirstInt(infile.val);
 			}
+			// @ATTR background|string|Filename for the background image.
 			else if (infile.key == "background") {
-			        setBackground(popFirstString(infile.val));
+				setBackground(popFirstString(infile.val));
 			}
 
 			if (infile.new_section) {
@@ -117,11 +120,13 @@ void MenuBook::loadBook() {
 }
 
 void MenuBook::loadImage(FileParser &infile) {
+	// @ATTR image.image_pos|x (integer), y (integer)|Position of the image.
 	if (infile.key == "image_pos") {
 		image_dest.back() = toPoint(infile.val);
 	}
+	// @ATTR image.image|string|Filename of the image.
 	else if (infile.key == "image") {
-	        Image *graphics;
+		Image *graphics;
 		graphics = render_device->loadGraphicSurface(popFirstString(infile.val));
 		if (graphics) {
 		  image.back() = graphics->createSprite();
@@ -131,6 +136,7 @@ void MenuBook::loadImage(FileParser &infile) {
 }
 
 void MenuBook::loadText(FileParser &infile) {
+	// @ATTR text.text_pos|x (integer), y (integer), w (integer), [left:center:right]|Position of the text.
 	if (infile.key == "text_pos") {
 		size.back().x = popFirstInt(infile.val);
 		size.back().y = popFirstInt(infile.val);
@@ -141,6 +147,7 @@ void MenuBook::loadText(FileParser &infile) {
 		else if (_justify == "center") justify.back() = JUSTIFY_CENTER;
 		else if (_justify == "right") justify.back() = JUSTIFY_RIGHT;
 	}
+	// @ATTR text.text_font|r (integer), g (integer), b (integer), style (string)|Font color and style.
 	else if (infile.key == "text_font") {
 		Color color;
 		color.r = popFirstInt(infile.val);
@@ -149,6 +156,7 @@ void MenuBook::loadText(FileParser &infile) {
 		textColor.back() = color;
 		textFont.back() = popFirstString(infile.val);
 	}
+	// @ATTR text.text|string|The text to be displayed.
 	else if (infile.key == "text") {
 		textData.back() = infile.val;
 		// remove comma from the end

--- a/src/MenuCharacter.cpp
+++ b/src/MenuCharacter.cpp
@@ -86,71 +86,120 @@ MenuCharacter::MenuCharacter(StatBlock *_stats) {
 
 	// Load config settings
 	FileParser infile;
+	// @CLASS MenuCharacter|Description of menus/character.txt
 	if (infile.open("menus/character.txt")) {
 		while(infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
 				continue;
 
+			// @ATTR close|x (integer), y (integer)|Position of the close button.
 			if(infile.key == "close") close_pos = toPoint(infile.val);
+			// @ATTR label_title|label|Position of the "Character" text.
 			else if(infile.key == "label_title") title = eatLabelInfo(infile.val);
+			// @ATTR upgrade_physical|x (integer), y (integer)|Position of the button used to add a stat point to Physical.
 			else if(infile.key == "upgrade_physical") upgrade_pos[0] = toPoint(infile.val);
+			// @ATTR upgrade_mental|x (integer), y (integer)|Position of the button used to add a stat point to Mental.
 			else if(infile.key == "upgrade_mental")	upgrade_pos[1] = toPoint(infile.val);
+			// @ATTR upgrade_offense|x (integer), y (integer)|Position of the button used to add a stat point to Offense.
 			else if(infile.key == "upgrade_offense") upgrade_pos[2] = toPoint(infile.val);
+			// @ATTR upgrade_defense|x (integer), y (integer)|Position of the button used to add a stat point to Defense.
 			else if(infile.key == "upgrade_defense") upgrade_pos[3] = toPoint(infile.val);
+			// @ATTR statlist|x (integer), y (integer)|Position of the scrollbox containing non-primary stats.
 			else if(infile.key == "statlist") statlist_pos = toPoint(infile.val);
+			// @ATTR statlist_rows|integer|The height of the statlist in rows.
 			else if (infile.key == "statlist_rows") statlist_rows = toInt(infile.val);
+			// @ATTR statlist_scrollbar_offset|integer|Right margin in pixels for the statlist's scrollbar.
 			else if (infile.key == "statlist_scrollbar_offset") statlist_scrollbar_offset = toInt(infile.val);
+
+			// @ATTR label_name|label|Position of the "Name" text.
 			else if(infile.key == "label_name") {
 				label_pos[0] = eatLabelInfo(infile.val);
 				cstat[CSTAT_NAME].visible = !label_pos[0].hidden;
 			}
+			// @ATTR label_level|label|Position of the "Level" text.
 			else if(infile.key == "label_level") {
 				label_pos[1] = eatLabelInfo(infile.val);
 				cstat[CSTAT_LEVEL].visible = !label_pos[1].hidden;
 			}
+			// @ATTR label_physical|label|Position of the "Physical" text.
 			else if(infile.key == "label_physical") {
 				label_pos[2] = eatLabelInfo(infile.val);
 				cstat[CSTAT_PHYSICAL].visible = !label_pos[2].hidden;
 			}
+			// @ATTR label_mental|label|Position of the "Mental" text.
 			else if(infile.key == "label_mental") {
 				label_pos[3] = eatLabelInfo(infile.val);
 				cstat[CSTAT_MENTAL].visible = !label_pos[3].hidden;
 			}
+			// @ATTR label_offense|label|Position of the "Offense" text.
 			else if(infile.key == "label_offense") {
 				label_pos[4] = eatLabelInfo(infile.val);
 				cstat[CSTAT_OFFENSE].visible = !label_pos[4].hidden;
 			}
+			// @ATTR label_defense|label|Position of the "Defense" text.
 			else if(infile.key == "label_defense") {
 				label_pos[5] = eatLabelInfo(infile.val);
 				cstat[CSTAT_DEFENSE].visible = !label_pos[5].hidden;
 			}
+
+			// @ATTR name|x (integer), y (integer), w (integer), h (integer)|Position of the player's name and dimensions of the tooltip hotspot.
 			else if(infile.key == "name") value_pos[0] = toRect(infile.val);
+			// @ATTR level|x (integer), y (integer), w (integer), h (integer)|Position of the player's level and dimensions of the tooltip hotspot.
 			else if(infile.key == "level") value_pos[1] = toRect(infile.val);
+			// @ATTR physical|x (integer), y (integer), w (integer), h (integer)|Position of the player's physical stat and dimensions of the tooltip hotspot.
 			else if(infile.key == "physical") value_pos[2] = toRect(infile.val);
+			// @ATTR mental|x (integer), y (integer), w (integer), h (integer)|Position of the player's mental stat and dimensions of the tooltip hotspot.
 			else if(infile.key == "mental") value_pos[3] = toRect(infile.val);
+			// @ATTR offense|x (integer), y (integer), w (integer), h (integer)|Position of the player's offense stat and dimensions of the tooltip hotspot.
 			else if(infile.key == "offense") value_pos[4] = toRect(infile.val);
+			// @ATTR defense|x (integer), y (integer), w (integer), h (integer)|Position of the player's defense stat and dimensions of the tooltip hotspot.
 			else if(infile.key == "defense") value_pos[5] = toRect(infile.val);
+
+			// @ATTR upspent|label|Position of the label showing the number of unspent stat points.
 			else if(infile.key == "unspent") unspent_pos = eatLabelInfo(infile.val);
+
+			// @ATTR show_upgrade_physical|boolean|Hide the Physical upgrade button if set to false.
 			else if (infile.key == "show_upgrade_physical") show_upgrade[0] = toBool(infile.val);
+			// @ATTR show_upgrade_mental|boolean|Hide the Mental upgrade button if set to false.
 			else if (infile.key == "show_upgrade_mental") show_upgrade[1] = toBool(infile.val);
+			// @ATTR show_upgrade_offense|boolean|Hide the Offense upgrade button if set to false.
 			else if (infile.key == "show_upgrade_offense") show_upgrade[2] = toBool(infile.val);
+			// @ATTR show_upgrade_defense|boolean|Hide the Defense upgrade button if set to false.
 			else if (infile.key == "show_upgrade_defense") show_upgrade[3] = toBool(infile.val);
+
+			// @ATTR show_maxhp|boolean|Hide the "Max HP" stat in the statlist if set to false.
 			else if (infile.key == "show_maxhp") show_stat[0] = toBool(infile.val);
+			// @ATTR show_hpregen|boolean|Hide the "HP Regen" stat in the statlist if set to false.
 			else if (infile.key == "show_hpregen") show_stat[1] = toBool(infile.val);
+			// @ATTR show_maxmp|boolean|Hide the "Max MP" stat in the statlist if set to false.
 			else if (infile.key == "show_maxmp") show_stat[2] = toBool(infile.val);
+			// @ATTR show_mpregen|boolean|Hide the "MP Regen" stat in the statlist if set to false.
 			else if (infile.key == "show_mpregen") show_stat[3] = toBool(infile.val);
+			// @ATTR show_accuracy|boolean|Hide the "Accuracy" stat in the statlist if set to false.
 			else if (infile.key == "show_accuracy") show_stat[4] = toBool(infile.val);
+			// @ATTR show_avoidance|boolean|Hide the "Avoidance" stat in the statlist if set to false.
 			else if (infile.key == "show_avoidance") show_stat[5] = toBool(infile.val);
+			// @ATTR show_melee|boolean|Hide the "Melee Damage" stat in the statlist if set to false.
 			else if (infile.key == "show_melee") show_stat[6] = toBool(infile.val);
+			// @ATTR show_ranged|boolean|Hide the "Ranged Damage" stat in the statlist if set to false.
 			else if (infile.key == "show_ranged") show_stat[7] = toBool(infile.val);
+			// @ATTR show_mental|boolean|Hide the "Mental Damage" stat in the statlist if set to false.
 			else if (infile.key == "show_mental") show_stat[8] = toBool(infile.val);
+			// @ATTR show_crit|boolean|Hide the "Crit" stat in the statlist if set to false.
 			else if (infile.key == "show_crit") show_stat[9] = toBool(infile.val);
+			// @ATTR show_absorb|boolean|Hide the "Absorb" stat in the statlist if set to false.
 			else if (infile.key == "show_absorb") show_stat[10] = toBool(infile.val);
+			// @ATTR show_poise|boolean|Hide the "Poise" stat in the statlist if set to false.
 			else if (infile.key == "show_poise") show_stat[11] = toBool(infile.val);
+			// @ATTR show_bonus_xp|boolean|Hide the "Bonus XP" stat in the statlist if set to false.
 			else if (infile.key == "show_bonus_xp") show_stat[12] = toBool(infile.val);
+			// @ATTR show_bonus_currency|boolean|Hide the "Bonus Gold" stat in the statlist if set to false.
 			else if (infile.key == "show_bonus_currency") show_stat[13] = toBool(infile.val);
+			// @ATTR show_bonus_itemfind|boolean|Hide the "Bonus Item Find" stat in the statlist if set to false.
 			else if (infile.key == "show_bonus_itemfind") show_stat[14] = toBool(infile.val);
+			// @ATTR show_bonus_stealth|boolean|Hide the "Stealth" stat in the statlist if set to false.
 			else if (infile.key == "show_bonus_stealth") show_stat[15] = toBool(infile.val);
+			// @ATTR show_resists|boolean|Hide the elemental "Resistance" stats in the statlist if set to false.
 			else if (infile.key == "show_resists") show_stat[16] = toBool(infile.val);
 		}
 		infile.close();

--- a/src/MenuEnemy.cpp
+++ b/src/MenuEnemy.cpp
@@ -40,6 +40,7 @@ MenuEnemy::MenuEnemy() {
 
 	// Load config settings
 	FileParser infile;
+	// @CLASS MenuEnemy|Description of menus/enemy.txt
 	if(infile.open("menus/enemy.txt")) {
 		while(infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
@@ -47,9 +48,11 @@ MenuEnemy::MenuEnemy() {
 
 			infile.val = infile.val + ',';
 
+			// @ATTR bar_pos|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the health bar.
 			if(infile.key == "bar_pos") {
 				bar_pos = toRect(infile.val);
 			}
+			// @ATTR text_pos|label|Position of the "$ENEMY level $LEVEL" text. Optional.
 			else if(infile.key == "text_pos") {
 				custom_text_pos = true;
 				text_pos = eatLabelInfo(infile.val);

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -60,12 +60,15 @@ MenuInventory::MenuInventory(StatBlock *_stats) {
 	// Load config settings
 	Rect equipment_slot;
 	FileParser infile;
+	// @CLASS MenuInventory|Description of menus/inventory.txt
 	if (infile.open("menus/inventory.txt")) {
 		while(infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
 				continue;
 
+			// @ATTR close|x (integer), y (integer)|Position of the close button.
 			if(infile.key == "close") close_pos = toPoint(infile.val);
+			// @ATTR equipment_slot|x (integer), y (integer), size (integer), slot_type (string)|Position and item type of an equipment slot.
 			else if(infile.key == "equipment_slot") {
 				equipment_slot.x = popFirstInt(infile.val);
 				equipment_slot.y = popFirstInt(infile.val);
@@ -73,15 +76,22 @@ MenuInventory::MenuInventory(StatBlock *_stats) {
 				equipped_area.push_back(equipment_slot);
 				slot_type.push_back(popFirstString(infile.val));
 			}
+			// @ATTR slot_name|string|The displayed name of the last defined equipment slot.
 			else if(infile.key == "slot_name") slot_desc.push_back(infile.val);
+			// @ATTR carried_area|x (integer), y (integer)|Position of the first normal inventory slot.
 			else if(infile.key == "carried_area") {
 				carried_area.x = popFirstInt(infile.val);
 				carried_area.y = popFirstInt(infile.val);
 			}
+			// @ATTR carried_cols|integer|The number of columns for the normal inventory.
 			else if (infile.key == "carried_cols") carried_cols = toInt(infile.val);
+			// @ATTR carried_rows|integer|The number of rows for the normal inventory.
 			else if (infile.key == "carried_rows") carried_rows = toInt(infile.val);
+			// @ATTR label_title|label|Position of the "Inventory" label.
 			else if (infile.key == "label_title") title =  eatLabelInfo(infile.val);
+			// @ATTR currency|label|Position of the label that displays the total currency being carried.
 			else if (infile.key == "currency") currency_lbl =  eatLabelInfo(infile.val);
+			// @ATTR help|x (integer), y (integer), w (integer), h (integer)|A mouse-over area that displays some help text for inventory shortcuts.
 			else if (infile.key == "help") help_pos = toRect(infile.val);
 		}
 		infile.close();

--- a/src/MenuLog.cpp
+++ b/src/MenuLog.cpp
@@ -40,17 +40,21 @@ MenuLog::MenuLog() {
 
 	// Load config settings
 	FileParser infile;
+	// @CLASS MenuLog|Description of menus/log.txt
 	if(infile.open("menus/log.txt")) {
 		while(infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
 				continue;
 
+			// @ATTR label_title|label|Position of the "Log" text.
 			if(infile.key == "label_title") {
 				title = eatLabelInfo(infile.val);
 			}
+			// @ATTR close|x (integer), y (integer)|Position of the close button.
 			else if(infile.key == "close") {
 				close_pos = toPoint(infile.val);
 			}
+			// @ATTR tab_area|x (integer), y (integer), w (integer), h (integer)|The position of the row of tabs, followed by the dimensions of the log text area.
 			else if(infile.key == "tab_area") {
 				tab_area = toRect(infile.val);
 			}

--- a/src/MenuMiniMap.cpp
+++ b/src/MenuMiniMap.cpp
@@ -47,14 +47,17 @@ MenuMiniMap::MenuMiniMap()
 
 	// Load config settings
 	FileParser infile;
+	// @CLASS MenuMiniMap|Description of menus/minimap.txt
 	if (infile.open("menus/minimap.txt")) {
 		while(infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
 				continue;
 
+			// @ATTR map_pos|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the map.
 			if(infile.key == "map_pos") {
 				pos = toRect(infile.val);
 			}
+			// @ATTR text_pos|label|Position of the text label with the map name.
 			else if(infile.key == "text_pos") {
 				text_pos = eatLabelInfo(infile.val);
 			}

--- a/src/MenuNPCActions.cpp
+++ b/src/MenuNPCActions.cpp
@@ -75,17 +75,25 @@ MenuNPCActions::MenuNPCActions()
 	, selected_dialog_node(-1) {
 	// Load config settings
 	FileParser infile;
+	// @CLASS MenuNPCActions/Description of menus/npc.txt
 	if (infile.open("menus/npc.txt")) {
 		while(infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
 				continue;
 
+			// @ATTR background_color|r (integer), g (integer), b (integer), a (integer)|Color and alpha of the menu's background.
 			if(infile.key == "background_color") background_color = toRGBA(infile.val);
+			// @ATTR topic_normal_color|r (integer), g (integer), b (integer)|The normal color of a generic topic text.
 			else if(infile.key == "topic_normal_color") topic_normal_color = toRGB(infile.val);
+			// @ATTR topic_hilight_color|r (integer), g (integer), b (integer)|The color of generic topic text when it's hovered over or selected.
 			else if(infile.key == "topic_hilight_color") topic_hilight_color = toRGB(infile.val);
+			// @ATTR vendor_normal_color|r (integer), g (integer), b (integer)|The normal color of the vendor option text.
 			else if(infile.key == "vendor_normal_color") vendor_normal_color = toRGB(infile.val);
+			// @ATTR vendor_hilight_color|r (integer), g (integer), b (integer)|The color of vendor option text when it's hovered over or selected.
 			else if(infile.key == "vendor_hilight_color") vendor_hilight_color = toRGB(infile.val);
+			// @ATTR cancel_normal_color|r (integer), g (integer), b (integer)|The normal color of the option to close the menu.
 			else if(infile.key == "cancel_normal_color") cancel_normal_color = toRGB(infile.val);
+			// @ATTR cancel_hilight_color|r (integer), g (integer), b (integer)|The color of the option to close the menu when it's hovered over or selected.
 			else if(infile.key == "cancel_hilight_color") cancel_hilight_color = toRGB(infile.val);
 		}
 		infile.close();

--- a/src/MenuPowers.cpp
+++ b/src/MenuPowers.cpp
@@ -57,6 +57,7 @@ MenuPowers::MenuPowers(StatBlock *_stats, MenuActionBar *_action_bar) {
 
 	// Read powers data from config file
 	FileParser infile;
+	// @CLASS MenuPowers|Description of menus/powers.txt
 	if (infile.open("menus/powers.txt")) {
 		while (infile.next()) {
 			if (infile.new_section) {
@@ -861,12 +862,19 @@ void MenuPowers::loadHeader(FileParser &infile) {
 	if (parseMenuKey(infile.key, infile.val))
 		return;
 
+	// @ATTR header.tab_title|string|Title to display for a tree page. Use only if tabs > 1.
 	if (infile.key == "tab_title") tab_titles.push_back(infile.val);
+	// @ATTR header.tab_tree|string|Filename of a background image to use for a tree page. Pair this with tab_title. Use only if tabs > 1.
 	else if (infile.key == "tab_tree") tree_image_files.push_back(infile.val);
+	// @ATTR header.label_title|label|Position of the "Powers" text.
 	else if (infile.key == "label_title") title = eatLabelInfo(infile.val);
+	// @ATTR header.unspent_points|label|Position of the text that displays the amount of unused power points.
 	else if (infile.key == "unspent_points") unspent_points = eatLabelInfo(infile.val);
+	// @ATTR header.close|x (integer), y (integer)|Position of the close button.
 	else if (infile.key == "close") close_pos = toPoint(infile.val);
+	// @ATTR header.tab_area|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the tree pages.
 	else if (infile.key == "tab_area") tab_area = toRect(infile.val);
+	// @ATTR header.tabs|integer|The total number of tree pages.
 	else if (infile.key == "tabs") {
 		tabs_count = toInt(infile.val);
 		if (tabs_count < 1) tabs_count = 1;
@@ -874,6 +882,7 @@ void MenuPowers::loadHeader(FileParser &infile) {
 }
 
 void MenuPowers::loadPower(FileParser &infile) {
+	// @ATTR power.id|integer|A power id from powers/powers.txt for this slot.
 	if (infile.key == "id") {
 		int id = popFirstInt(infile.val);
 		if (id > 0) {
@@ -892,18 +901,42 @@ void MenuPowers::loadPower(FileParser &infile) {
 	if (skip_section)
 		return;
 
+	// @ATTR power.tab|integer|Tab index to place this power on, starting from 0.
 	if (infile.key == "tab") power_cell.back().tab = toInt(infile.val);
+	// @ATTR power.position|x (integer), y (integer)|Position of this power icon.
 	else if (infile.key == "position") power_cell.back().pos = toPoint(infile.val);
+
+	// @ATTR power.requires_physoff|integer|Power requires Physical and Offense stat of this value.
 	else if (infile.key == "requires_physoff") power_cell.back().requires_physoff = toInt(infile.val);
+	// @ATTR power.requires_physdef|integer|Power requires Physical and Defense stat of this value.
 	else if (infile.key == "requires_physdef") power_cell.back().requires_physdef = toInt(infile.val);
+	// @ATTR power.requires_mentoff|integer|Power requires Mental and Offense stat of this value.
 	else if (infile.key == "requires_mentoff") power_cell.back().requires_mentoff = toInt(infile.val);
+	// @ATTR power.requires_mentdef|integer|Power requires Mental and Defense stat of this value.
 	else if (infile.key == "requires_mentdef") power_cell.back().requires_mentdef = toInt(infile.val);
+
+	// @ATTR power.requires_defense|integer|Power requires Defense stat of this value.
 	else if (infile.key == "requires_defense") power_cell.back().requires_defense = toInt(infile.val);
+	// @ATTR power.requires_offense|integer|Power requires Offense stat of this value.
 	else if (infile.key == "requires_offense") power_cell.back().requires_offense = toInt(infile.val);
+	// @ATTR power.requires_physical|integer|Power requires Physical stat of this value.
 	else if (infile.key == "requires_physical") power_cell.back().requires_physical = toInt(infile.val);
+	// @ATTR power.requires_mental|integer|Power requires Mental stat of this value.
 	else if (infile.key == "requires_mental") power_cell.back().requires_mental = toInt(infile.val);
+
+	// @ATTR power.requires_point|boolean|Power requires a power point to unlock.
 	else if (infile.key == "requires_point") power_cell.back().requires_point = toBool(infile.val);
+	// @ATTR power.requires_level|integer|Power requires at least this level for the hero.
 	else if (infile.key == "requires_level") power_cell.back().requires_level = toInt(infile.val);
+	// @ATTR power.requires_power|integer|Power requires another power id.
+	else if (infile.key == "requires_power") power_cell.back().requires_power.push_back(toInt(infile.val));
+
+	// @ATTR power.visible_requires_status|string|Hide the power if we don't have this campaign status.
+	else if (infile.key == "visible_requires_status") power_cell.back().visible_requires_status.push_back(infile.val);
+	// @ATTR power.visible_requires_status|string|Hide the power if we have this campaign status.
+	else if (infile.key == "visible_requires_not_status") power_cell.back().visible_requires_not.push_back(infile.val);
+
+	// @ATTR power.upgrades|id (integer), ...|A list of upgrade power ids that this power slot can upgrade to. Each of these powers should have a matching upgrade section.
 	else if (infile.key == "upgrades") {
 		upgradeButtons.back() = new WidgetButton("images/menus/buttons/button_plus.png");
 		string repeat_val = infile.nextValue();
@@ -912,12 +945,10 @@ void MenuPowers::loadPower(FileParser &infile) {
 			repeat_val = infile.nextValue();
 		}
 	}
-	else if (infile.key == "requires_power") power_cell.back().requires_power.push_back(toInt(infile.val));
-	else if (infile.key == "visible_requires_status") power_cell.back().visible_requires_status.push_back(infile.val);
-	else if (infile.key == "visible_requires_not_status") power_cell.back().visible_requires_not.push_back(infile.val);
 }
 
 void MenuPowers::loadUpgrade(FileParser &infile) {
+	// @ATTR upgrade.id|integer|A power id from powers/powers.txt for this upgrade.
 	if (infile.key == "id") {
 		int id = popFirstInt(infile.val);
 		if (id > 0) {
@@ -934,17 +965,33 @@ void MenuPowers::loadUpgrade(FileParser &infile) {
 	if (skip_section)
 		return;
 
+	// @ATTR upgrade.requires_physoff|integer|Upgrade requires Physical and Offense stat of this value.
 	if (infile.key == "requires_physoff") power_cell_upgrade.back().requires_physoff = toInt(infile.val);
+	// @ATTR upgrade.requires_physdef|integer|Upgrade requires Physical and Defense stat of this value.
 	else if (infile.key == "requires_physdef") power_cell_upgrade.back().requires_physdef = toInt(infile.val);
+	// @ATTR upgrade.requires_mentoff|integer|Upgrade requires Mental and Offense stat of this value.
 	else if (infile.key == "requires_mentoff") power_cell_upgrade.back().requires_mentoff = toInt(infile.val);
+	// @ATTR upgrade.requires_mentdef|integer|Upgrade requires Mental and Defense stat of this value.
 	else if (infile.key == "requires_mentdef") power_cell_upgrade.back().requires_mentdef = toInt(infile.val);
+
+	// @ATTR upgrade.requires_defense|integer|Upgrade requires Defense stat of this value.
 	else if (infile.key == "requires_defense") power_cell_upgrade.back().requires_defense = toInt(infile.val);
+	// @ATTR upgrade.requires_offense|integer|Upgrade requires Offense stat of this value.
 	else if (infile.key == "requires_offense") power_cell_upgrade.back().requires_offense = toInt(infile.val);
+	// @ATTR upgrade.requires_physical|integer|Upgrade requires Physical stat of this value.
 	else if (infile.key == "requires_physical") power_cell_upgrade.back().requires_physical = toInt(infile.val);
+	// @ATTR upgrade.requires_mental|integer|Upgrade requires Mental stat of this value.
 	else if (infile.key == "requires_mental") power_cell_upgrade.back().requires_mental = toInt(infile.val);
+
+	// @ATTR upgrade.requires_point|boolean|Upgrade requires a power point to unlock.
 	else if (infile.key == "requires_point") power_cell_upgrade.back().requires_point = toBool(infile.val);
+	// @ATTR upgrade.requires_level|integer|Upgrade requires at least this level for the hero.
 	else if (infile.key == "requires_level") power_cell_upgrade.back().requires_level = toInt(infile.val);
+	// @ATTR upgrade.requires_power|integer|Upgrade requires another power id.
 	else if (infile.key == "requires_power") power_cell_upgrade.back().requires_power.push_back(toInt(infile.val));
+
+	// @ATTR upgrade.visible_requires_status|string|Hide the upgrade if we don't have this campaign status.
 	else if (infile.key == "visible_requires_status") power_cell_upgrade.back().visible_requires_status.push_back(infile.val);
+	// @ATTR upgrade.visible_requires_not_status|string|Hide the upgrade if we have this campaign status.
 	else if (infile.key == "visible_requires_not_status") power_cell_upgrade.back().visible_requires_not.push_back(infile.val);
 }

--- a/src/MenuStash.cpp
+++ b/src/MenuStash.cpp
@@ -51,27 +51,34 @@ MenuStash::MenuStash(StatBlock *_stats)
 
 	// Load config settings
 	FileParser infile;
+	// @CLASS MenuStash|Description of menus/stash.txt
 	if (infile.open("menus/stash.txt")) {
 		while(infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
 				continue;
 
+			// @ATTR close|x (integer), y (integer)|Position of the close button.
 			if (infile.key == "close") {
 				close_pos = toPoint(infile.val);
 			}
+			// @ATTR slots_area|x (integer), y (integer)|Position of the top-left slot.
 			else if (infile.key == "slots_area") {
 				slots_area.x = popFirstInt(infile.val);
 				slots_area.y = popFirstInt(infile.val);
 			}
+			// @ATTR stash_cols|integer|The number of columns for the grid of slots.
 			else if (infile.key == "stash_cols") {
 				slots_cols = toInt(infile.val);
 			}
+			// @ATTR stash_rows|integer|The number of rows for the grid of slots.
 			else if (infile.key == "stash_rows") {
 				slots_rows = toInt(infile.val);
 			}
+			// @ATTR label_title|label|Position of the "Stash" label.
 			else if (infile.key == "label_title") {
 				title =  eatLabelInfo(infile.val);
 			}
+			// @ATTR currency|label|Position of the label displaying the amount of currency stored in the stash.
 			else if (infile.key == "currency") {
 				currency =  eatLabelInfo(infile.val);
 			}

--- a/src/MenuStatBar.cpp
+++ b/src/MenuStatBar.cpp
@@ -52,24 +52,30 @@ MenuStatBar::MenuStatBar(std::string type)
 
 	// Load config settings
 	FileParser infile;
+	// @CLASS MenuStatBar|Description of menus/hp.txt, menus/mp.txt, menus/xp.txt
 	if(infile.open("menus/"+type+".txt")) {
 		while(infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
 				continue;
 
+			// @ATTR bar_pos|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the bar graphics.
 			if(infile.key == "bar_pos") {
 				bar_pos = toRect(infile.val);
 			}
+			// @ATTR text_pos|label|Position of the "$CURRENT/$TOTAL" text.
 			else if(infile.key == "text_pos") {
 				custom_text_pos = true;
 				text_pos = eatLabelInfo(infile.val);
 			}
+			// @ATTR orientation|boolean|True is vertical orientation; false is horizontal.
 			else if(infile.key == "orientation") {
 				orientation = toBool(infile.val);
 			}
+			// @ATTR bar_gfx|string|Filename of the image to use for the "fill" of the bar.
 			else if (infile.key == "bar_gfx") {
 				bar_gfx = infile.val;
 			}
+			// @ATTR bar_gfx_background|string|Filename of the image to use for the base of the bar.
 			else if (infile.key == "bar_gfx_background") {
 				bar_gfx_background = infile.val;
 			}

--- a/src/MenuTalker.cpp
+++ b/src/MenuTalker.cpp
@@ -56,19 +56,29 @@ MenuTalker::MenuTalker(MenuManager *_menu)
 
 	// Load config settings
 	FileParser infile;
+	// @CLASS MenuTalker|Description of menus/talker.txt
 	if(infile.open("menus/talker.txt")) {
 		while(infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
 				continue;
 
+			// @ATTR close|x (integer), y (integer)|Position of the close button.
 			if(infile.key == "close") close_pos = toPoint(infile.val);
+			// @ATTR advance|x (integer), y (integer)|Position of the button to advance dialog.
 			else if(infile.key == "advance") advance_pos = toPoint(infile.val);
+			// @ATTR dialogbox|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the text box graphics.
 			else if (infile.key == "dialogbox") dialog_pos = toRect(infile.val);
+			// @ATTR dialogtext|x (integer), y (integer), w (integer), h (integer)|Rectangle where the dialog text is placed.
 			else if (infile.key == "dialogtext") text_pos = toRect(infile.val);
+			// @ATTR text_offset|x (integer), y (integer)|Margins for the left/right and top/bottom of the dialog text.
 			else if (infile.key == "text_offset") text_offset = toPoint(infile.val);
+			// @ATTR portrait_he|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the NPC portrait graphics.
 			else if (infile.key == "portrait_he") portrait_he = toRect(infile.val);
+			// @ATTR portrait_you|x (integer), y (integer), w (integer), h (integer)|Position and dimensions of the player's portrait graphics.
 			else if (infile.key == "portrait_you") portrait_you = toRect(infile.val);
+			// @ATTR font_who|string|Font style to use for the name of the currently talking person.
 			else if (infile.key == "font_who") font_who = infile.val;
+			// @ATTR font_dialog|string|Font style to use for the dialog text.
 			else if (infile.key == "font_dialog") font_dialog = infile.val;
 		}
 		infile.close();

--- a/src/MenuVendor.cpp
+++ b/src/MenuVendor.cpp
@@ -56,24 +56,30 @@ MenuVendor::MenuVendor(StatBlock *_stats)
 
 	// Load config settings
 	FileParser infile;
+	// @CLASS MenuVendor|Description of menus/vendor.txt
 	if(infile.open("menus/vendor.txt")) {
 		while(infile.next()) {
 			if (parseMenuKey(infile.key, infile.val))
 				continue;
 
+			// @ATTR close|x (integer), y (integer)|Position of the close button.
 			if(infile.key == "close") {
 				close_pos = toPoint(infile.val);
 			}
+			// @ATTR slots_area|x (integer), y (integer)|Position of the top-left slot.
 			else if(infile.key == "slots_area") {
 				slots_area.x = popFirstInt(infile.val);
 				slots_area.y = popFirstInt(infile.val);
 			}
+			// @ATTR vendor_cols|integer|The number of columns in the grid of slots.
 			else if (infile.key == "vendor_cols") {
 				slots_cols = toInt(infile.val);
 			}
+			// @ATTR vendor_rows|integer|The number of rows in the grid of slots.
 			else if (infile.key == "vendor_rows") {
 				slots_rows = toInt(infile.val);
 			}
+			// @ATTR label_title|label|The position of the text that displays the NPC's name.
 			else if (infile.key == "label_title") {
 				title =  eatLabelInfo(infile.val);
 			}

--- a/src/NPC.cpp
+++ b/src/NPC.cpp
@@ -72,6 +72,7 @@ void NPC::load(const string& npc_id, int hero_level) {
 
 	string filename_portrait = "";
 
+	// @CLASS NPC|Description of NPCs in npcs/
 	if (infile.open(npc_id)) {
 		while (infile.next()) {
 			if (infile.section == "dialog") {
@@ -81,19 +82,25 @@ void NPC::load(const string& npc_id, int hero_level) {
 				Event_Component e;
 				e.type = infile.key;
 				if (infile.key == "him" || infile.key == "her")
+					// @ATTR dialog.him, dialog.her|string|A line of dialog from the NPC.
 					e.s = msg->get(infile.val);
 				else if (infile.key == "you")
+					// @ATTR dialog.you|string|A line of dialog from the player.
 					e.s = msg->get(infile.val);
 				else if (infile.key == "voice") {
+					// @ATTR dialog.voice|string|Filename of a voice sound file to play.
 					e.x = loadSound(infile.val, NPC_VOX_QUEST);
 				}
 				else if (infile.key == "topic") {
+					// @ATTR dialog.topic|string|The name of this dialog topic. Displayed when picking a dialog tree.
 					e.s = msg->get(infile.val);
 				}
 				else if (infile.key == "group") {
+					// @ATTR dialog.group|string|Dialog group.
 					e.s = infile.val;
 				}
 				else if (infile.key == "allow_movement") {
+					// @ATTR dialog.allow_movement|boolean|Restrict the player's mvoement during dialog.
 					e.s = infile.val;
 				}
 				else {
@@ -105,31 +112,38 @@ void NPC::load(const string& npc_id, int hero_level) {
 			else {
 				filename = npc_id;
 				if (infile.key == "name") {
+					// @ATTR name|string|NPC's name.
 					name = msg->get(infile.val);
 				}
 				else if (infile.key == "level") {
+					// @ATTR level|[hero, level (integer)]|NPC's level. Can be "hero" to match the player's level.
 					if (infile.val == "hero")
 						level = hero_level;
 					else
 						level = toInt(infile.val);
 				}
 				else if (infile.key == "gfx") {
+					// @ATTR gfx|string|Filename of an animation definition.
 					gfx = infile.val;
 				}
 
 				// handle talkers
 				else if (infile.key == "talker") {
-					if (infile.val == "true") talker = true;
+					// @ATTR talker|boolean|Allows this NPC to be talked to.
+					talker = toBool(infile.val);
 				}
 				else if (infile.key == "portrait") {
+					// @ATTR portrait|string|Filename of a portrait image.
 					filename_portrait = infile.val;
 				}
 
 				// handle vendors
 				else if (infile.key == "vendor") {
-					if (infile.val == "true") vendor = true;
+					// @ATTR vendor|string|Allows this NPC to buy/sell items.
+					vendor = toBool(infile.val);
 				}
 				else if (infile.key == "constant_stock") {
+					// @ATTR constant_stock|item (integer), ...|A list of items this vendor has for sale.
 					stack.quantity = 1;
 					while (infile.val != "") {
 						stack.item = toInt(infile.nextValue());
@@ -137,6 +151,7 @@ void NPC::load(const string& npc_id, int hero_level) {
 					}
 				}
 				else if (infile.key == "status_stock") {
+					// @ATTR status_stock|status (string), item (integer), ...|A list of items this vendor will have for sale if the required status is met.
 					if (camp->checkStatus(infile.nextValue())) {
 						stack.quantity = 1;
 						while (infile.val != "") {
@@ -148,6 +163,7 @@ void NPC::load(const string& npc_id, int hero_level) {
 
 				// handle vocals
 				else if (infile.key == "vox_intro") {
+					// @ATTR vox_intro|string|Filename of a sound file to play when initially interacting with the NPC.
 					loadSound(infile.val, NPC_VOX_INTRO);
 				}
 			}

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -45,9 +45,11 @@ NPCManager::NPCManager(StatBlock *_stats)
 	, tooltip_margin(0) {
 	FileParser infile;
 	// load tooltip_margin from engine config file
+	// @CLASS NPCManager|Description of engine/tooltips.txt
 	if (infile.open("engine/tooltips.txt")) {
 		while (infile.next()) {
 			if (infile.key == "npc_tooltip_margin") {
+				// @ATTR npc_tooltip_margin|integer|Vertical offset for NPC labels.
 				tooltip_margin = toInt(infile.val);
 			}
 		}

--- a/src/PowerManager.cpp
+++ b/src/PowerManager.cpp
@@ -58,6 +58,7 @@ PowerManager::PowerManager()
 void PowerManager::loadEffects() {
 	FileParser infile;
 
+	// @CLASS Effects|Description of powers/effects.txt
 	if (!infile.open("powers/effects.txt", true, false))
 		return;
 
@@ -87,11 +88,11 @@ void PowerManager::loadEffects() {
 			effects[input_name].icon = toInt(infile.val);
 		}
 		else if (infile.key == "animation") {
-			// @ATTR animation|string|The name of effect animation.
+			// @ATTR animation|string|The filename of effect animation.
 			effects[input_name].animation = infile.val;
 		}
 		else if (infile.key == "additive") {
-			// @ATTR additive|bool|Effect is additive
+			// @ATTR additive|bool|Effect is cumulative
 			effects[input_name].additive = toBool(infile.val);
 		}
 		else if (infile.key == "render_above") {
@@ -105,7 +106,7 @@ void PowerManager::loadEffects() {
 void PowerManager::loadPowers() {
 	FileParser infile;
 
-	// @CLASS Power|Description about powers...
+	// @CLASS Powers|Description of powers/powers.txt
 	if (!infile.open("powers/powers.txt", true, false))
 		return;
 
@@ -159,7 +160,7 @@ void PowerManager::loadPowers() {
 			// @ATTR face|bool|Power will make hero or enemy to face the target location.
 			powers[input_id].face = toBool(infile.val);
 		else if (infile.key == "source_type") {
-			// @ATTR source_type|[hero:neutral:enemy]|
+			// @ATTR source_type|[hero:neutral:enemy]|Determines which entities the power can effect.
 			if (infile.val == "hero") powers[input_id].source_type = SOURCE_TYPE_HERO;
 			else if (infile.val == "neutral") powers[input_id].source_type = SOURCE_TYPE_NEUTRAL;
 			else if (infile.val == "enemy") powers[input_id].source_type = SOURCE_TYPE_ENEMY;
@@ -185,6 +186,7 @@ void PowerManager::loadPowers() {
 		}
 		// power requirements
 		else if (infile.key == "requires_flags") {
+			// @ATTR requires_flags|flag (string), ...|A comma separated list of equip flags that are required to use this power. See engine/equip_flags.txt
 			std::string flag = popFirstString(infile.val);
 
 			while (flag != "") {
@@ -199,7 +201,7 @@ void PowerManager::loadPowers() {
 			// @ATTR requires_hp|integer|Restrict power usage to a specified HP level.
 			powers[input_id].requires_hp = toInt(infile.val);
 		else if (infile.key == "sacrifice")
-			// @ATTR sacrifice|bool|
+			// @ATTR sacrifice|bool|If the power has requires_hp, allow it to kill the caster.
 			powers[input_id].sacrifice = toBool(infile.val);
 		else if (infile.key == "requires_los")
 			// @ATTR requires_los|bool|Requires a line-of-sight to target.
@@ -221,7 +223,7 @@ void PowerManager::loadPowers() {
 			powers[input_id].cooldown = parse_duration(infile.val);
 		// animation info
 		else if (infile.key == "animation")
-			// @ATTR animation|string|The name of power animation.
+			// @ATTR animation|string|The filename of the power animation.
 			powers[input_id].animation_name = infile.val;
 		else if (infile.key == "soundfx")
 			// @ATTR soundfx|string|Sound effect to play when use of power.
@@ -248,14 +250,14 @@ void PowerManager::loadPowers() {
 			// @ATTR floor|bool|The hazard is drawn between the background and the object layer.
 			powers[input_id].floor = toBool(infile.val);
 		else if (infile.key == "complete_animation")
-			// @ATTR complete_animation|bool|
+			// @ATTR complete_animation|bool|For hazards; Play the entire animation, even if the hazard has hit a target.
 			powers[input_id].complete_animation = toBool(infile.val);
 		// hazard traits
 		else if (infile.key == "use_hazard")
 			// @ATTR use_hazard|bool|Power uses hazard.
 			powers[input_id].use_hazard = toBool(infile.val);
 		else if (infile.key == "no_attack")
-			// @ATTR no_attack|bool|
+			// @ATTR no_attack|bool|Hazard won't affect other entities.
 			powers[input_id].no_attack = toBool(infile.val);
 		else if (infile.key == "radius")
 			// @ATTR radius|integer|Radius in pixels
@@ -276,32 +278,32 @@ void PowerManager::loadPowers() {
 			else fprintf(stderr, "unknown starting_pos %s\n", infile.val.c_str());
 		}
 		else if (infile.key == "multitarget")
-			// @ATTR multitarget|bool|
+			// @ATTR multitarget|bool|Allows a hazard power to hit more than one entity.
 			powers[input_id].multitarget = toBool(infile.val);
 		else if (infile.key == "trait_armor_penetration")
-			// @ATTR trait_armor_penetration|bool|
+			// @ATTR trait_armor_penetration|bool|Ignores the target's Absorbtion stat
 			powers[input_id].trait_armor_penetration = toBool(infile.val);
 		else if (infile.key == "trait_avoidance_ignore")
-			// @ATTR trait_avoidance_ignore|bool|
+			// @ATTR trait_avoidance_ignore|bool|Ignores the target's Avoidance stat
 			powers[input_id].trait_avoidance_ignore = toBool(infile.val);
 		else if (infile.key == "trait_crits_impaired")
-			// @ATTR trait_crits_impaired|bool|
+			// @ATTR trait_crits_impaired|integer|Increases critical hit percentage for slowed/immobile targets
 			powers[input_id].trait_crits_impaired = toInt(infile.val);
 		else if (infile.key == "trait_elemental") {
-			// @ATTR, trait_elemental|string|
+			// @ATTR trait_elemental|string|Damage done is elemental. See engine/elements.txt
 			for (unsigned int i=0; i<ELEMENTS.size(); i++) {
 				if (infile.val == ELEMENTS[i].name) powers[input_id].trait_elemental = i;
 			}
 		}
 		else if (infile.key == "target_range")
-			// @ATTR, target_range|float||The distance from the caster that the power can be activated
+			// @ATTR target_range|float||The distance from the caster that the power can be activated
 			powers[input_id].target_range = toFloat(infile.nextValue());
 		//steal effects
 		else if (infile.key == "hp_steal")
-			// @ATTR, hp_steal|integer|Percentage of damage to steal into HP
+			// @ATTR hp_steal|integer|Percentage of damage to steal into HP
 			powers[input_id].hp_steal = toInt(infile.val);
 		else if (infile.key == "mp_steal")
-			// @ATTR, mp_steal|integer|Percentage of damage to steal into MP
+			// @ATTR mp_steal|integer|Percentage of damage to steal into MP
 			powers[input_id].mp_steal = toInt(infile.val);
 		//missile modifiers
 		else if (infile.key == "missile_angle")
@@ -322,23 +324,23 @@ void PowerManager::loadPowers() {
 			// @ATTR transform_duration|duration|Duration for transform
 			powers[input_id].transform_duration = toInt(infile.val);
 		else if (infile.key == "manual_untransform")
-			// @ATTR transform_duration|bool|Force manual untranform
+			// @ATTR manual_untransform|bool|Force manual untranform
 			powers[input_id].manual_untransform = toBool(infile.val);
 		else if (infile.key == "keep_equipment")
 			// @ATTR keep_equipment|bool|Keep  equipment while transformed
 			powers[input_id].keep_equipment = toBool(infile.val);
 		// buffs
 		else if (infile.key == "buff")
-			// @ATTR buff|bool|
+			// @ATTR buff|bool|Power is cast upon the caster.
 			powers[input_id].buff= toBool(infile.val);
 		else if (infile.key == "buff_teleport")
-			// @ATTR buff_teleport|bool|
+			// @ATTR buff_teleport|bool|Power is a teleportation power.
 			powers[input_id].buff_teleport = toBool(infile.val);
 		else if (infile.key == "buff_party")
-			// @ATTR buff_part|bool|
+			// @ATTR buff_part|bool|Power is cast upon party members
 			powers[input_id].buff_party = toBool(infile.val);
 		else if (infile.key == "buff_party_power_id")
-			// @ATTR buff_part_power_id|bool|
+			// @ATTR buff_part_power_id|integer|Buffs a power id for all party members
 			powers[input_id].buff_party_power_id = toInt(infile.val);
 		else if (infile.key == "post_effect") {
 			// @ATTR post_effect|[effect_id, magnitude (integer), duration (integer)]|Post effect.
@@ -350,10 +352,10 @@ void PowerManager::loadPowers() {
 		}
 		// pre and post power effects
 		else if (infile.key == "post_power")
-			// @ATTR post_power|power_id|Post power
+			// @ATTR post_power|power_id|Trigger a power if the hazard did damage.
 			powers[input_id].post_power = toInt(infile.val);
 		else if (infile.key == "wall_power")
-			// @ATTR wall_power|power_id|Wall power
+			// @ATTR wall_power|power_id|Trigger a power if the hazard hit a wall.
 			powers[input_id].wall_power = toInt(infile.val);
 		else if (infile.key == "allow_power_mod")
 			// @ATTR allow_power_mod|bool|Allow power modifiers
@@ -363,7 +365,7 @@ void PowerManager::loadPowers() {
 			// @ATTR spawn_type|string|Type of spawn.
 			powers[input_id].spawn_type = infile.val;
 		else if (infile.key == "target_neighbor")
-			// @ATTR target_neighbor|int|Neigbor target.
+			// @ATTR target_neighbor|int|Target is changed to an adjacent tile within a radius.
 			powers[input_id].target_neighbor = toInt(infile.val);
 		else if (infile.key == "spawn_limit") {
 			// @ATTR spawn_limit|[fixed:stat:unlimited],stat[physical:mental:offense:defens]|
@@ -389,6 +391,7 @@ void PowerManager::loadPowers() {
 			}
 		}
 		else if (infile.key == "spawn_level") {
+			// @ATTR spawn_level|[default:fixed:stat:level],stat[physical:mental:offense:defens]|
 			std::string mode = popFirstString(infile.val);
 			if (mode == "default") powers[input_id].spawn_level_mode = SPAWN_LEVEL_MODE_DEFAULT;
 			else if (mode == "fixed") powers[input_id].spawn_level_mode = SPAWN_LEVEL_MODE_FIXED;
@@ -414,17 +417,17 @@ void PowerManager::loadPowers() {
 			}
 		}
 		else if (infile.key == "target_party")
-			// @ATTR target_party|bool|
+			// @ATTR target_party|bool|Hazard will only affect party members.
 			powers[input_id].target_party = toBool(infile.val);
 		else if (infile.key == "target_categories") {
-			// @ATTR target_categories|string,...|
+			// @ATTR target_categories|string,...|Hazard will only affect enemies in these categories.
 			string cat;
 			while ((cat = infile.nextValue()) != "") {
 				powers[input_id].target_categories.push_back(cat);
 			}
 		}
 		else if (infile.key == "modifier_accuracy") {
-			// @ATTR modifier_accuracy|[multiply:add:absolute], integer|
+			// @ATTR modifier_accuracy|[multiply:add:absolute], integer|Changes this power's accuracy.
 			std::string mode = popFirstString(infile.val);
 			if(mode == "multiply") powers[input_id].mod_accuracy_mode = STAT_MODIFIER_MODE_MULTIPLY;
 			else if(mode == "add") powers[input_id].mod_accuracy_mode = STAT_MODIFIER_MODE_ADD;
@@ -434,7 +437,7 @@ void PowerManager::loadPowers() {
 			powers[input_id].mod_accuracy_value = popFirstInt(infile.val);
 		}
 		else if (infile.key == "modifier_damage") {
-			// @ATTR modifier_damage|[multiply:add:absolute], integer|
+			// @ATTR modifier_damage|[multiply:add:absolute], integer|Changes this power's damage.
 			std::string mode = popFirstString(infile.val);
 			if(mode == "multiply") powers[input_id].mod_damage_mode = STAT_MODIFIER_MODE_MULTIPLY;
 			else if(mode == "add") powers[input_id].mod_damage_mode = STAT_MODIFIER_MODE_ADD;
@@ -445,7 +448,7 @@ void PowerManager::loadPowers() {
 			powers[input_id].mod_damage_value_max = popFirstInt(infile.val);
 		}
 		else if (infile.key == "modifier_critical") {
-			// @ATTR modifier_critical|[multiply:add:absolute], integer|
+			// @ATTR modifier_critical|[multiply:add:absolute], integer|Changes the chance that this power will land a critical hit.
 			std::string mode = popFirstString(infile.val);
 			if(mode == "multiply") powers[input_id].mod_crit_mode = STAT_MODIFIER_MODE_MULTIPLY;
 			else if(mode == "add") powers[input_id].mod_crit_mode = STAT_MODIFIER_MODE_ADD;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -407,15 +407,18 @@ void loadTilesetSettings() {
 
 	FileParser infile;
 	// load tileset settings from engine config
+	// @CLASS Settings: Tileset config|Description of engine/tileset_config.txt
 	if (infile.open("engine/tileset_config.txt", true, true, "Unable to open engine/tileset_config.txt! Defaulting to 64x32 isometric tiles.\n")) {
 		while (infile.next()) {
 			if (infile.key == "tile_size") {
+				// @ATTR tile_size|w (integet), h (integer)|The width and height of a tile.
 				TILE_W = toInt(infile.nextValue());
 				TILE_H = toInt(infile.nextValue());
 				TILE_W_HALF = TILE_W /2;
 				TILE_H_HALF = TILE_H /2;
 			}
 			else if (infile.key == "orientation") {
+				// @ATTR orientation|[isometric, orthogonal]|The perspective of tiles; isometric or orthogonal.
 				if (infile.val == "isometric")
 					TILESET_ORIENTATION = TILESET_ISOMETRIC;
 				else if (infile.val == "orthogonal")
@@ -497,59 +500,77 @@ void loadMiscSettings() {
 	INTERACT_RANGE = 3;
 
 	FileParser infile;
-	// load miscellaneous settings from engine config
-	// misc.txt
+	// @CLASS Settings: Misc|Description of engine/misc.txt
 	if (infile.open("engine/misc.txt")) {
 		while (infile.next()) {
+			// @ATTR save_hpmp|boolean|When saving the game, keep the hero's current HP and MP.
 			if (infile.key == "save_hpmp")
 				SAVE_HPMP = toBool(infile.val);
+			// @ATTR corpse_timeout|integer|Duration that a corpse can exist on the map.
 			else if (infile.key == "corpse_timeout")
 				CORPSE_TIMEOUT = toInt(infile.val);
+			// @ATTR sell_without_vendor|boolean|Allows selling items when not at a vendor via CTRL-Click.
 			else if (infile.key == "sell_without_vendor")
 				SELL_WITHOUT_VENDOR = toBool(infile.val);
+			// @ATTR aim_assist|integer|The pixel offset for powers that use aim_assist.
 			else if (infile.key == "aim_assist")
 				AIM_ASSIST = toInt(infile.val);
+			// @ATTR window_title|string|Sets the text in the window's titlebar.
 			else if (infile.key == "window_title")
 				WINDOW_TITLE = infile.val;
+			// @ATTR game_prefix|string|A string that's prepended to save filenames to prevent conflicts between mods.
 			else if (infile.key == "game_prefix")
 				GAME_PREFIX = infile.val;
+			// @ATTR sound_falloff|integer|The maximum radius in tiles that any single sound is audible.
 			else if (infile.key == "sound_falloff")
 				SOUND_FALLOFF = toInt(infile.val);
+			// @ATTR party_exp_percentage|integer|The percentage of XP given to allies.
 			else if (infile.key == "party_exp_percentage")
 				PARTY_EXP_PERCENTAGE = toInt(infile.val);
+			// @ATTR enable_ally_collision|boolean|Allows allies to block the player's path.
 			else if (infile.key == "enable_ally_collision")
 				ENABLE_ALLY_COLLISION = toBool(infile.val);
+			// @ATTR enable_ally_collision_ai|boolean|Allows allies to block the path of other AI creatures.
 			else if (infile.key == "enable_ally_collision_ai")
 				ENABLE_ALLY_COLLISION_AI = toBool(infile.val);
 			else if (infile.key == "currency_id") {
+				// @ATTR currency_id|integer|An item id that will be used as currency.
 				CURRENCY_ID = toInt(infile.val);
 				if (CURRENCY_ID < 1) {
 					CURRENCY_ID = 1;
 					fprintf(stderr, "Currency ID below the minimum allowed value. Resetting it to %d\n", CURRENCY_ID);
 				}
 			}
+			// @ATTR interact_range|float|Distance where the player can interact with objects and NPCs.
 			else if (infile.key == "interact_range")
 				INTERACT_RANGE = toFloat(infile.val);
+			// @ATTR menus_pause|boolean|Opening any menu will pause the game.
 			else if (infile.key == "menus_pause")
 				MENUS_PAUSE = toBool(infile.val);
 
 		}
 		infile.close();
 	}
-	// resolutions.txt
+
+	// @CLASS Settings: Resolution|Description of engine/resolutions.txt
 	if (infile.open("engine/resolutions.txt")) {
 		while (infile.next()) {
+			// @ATTR menu_frame_width|integer|Width of frame for New Game, Configuration, etc. menus.
 			if (infile.key == "menu_frame_width")
 				FRAME_W = toInt(infile.val);
+			// @ATTR menu_frame_width|integer|Height of frame for New Game, Configuration, etc. menus.
 			else if (infile.key == "menu_frame_height")
 				FRAME_H = toInt(infile.val);
+			// @ATTR icon_size|integer|Size of icons.
 			else if (infile.key == "icon_size")
 				ICON_SIZE = toInt(infile.val);
+			// @ATTR required_width|integer|Minimum window/screen resolution width.
 			else if (infile.key == "required_width") {
 				MIN_VIEW_W = toInt(infile.val);
 				if (VIEW_W < MIN_VIEW_W) VIEW_W = MIN_VIEW_W;
 				VIEW_W_HALF = VIEW_W/2;
 			}
+			// @ATTR required_width|integer|Minimum window/screen resolution height.
 			else if (infile.key == "required_height") {
 				MIN_VIEW_H = toInt(infile.val);
 				if (VIEW_H < MIN_VIEW_H) VIEW_H = MIN_VIEW_H;
@@ -558,34 +579,48 @@ void loadMiscSettings() {
 		}
 		infile.close();
 	}
-	// gameplay.txt
+
+	// @CLASS Settings: Gameplay|Description of engine/gameplay.txt
 	if (infile.open("engine/gameplay.txt")) {
 		while (infile.next()) {
 			if (infile.key == "enable_playgame") {
+				// @ATTR enable_playgame|boolean|Enables the "Play Game" button on the main menu.
 				ENABLE_PLAYGAME = toBool(infile.val);
 			}
 		}
 		infile.close();
 	}
-	// combat.txt
+
+	// @CLASS Settings: Combat|Description of engine/combat.txt
 	if (infile.open("engine/combat.txt")) {
 		while (infile.next()) {
+			// @ATTR max_absorb_percent|integer|Maximum percentage of damage that can be absorbed.
 			if (infile.key == "max_absorb_percent") MAX_ABSORB = toInt(infile.val);
+			// @ATTR max_resist_percent|integer|Maximum percentage of elemental damage that can be resisted.
 			else if (infile.key == "max_resist_percent") MAX_RESIST = toInt(infile.val);
+			// @ATTR max_block_percent|integer|Maximum percentage of damage that can be blocked.
 			else if (infile.key == "max_block_percent") MAX_BLOCK = toInt(infile.val);
+			// @ATTR max_avoidance_percent|integer|Maximum percentage chance that hazards can be avoided.
 			else if (infile.key == "max_avoidance_percent") MAX_AVOIDANCE = toInt(infile.val);
+			// @ATTR min_absorb_percent|integer|Minimum percentage of damage that can be absorbed.
 			else if (infile.key == "min_absorb_percent") MIN_ABSORB = toInt(infile.val);
+			// @ATTR min_resist_percent|integer|Minimum percentage of elemental damage that can be resisted.
 			else if (infile.key == "min_resist_percent") MIN_RESIST = toInt(infile.val);
+			// @ATTR min_block_percent|integer|Minimum percentage of damage that can be blocked.
 			else if (infile.key == "min_block_percent") MIN_BLOCK = toInt(infile.val);
+			// @ATTR min_avoidance_percent|integer|Minimum percentage chance that hazards can be avoided.
 			else if (infile.key == "min_avoidance_percent") MIN_AVOIDANCE = toInt(infile.val);
 		}
 		infile.close();
 	}
-	// elements.txt
+
+	// @CLASS Settings: Elements|Description of engine/elements.txt
 	if (infile.open("engine/elements.txt")) {
 		Element e;
 		while (infile.next()) {
+			// @ATTR name|string|An identifier for this element.
 			if (infile.key == "name") e.name = infile.val;
+			// @ATTR dscription|string|The displayed name of this element.
 			else if (infile.key == "description") e.description = infile.val;
 
 			if (e.name != "" && e.description != "") {
@@ -595,13 +630,16 @@ void loadMiscSettings() {
 		}
 		infile.close();
 	}
-	// equip_flags.txt
+
+	// @CLASS Settings: Equip flags|Description of engine/equip_flags.txt
 	if (infile.open("engine/equip_flags.txt", true, false)) {
 		string type,description;
 		type = description = "";
 
 		while (infile.next()) {
+			// @ATTR name|string|An identifier for this equip flag.
 			if (infile.key == "name") type = infile.val;
+			// @ATTR dscription|string|The displayed name of this equip flag.
 			else if (infile.key == "description") description = infile.val;
 
 			if (type != "" && description != "") {
@@ -611,10 +649,12 @@ void loadMiscSettings() {
 		}
 		infile.close();
 	}
-	// classes.txt
+
+	// @CLASS Settings: Classes|Description of engine/classes.txt
 	if (infile.open("engine/classes.txt")) {
 		HeroClass c;
 		while (infile.next()) {
+			// @ATTR name|string|The displayed name of this class.
 			if (infile.key == "name") c.name = infile.val;
 
 			if (c.name != "") {
@@ -623,25 +663,36 @@ void loadMiscSettings() {
 			}
 
 			if (!HERO_CLASSES.empty()) {
+				// @ATTR description|string|A description of this class.
 				if (infile.key == "description") HERO_CLASSES.back().description = infile.val;
+				// @ATTR currency|integer|The amount of currency this class will start with.
 				else if (infile.key == "currency") HERO_CLASSES.back().currency = toInt(infile.val);
+				// @ATTR equipment|item (integer), ...|A list of items that are equipped when starting with this class.
 				else if (infile.key == "equipment") HERO_CLASSES.back().equipment = infile.val;
+				// @ATTR physical|integer|Class starts with this physical stat.
 				else if (infile.key == "physical") HERO_CLASSES.back().physical = toInt(infile.val);
+				// @ATTR mental|integer|Class starts with this mental stat.
 				else if (infile.key == "mental") HERO_CLASSES.back().mental = toInt(infile.val);
+				// @ATTR offense|integer|Class starts with this offense stat.
 				else if (infile.key == "offense") HERO_CLASSES.back().offense = toInt(infile.val);
+				// @ATTR defense|integer|Class starts with this defense stat.
 				else if (infile.key == "defense") HERO_CLASSES.back().defense = toInt(infile.val);
+
 				else if (infile.key == "actionbar") {
+					// @ATTR actionbar|power (integer), ...|A list of powers to place in the action bar for the class.
 					for (int i=0; i<12; i++) {
 						HERO_CLASSES.back().hotkeys[i] = toInt(infile.nextValue());
 					}
 				}
 				else if (infile.key == "powers") {
+					// @ATTR powers|power (integer), ...|A list of powers that are unlocked when starting this class.
 					string power;
 					while ( (power = infile.nextValue()) != "") {
 						HERO_CLASSES.back().powers.push_back(toInt(power));
 					}
 				}
 				else if (infile.key == "campaign") {
+					// @ATTR campaign|status (string), ...|A list of campaign statuses that are set when starting this class.
 					string status;
 					while ( (status = infile.nextValue()) != "") {
 						HERO_CLASSES.back().statuses.push_back(status);
@@ -658,14 +709,20 @@ void loadMiscSettings() {
 		HERO_CLASSES.push_back(c);
 	}
 
-	// death_penalty.txt
+	// @CLASS Settings: Death penalty|Description of engine/death_penalty.txt
 	if (infile.open("engine/death_penalty.txt")) {
 		while (infile.next()) {
+			// @ATTR enable|boolean|Enable the death penalty.
 			if (infile.key == "enable") DEATH_PENALTY = toBool(infile.val);
+			// @ATTR permadeath|boolean|Force permadeath for all new saves.
 			else if (infile.key == "permadeath") DEATH_PENALTY_PERMADEATH = toBool(infile.val);
+			// @ATTR currency|integer|Remove this percentage of currency.
 			else if (infile.key == "currency") DEATH_PENALTY_CURRENCY = toInt(infile.val);
+			// @ATTR xp_total|integer|Remove this percentage of total XP.
 			else if (infile.key == "xp_total") DEATH_PENALTY_XP = toInt(infile.val);
+			// @ATTR xp_current_level|integer|Remove this percentage of the XP gained since the last level.
 			else if (infile.key == "xp_current_level") DEATH_PENALTY_XP_CURRENT = toInt(infile.val);
+			// @ATTR random_item|integer|Removes a random item from the player's inventory.
 			else if (infile.key == "random_item") DEATH_PENALTY_ITEM = toBool(infile.val);
 		}
 		infile.close();

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -180,44 +180,45 @@ bool sortLoot(const EnemyLoot &a, const EnemyLoot &b) {
 }
 
 bool StatBlock::loadCoreStat(FileParser *infile) {
+	// @CLASS StatBlock: Core stats|Description of engine/stats.txt and enemies in enemies/
 
 	int value = toInt(infile->val, 0);
 	float fvalue = toFloat(infile->val, 0);
 
 	if (infile->key == "speed") {
+		// @ATTR speed|float|Movement speed
 		speed = speed_default = fvalue / MAX_FRAMES_PER_SEC;
-		return true;
-	}
-	else if (infile->key == "categories") {
-		string cat;
-		while ((cat = infile->nextValue()) != "") {
-			categories.push_back(cat);
-		}
 		return true;
 	}
 	else {
 		for (unsigned i=0; i<STAT_COUNT; i++) {
 			if (infile->key == STAT_NAME[i]) {
+				// @ATTR $STATNAME|integer|The starting value for this stat.
 				starting[i] = value;
 				return true;
 			}
 			else if (infile->key == STAT_NAME[i] + "_per_level") {
+				// @ATTR $STATNAME_per_level|integer|The value for this stat added per level.
 				per_level[i] = value;
 				return true;
 			}
 			else if (infile->key == STAT_NAME[i] + "_per_physical") {
+				// @ATTR $STATNAME_per_physical|integer|The value for this stat added per Physical.
 				per_physical[i] = value;
 				return true;
 			}
 			else if (infile->key == STAT_NAME[i] + "_per_mental") {
+				// @ATTR $STATNAME_per_mental|integer|The value for this stat added per Mental.
 				per_mental[i] = value;
 				return true;
 			}
 			else if (infile->key == STAT_NAME[i] + "_per_offense") {
+				// @ATTR $STATNAME_per_offense|integer|The value for this stat added per Offense.
 				per_offense[i] = value;
 				return true;
 			}
 			else if (infile->key == STAT_NAME[i] + "_per_defense") {
+				// @ATTR $STATNAME_per_defense|integer|The value for this stat added per Defense.
 				per_defense[i] = value;
 				return true;
 			}
@@ -225,6 +226,7 @@ bool StatBlock::loadCoreStat(FileParser *infile) {
 
 		for (unsigned int i=0; i<ELEMENTS.size(); i++) {
 			if (infile->key == "vulnerable_" + ELEMENTS[i].name) {
+				// @ATTR vulnerable_$ELEMENT|integer|Percentage weakness to this element.
 				vulnerable[i] = vulnerable_base[i] = value;
 				return true;
 			}
@@ -238,12 +240,21 @@ bool StatBlock::loadCoreStat(FileParser *infile) {
  * Set paths for sound effects
  */
 bool StatBlock::loadSfxStat(FileParser *infile) {
+	// @CLASS StatBlock: Sound effects|Description of heroes in engine/avatar/ and enemies in enemies/
+
+	// @ATTR sfx_phys|string|Filename of sound effect for physical attack.
 	if (infile->key == "sfx_phys") sfx_phys = infile->val;
+	// @ATTR sfx_ment|string|Filename of sound effect for mental attack.
 	else if (infile->key == "sfx_ment") sfx_ment = infile->val;
+	// @ATTR sfx_hit|string|Filename of sound effect for being hit.
 	else if (infile->key == "sfx_hit") sfx_hit = infile->val;
+	// @ATTR sfx_die|string|Filename of sound effect for dying.
 	else if (infile->key == "sfx_die") sfx_die = infile->val;
+	// @ATTR sfx_critdie|string|Filename of sound effect for dying to a critical hit.
 	else if (infile->key == "sfx_critdie") sfx_critdie = infile->val;
+	// @ATTR sfx_block|string|Filename of sound effect for blocking an incoming hit.
 	else if (infile->key == "sfx_block") sfx_block = infile->val;
+	// @ATTR sfx_levelup|string|Filename of sound effect for leveling up.
 	else if (infile->key == "sfx_levelup") sfx_levelup = infile->val;
 	else return false;
 
@@ -254,6 +265,7 @@ bool StatBlock::loadSfxStat(FileParser *infile) {
  * load a statblock, typically for an enemy definition
  */
 void StatBlock::load(const string& filename) {
+	// @CLASS StatBlock: Enemies|Description of enemies in enemies/
 	FileParser infile;
 	if (!infile.open(filename))
 		return;
@@ -265,14 +277,19 @@ void StatBlock::load(const string& filename) {
 		float fnum = toFloat(infile.val);
 		bool valid = loadCoreStat(&infile) || loadSfxStat(&infile);
 
+		// @ATTR name|string|Name
 		if (infile.key == "name") name = msg->get(infile.val);
+		// @ATTR humanoid|boolean|This creature gives human traits when transformed into, such as the ability to talk with NPCs.
 		else if (infile.key == "humanoid") humanoid = toBool(infile.val);
 
+		// @ATTR level|integer|Level
 		else if (infile.key == "level") level = num;
 
 		// enemy death rewards and events
+		// @ATTR xp|integer|XP awarded upon death.
 		else if (infile.key == "xp") xp = num;
 		else if (infile.key == "loot") {
+			// @ATTR loot|[currency:item (integer)], chance (integer), min (integer), max (integer)|Possible loot that can be dropped on death.
 
 			// loot entries format:
 			// loot=[id],[percent_chance]
@@ -302,54 +319,91 @@ void StatBlock::load(const string& filename) {
 
 			loot.push_back(el);
 		}
+		// @ATTR defeat_status|string|Campaign status to set upon death.
 		else if (infile.key == "defeat_status") defeat_status = infile.val;
+		// @ATTR convert_status|string|Campaign status to set upon being converted to a player ally.
 		else if (infile.key == "convert_status") convert_status = infile.val;
+		// @ATTR first_defeat_loot|integer|Drops this item upon first death.
 		else if (infile.key == "first_defeat_loot") first_defeat_loot = num;
+		// @ATTR quest_loot|[requires status (string), requires not status (string), item (integer)|Drops this item when campaign status is met.
 		else if (infile.key == "quest_loot") {
 			quest_loot_requires_status = infile.nextValue();
 			quest_loot_requires_not_status = infile.nextValue();
 			quest_loot_id = toInt(infile.nextValue());
 		}
 		// combat stats
+		// @ATTR cooldown|integer|Cooldown between attacks.
 		else if (infile.key == "cooldown") cooldown = parse_duration(infile.val);
 
 		// behavior stats
+		// @ATTR flying|boolean|Creature can move over gaps/water.
 		else if (infile.key == "flying") flying = toBool(infile.val);
+		// @ATTR intangible|boolean|Creature can move through walls.
 		else if (infile.key == "intangible") intangible = toBool(infile.val);
+		// @ATTR facing|boolean|Creature can turn to face their target.
 		else if (infile.key == "facing") facing = toBool(infile.val);
 
+		// @ATTR waypoint_pause|integer|Duration to wait at each waypoint.
 		else if (infile.key == "waypoint_pause") waypoint_pause = num;
 
+		// @ATTR turn_delay|integer|Duration it takes for this creature to turn and face their target.
 		else if (infile.key == "turn_delay") turn_delay = num;
+		// @ATTR chance_pursue|integer|Percentage change that the creature will chase their target.
 		else if (infile.key == "chance_pursue") chance_pursue = num;
+		// @ATTR chance_flee|integer|Percentage chance that the creature will run away from their target.
 		else if (infile.key == "chance_flee") chance_flee = num;
 
+		// @ATTR chance_melee_phys|integer|Percentage chance that the creature will use their physical melee power.
 		else if (infile.key == "chance_melee_phys") power_chance[MELEE_PHYS] = num;
+		// @ATTR chance_melee_ment|integer|Percentage chance that the creature will use their mental melee power.
 		else if (infile.key == "chance_melee_ment") power_chance[MELEE_MENT] = num;
+		// @ATTR chance_ranged_phys|integer|Percentage chance that the creature will use their physical ranged power.
 		else if (infile.key == "chance_ranged_phys") power_chance[RANGED_PHYS] = num;
+		// @ATTR chance_ranged_ment|integer|Percentage chance that the creature will use their mental ranged power.
 		else if (infile.key == "chance_ranged_ment") power_chance[RANGED_MENT] = num;
+		// @ATTR power_melee_phys|integer|Power index for the physical melee power.
 		else if (infile.key == "power_melee_phys") power_index[MELEE_PHYS] = num;
+		// @ATTR power_melee_ment|integer|Power index for the mental melee power.
 		else if (infile.key == "power_melee_ment") power_index[MELEE_MENT] = num;
+		// @ATTR power_ranged_phys|integer|Power index for the physical ranged power.
 		else if (infile.key == "power_ranged_phys") power_index[RANGED_PHYS] = num;
+		// @ATTR power_ranged_ment|integer|Power index for the mental ranged power.
 		else if (infile.key == "power_ranged_ment") power_index[RANGED_MENT] = num;
+		// @ATTR power_beacon|integer|Power index of a "beacon" power used to aggro nearby creatures.
 		else if (infile.key == "power_beacon") power_index[BEACON] = num;
+		// @ATTR cooldown_melee_phys|duration|Cooldown after using the physical melee power.
 		else if (infile.key == "cooldown_melee_phys") power_cooldown[MELEE_PHYS] = parse_duration(infile.val);
+		// @ATTR cooldown_melee_ment|duration|Cooldown after using the mental melee power.
 		else if (infile.key == "cooldown_melee_ment") power_cooldown[MELEE_MENT] = parse_duration(infile.val);
+		// @ATTR cooldown_ranged_phys|duration|Cooldown after using the physical ranged power.
 		else if (infile.key == "cooldown_ranged_phys") power_cooldown[RANGED_PHYS] = parse_duration(infile.val);
+		// @ATTR cooldown_ranged_ment|duration|Cooldown after using the mental ranged power.
 		else if (infile.key == "cooldown_ranged_ment") power_cooldown[RANGED_MENT] = parse_duration(infile.val);
+		// @ATTR power_on_hit|integer|Power index that is triggered when hit.
 		else if (infile.key == "power_on_hit") power_index[ON_HIT] = num;
+		// @ATTR power_on_death|integer|Power index that is triggered when dead.
 		else if (infile.key == "power_on_death") power_index[ON_DEATH] = num;
+		// @ATTR power_on_half_dead|integer|Power index that is triggered when at half health.
 		else if (infile.key == "power_on_half_dead") power_index[ON_HALF_DEAD] = num;
+		// @ATTR power_on_debuff|integer|Power index that is triggered when under a negative status effect.
 		else if (infile.key == "power_on_debuff") power_index[ON_DEBUFF] = num;
+		// @ATTR power_on_join_combat|integer|Power index that is triggered when initiating combat.
 		else if (infile.key == "power_on_join_combat") power_index[ON_JOIN_COMBAT] = num;
+		// @ATTR chance_on_hit|integer|Percentage chance that power_on_hit will be triggered.
 		else if (infile.key == "chance_on_hit") power_chance[ON_HIT] = num;
+		// @ATTR chance_on_death|integer|Percentage chance that power_on_death will be triggered.
 		else if (infile.key == "chance_on_death") power_chance[ON_DEATH] = num;
+		// @ATTR chance_on_half_dead|integer|Percentage chance that power_on_half_dead will be triggered.
 		else if (infile.key == "chance_on_half_dead") power_chance[ON_HALF_DEAD] = num;
+		// @ATTR chance_on_debuff|integer|Percentage chance that power_on_debuff will be triggered.
 		else if (infile.key == "chance_on_debuff") power_chance[ON_DEBUFF] = num;
+		// @ATTR chance_on_join_combat|integer|Percentage chance that power_on_join_combat will be triggered.
 		else if (infile.key == "chance_on_join_combat") power_chance[ON_JOIN_COMBAT] = num;
+		// @ATTR cooldown_hit|integer|Duration of cooldown after being hit.
 		else if (infile.key == "cooldown_hit") cooldown_hit = num;
 
 		else if (infile.key == "passive_powers") {
+			// @ATTR passive_powers|power (integer), ...|A list of passive powers this creature has.
 			std::string p = infile.nextValue();
 			while (p != "") {
 				powers_passive.push_back(toInt(p));
@@ -357,22 +411,38 @@ void StatBlock::load(const string& filename) {
 			}
 		}
 
+		// @ATTR melee_range|float|Minimum distance from target required to use melee powers.
 		else if (infile.key == "melee_range") melee_range = fnum;
+		// @ATTR threat_range|float|Radius of the area this creature will be able to start chasing the hero.
 		else if (infile.key == "threat_range") threat_range = fnum;
+		// @ATTR passive_attacker|boolean|Won't initiate combat until attacked.
 		else if (infile.key == "passive_attacker") passive_attacker = toBool(infile.val);
 
-		// animation stats
+		// @ATTR melee_weapon_power|integer|Power index of a melee power that can be affected by power mod.
 		else if (infile.key == "melee_weapon_power") melee_weapon_power = num;
+		// @ATTR mental_weapon_power|integer|Power index of a mental power that can be affected by power mod.
 		else if (infile.key == "mental_weapon_power") mental_weapon_power = num;
+		// @ATTR ranged_weapon_power|integer|Power index of a ranged power that can be affected by power mod.
 		else if (infile.key == "ranged_weapon_power") ranged_weapon_power = num;
 
+		// @ATTR animations|string|Filename of an animation definition.
 		else if (infile.key == "animations") animations = infile.val;
 
-		// hide enemy HP bar
+		// @ATTR supress_hp|boolean|Hides the enemy HP bar for this creature.
 		else if (infile.key == "suppress_hp") suppress_hp = toBool(infile.val);
+
+		else if (infile.key == "categories") {
+			// @ATTR categories|category (string), ...|Categories that this enemy belongs to.
+			string cat;
+			while ((cat = infile.nextValue()) != "") {
+				categories.push_back(cat);
+			}
+		}
+
 		// this is only used for EnemyGroupManager
 		// we check for them here so that we don't get an error saying they are invalid
 		else if (infile.key == "rarity") ; // but do nothing
+
 		else if (!valid) {
 			fprintf(stderr, "%s=%s not a valid StatBlock parameter\n", infile.key.c_str(), infile.val.c_str());
 		}
@@ -621,6 +691,7 @@ bool StatBlock::canUsePower(const Power &power, unsigned powerid) const {
 void StatBlock::loadHeroStats() {
 	// Redefine numbers from config file if present
 	FileParser infile;
+	// @CLASS StatBlock: Hero stats|Description of engine/stats.txt
 	if (infile.open("engine/stats.txt")) {
 		while (infile.next()) {
 			int value = toInt(infile.val);
@@ -628,18 +699,23 @@ void StatBlock::loadHeroStats() {
 			loadCoreStat(&infile);
 
 			if (infile.key == "max_points_per_stat") {
+				// @ATTR max_points_per_stat|integer|Maximum points for each primary stat.
 				max_points_per_stat = value;
 			}
 			else if (infile.key == "sfx_step") {
+				// @ATTR sfx_step|string|An id for a set of step sound effects. See items/step_sounds.txt.
 				sfx_step = infile.val;
 			}
 			else if (infile.key == "stat_points_per_level") {
+				// @ATTR stat_points_per_level|integer|The amount of stat points awarded each level.
 				stat_points_per_level = value;
 			}
 			else if (infile.key == "power_points_per_level") {
+				// @ATTR power_points_per_level|integer|The amount of power points awarded each level.
 				power_points_per_level = value;
 			}
 			else if (infile.key == "cooldown_hit") {
+				// @ATTR cooldown_hit|integer|Cooldown after being hit.
 				cooldown_hit = value;
 			}
 		}
@@ -650,10 +726,12 @@ void StatBlock::loadHeroStats() {
 	statsLoaded = true;
 
 	// load the XP table
+	// @CLASS StatBlock: XP table|Description of engine/xp_table.txt
 	if (infile.open("engine/xp_table.txt")) {
 		while(infile.next()) {
 			unsigned key = toInt(infile.key);
 			if (key > 0) {
+				// @ATTR $LEVEL|integer|The amount of XP required for this level.
 				if (key > xp_table.size())
 					xp_table.resize(key);
 				xp_table[key - 1] = toInt(infile.val);

--- a/src/TileSet.cpp
+++ b/src/TileSet.cpp
@@ -88,12 +88,15 @@ void TileSet::load(const std::string& filename) {
 
 	FileParser infile;
 
+	// @CLASS TileSet|Description of tilesets in tilesets/
 	if (infile.open(filename)) {
 		while (infile.next()) {
 			if (infile.key == "img") {
+				// @ATTR img|string|Filename of a tile sheet image.
 				loadGraphics(infile.val);
 			}
 			else if (infile.key == "tile") {
+				// @ATTR tile|index (integer), x (integer), y (integer), w (integer), h (integer), x offset (integer), y offset (integer)|A single tile definition.
 
 				// Verify that we have graphics for tiles
 				if (!sprites) {
@@ -118,6 +121,7 @@ void TileSet::load(const std::string& filename) {
 				max_size_y = std::max(max_size_y, (tiles[index].tile->getClip().h / TILE_H) + 1);
 			}
 			else if (infile.key == "transparency") {
+				// @ATTR transparency|r (integer), g (integer), b (integer)|An RGB color to key out and treat as transparent.
 				alpha_background = false;
 
 				trans_r = (Uint8)popFirstInt(infile.val);
@@ -126,6 +130,7 @@ void TileSet::load(const std::string& filename) {
 
 			}
 			else if (infile.key == "animation") {
+				// @ATTR animation|tile index (integer), x (integer), y (integer), duration (integer), ...|An animation for a tile.
 				int frame = 0;
 				unsigned TILE_ID = toInt(infile.nextValue());
 

--- a/src/WidgetTooltip.cpp
+++ b/src/WidgetTooltip.cpp
@@ -39,12 +39,16 @@ WidgetTooltip::WidgetTooltip()
 
 	FileParser infile;
 	// load tooltip settings from engine config file
+	// @CLASS WidgetTooltip|Description of engine/tooltips.txt
 	if (infile.open("engine/tooltips.txt")) {
 		while (infile.next()) {
+			// @ATTR tooltip_offset|integer|Offset in pixels from the origin point (usually mouse cursor).
 			if (infile.key == "tooltip_offset")
 				offset = toInt(infile.val);
+			// @ATTR tooltip_width|integer|Maximum width of tooltip in pixels.
 			else if (infile.key == "tooltip_width")
 				width = toInt(infile.val);
+			// @ATTR tooltip_margin|integer|Padding between the text and the tooltip borders.
 			else if (infile.key == "tooltip_margin")
 				margin = toInt(infile.val);
 		}


### PR DESCRIPTION
This should cover all of Flare's moddable configuration files. Some of
the descriptions might not be perfect, but at least we'll have an
overview of everything we can put in these files.

Of course, the Attribute Documentation wiki page should be regenerated
and updated after this. I added a few new types that should be added to
the top of that page:
- float - a floating point number
- alignment - can be any of: topleft, top, topright, left, center, right, bottomleft, bottom, bottomright
- label - specified as: "hidden" or as: x (integer), y (integer), justify (string), valign (string), style (string); justify can be [left:center:right]; valign can be [top:center:bottom]; style is any font style defined in engine/font_settings.txt

Known issue: The only functionality change I made was to the position
attribute in menus/fps.txt. I changed the old parsing of the corner to
place it in to use the alignment type mentioned above. Yay consistency!
