### PR TITLE
Fix problems building with CodeBlocks/MinGW

### DIFF
--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -58,7 +58,7 @@ if(NOT SDL2_BUILDING_LIBRARY)
     # seem to provide SDLmain for compatibility even though they don't
     # necessarily need it.
     find_library(SDL2MAIN_LIBRARY
-      NAMES SDLmain
+      NAMES SDL2main
       HINTS
         ENV SDLDIR
       PATH_SUFFIXES lib

--- a/src/MapCollision.cpp
+++ b/src/MapCollision.cpp
@@ -30,6 +30,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include <cfloat>
 #include <math.h>
 #include <cassert>
+#include <cstring>
 
 using namespace std;
 

--- a/src/RenderDevice.cpp
+++ b/src/RenderDevice.cpp
@@ -16,6 +16,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 */
 
 #include <assert.h>
+#include <stdio.h>
 #include "RenderDevice.h"
 
 


### PR DESCRIPTION
- Fix searching for SDL2main
- Include cstring in MapCollision.cpp for memset()
- Include stdio.h in RenderDevice.cpp for fprintf()
