### PR TITLE
Don't floor() values that we cast to int

### DIFF
--- a/src/Hazard.cpp
+++ b/src/Hazard.cpp
@@ -104,7 +104,7 @@ void Hazard::logic() {
 			lifespan = 0;
 			hit_wall = true;
 
-			if (collider->is_outside_map((int)floor(pos.x), (int)floor(pos.y)))
+			if (collider->is_outside_map(int(pos.x), int(pos.y)))
 				remove_now = true;
 		}
 	}

--- a/src/MapCollision.cpp
+++ b/src/MapCollision.cpp
@@ -90,14 +90,14 @@ bool MapCollision::small_step_forced_slide(float &x, float &y, float step_x, flo
 		assert(step_y == 0);
 		float dy = y - floor(y);
 
-		if (is_valid_tile((int)floor(x), (int)floor(y) + 1, movement_type, is_hero)
-				&& is_valid_tile((int)floor(x) + sgn(step_x), (int)floor(y) + 1, movement_type, is_hero)
+		if (is_valid_tile(int(x), int(y) + 1, movement_type, is_hero)
+				&& is_valid_tile(int(x) + sgn(step_x), int(y) + 1, movement_type, is_hero)
 				&& dy > 0.5) {
 			y += 1 - dy + epsilon;
 			x += step_x;
 		}
-		else if (is_valid_tile((int)floor(x), (int)floor(y) - 1, movement_type, is_hero)
-				 && is_valid_tile((int)floor(x) + sgn(step_x), (int)floor(y) - 1, movement_type, is_hero)
+		else if (is_valid_tile(int(x), int(y) - 1, movement_type, is_hero)
+				 && is_valid_tile(int(x) + sgn(step_x), int(y) - 1, movement_type, is_hero)
 				 && dy < 0.5) {
 			y -= dy + epsilon;
 			x += step_x;
@@ -111,14 +111,14 @@ bool MapCollision::small_step_forced_slide(float &x, float &y, float step_x, flo
 		assert(step_x == 0);
 		float dx = x - floor(x);
 
-		if (is_valid_tile((int)floor(x) + 1, (int)floor(y), movement_type, is_hero)
-				&& is_valid_tile((int)floor(x) + 1, (int)floor(y) + sgn(step_y), movement_type, is_hero)
+		if (is_valid_tile(int(x) + 1, int(y), movement_type, is_hero)
+				&& is_valid_tile(int(x) + 1, int(y) + sgn(step_y), movement_type, is_hero)
 				&& dx > 0.5) {
 			x += 1 - dx + epsilon;
 			y += step_y;
 		}
-		else if (is_valid_tile((int)floor(x) - 1, (int)floor(y), movement_type, is_hero)
-				 && is_valid_tile((int)floor(x) - 1, (int)floor(y) + sgn(step_y), movement_type, is_hero)
+		else if (is_valid_tile(int(x) - 1, int(y), movement_type, is_hero)
+				 && is_valid_tile(int(x) - 1, int(y) + sgn(step_y), movement_type, is_hero)
 				 && dx < 0.5) {
 			x -= dx + epsilon;
 			y += step_y;
@@ -198,8 +198,8 @@ bool MapCollision::is_outside_map(const int& tile_x, const int& tile_y) const {
  */
 bool MapCollision::is_empty(const float& x, const float& y) const {
 	// map bounds check
-	const int tile_x = (int)floor(x);
-	const int tile_y = (int)floor(y);
+	const int tile_x = int(x);
+	const int tile_y = int(y);
 	if (is_outside_map(tile_x, tile_y)) return false;
 
 	// collision type check
@@ -213,8 +213,8 @@ bool MapCollision::is_empty(const float& x, const float& y) const {
 bool MapCollision::is_wall(const float& x, const float& y) const {
 
 	// bounds check
-	const int tile_x = (int)floor(x);
-	const int tile_y = (int)floor(y);
+	const int tile_x = int(x);
+	const int tile_y = int(y);
 	if (is_outside_map(tile_x, tile_y)) return true;
 
 	// collision type check
@@ -256,7 +256,7 @@ bool MapCollision::is_valid_tile(const int& tile_x, const int& tile_y, MOVEMENTT
  * Is this a valid position for an entity with this movement type?
  */
 bool MapCollision::is_valid_position(const float& x, const float& y, MOVEMENTTYPE movement_type, bool is_hero) const {
-	return is_valid_tile((int)floor(x), (int)floor(y), movement_type, is_hero);
+	return is_valid_tile(int(x), int(y), movement_type, is_hero);
 }
 
 /**
@@ -318,8 +318,8 @@ bool MapCollision::line_of_movement(const float& x1, const float& y1, const floa
 	if (movement_type == MOVEMENT_INTANGIBLE) return true;
 
 	// if the target is blocking, clear it temporarily
-	int tile_x = (int)floor(x2);
-	int tile_y = (int)floor(y2);
+	int tile_x = int(x2);
+	int tile_y = int(y2);
 	bool target_blocks = false;
 	int target_blocks_type = colmap[tile_x][tile_y];
 	if (colmap[tile_x][tile_y] == BLOCKS_ENTITIES || colmap[tile_x][tile_y] == BLOCKS_ENEMIES) {
@@ -475,8 +475,8 @@ bool MapCollision::compute_path(FPoint start_pos, FPoint end_pos, vector<FPoint>
 
 void MapCollision::block(const float& map_x, const float& map_y, bool is_ally) {
 
-	const int tile_x = (int)floor(map_x);
-	const int tile_y = (int)floor(map_y);
+	const int tile_x = int(map_x);
+	const int tile_y = int(map_y);
 
 	if (colmap[tile_x][tile_y] == BLOCKS_NONE) {
 		if(is_ally)
@@ -489,8 +489,8 @@ void MapCollision::block(const float& map_x, const float& map_y, bool is_ally) {
 
 void MapCollision::unblock(const float& map_x, const float& map_y) {
 
-	const int tile_x = (int)floor(map_x);
-	const int tile_y = (int)floor(map_y);
+	const int tile_x = int(map_x);
+	const int tile_y = int(map_y);
 
 	if (colmap[tile_x][tile_y] == BLOCKS_ENTITIES || colmap[tile_x][tile_y] == BLOCKS_ENEMIES) {
 		colmap[tile_x][tile_y] = BLOCKS_NONE;

--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -600,8 +600,8 @@ void MapRenderer::executeOnMapExitEvents() {
 
 void MapRenderer::checkEvents(FPoint loc) {
 	Point maploc;
-	maploc.x = (int)floor(loc.x);
-	maploc.y = (int)floor(loc.y);
+	maploc.x = int(loc.x);
+	maploc.y = int(loc.y);
 	vector<Event>::iterator it;
 
 	// loop in reverse because we may erase elements

--- a/src/MenuMiniMap.cpp
+++ b/src/MenuMiniMap.cpp
@@ -121,8 +121,8 @@ void MenuMiniMap::prerender(MapCollision *collider, int map_w, int map_h) {
  */
 void MenuMiniMap::renderOrtho(FPoint hero_pos) {
 
-	const int herox = (int)floor(hero_pos.x);
-	const int heroy = (int)floor(hero_pos.y);
+	const int herox = int(hero_pos.x);
+	const int heroy = int(hero_pos.y);
 
 	Rect clip;
 	clip.x = herox - pos.w/2;
@@ -155,8 +155,8 @@ void MenuMiniMap::renderOrtho(FPoint hero_pos) {
  */
 void MenuMiniMap::renderIso(FPoint hero_pos) {
 
-	const int herox = (int)floor(hero_pos.x);
-	const int heroy = (int)floor(hero_pos.y);
+	const int herox = int(hero_pos.x);
+	const int heroy = int(hero_pos.y);
 	const int heroy_screen = herox + heroy;
 	const int herox_screen = herox - heroy + std::max(map_size.x, map_size.y);
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -28,8 +28,8 @@ using namespace std;
 
 Point floor(FPoint fp) {
 	Point result;
-	result.x = (int)floor(fp.x);
-	result.y = (int)floor(fp.y);
+	result.x = int(fp.x);
+	result.y = int(fp.y);
 	return result;
 }
 
@@ -91,8 +91,8 @@ FPoint collision_to_map(Point p) {
 
 Point map_to_collision(FPoint p) {
 	Point ret;
-	ret.x = (int)floor(p.x);
-	ret.y = (int)floor(p.y);
+	ret.x = int(p.x);
+	ret.y = int(p.y);
 	return ret;
 }
 


### PR DESCRIPTION
Doing so was a pointless step, since casting floats to ints implicitly
"floors" them.
