### PR TITLE
Fix a segfault when dealing with erroneous menu power definitions.

### DIFF
--- a/src/MenuPowers.cpp
+++ b/src/MenuPowers.cpp
@@ -890,12 +890,16 @@ void MenuPowers::loadPower(FileParser &infile) {
 			power_cell.back().id = id;
 		}
 		else {
-			skip_section = true;
-			power_cell.pop_back();
-			slots.pop_back();
-			upgradeButtons.pop_back();
-			fprintf(stderr, "Power index inside power menu definition out of bounds 1-%d, skipping\n", INT_MAX);
+			fprintf(stderr, "Power index %d inside power menu definition out of bounds 1-%d, skipping\n", id, INT_MAX);
 		}
+	}
+
+	if (power_cell.back().id <= 0) {
+		skip_section = true;
+		power_cell.pop_back();
+		slots.pop_back();
+		upgradeButtons.pop_back();
+		fprintf(stderr, "There is a power without a valid id as the first attribute.\nIDs must be the first attribute in the power menu definition.\n");
 	}
 
 	if (skip_section)


### PR DESCRIPTION
If there was a power with no id attribute, you could crash the engine
by hovering the mouse over this power.

To reproduce the bug apply the following patch to the current flare-game:
--8<--
From 30545c2f1d006eed79641a8a9e54cb5f367f5ac5 Mon Sep 17 00:00:00 2001
From: Stefan Beller stefanbeller@googlemail.com
Date: Thu, 17 Apr 2014 18:05:39 +0200
Subject: [PATCH] show engine crash

---

 mods/fantasycore/menus/powers.txt | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)

diff --git a/mods/fantasycore/menus/powers.txt b/mods/fantasycore/menus/powers.txt
index 787816b..2db9c04 100644
--- a/mods/fantasycore/menus/powers.txt
+++ b/mods/fantasycore/menus/powers.txt
@@ -15,7 +15,7 @@ label_title=160,8,center,top
 close=294,2
 unspent_points=160,396,center,top
 #unspent_points=hidden
-tabs=3
+tabs=4

 tab_area=32,30,240,348

@@ -28,6 +28,10 @@ tab_tree=images/menus/powers_tree.png
 tab_title=Magician
 tab_tree=images/menus/powers_tree.png

+tab_title=test
+tab_tree=images/menus/powers_tree.png
+
+
 # First tab has index=0
 # Don't add tab_title=, tab_tree=, and tab= keys if you use only 1 tab

@@ -251,4 +255,6 @@ requires_defense=3
 requires_point=true

+[power]
+tab=4
## 

1.9.2.655.g72ce72a
