### PR TITLE
Create a new Image when using resize()

### DIFF
--- a/src/GameStateCutscene.cpp
+++ b/src/GameStateCutscene.cpp
@@ -53,7 +53,9 @@ Image *Scene::loadImage(std::string filename, bool scale_graphics) {
 	if (scale_graphics) {
 		if (image->getWidth() > 0) {
 			float ratio = image->getHeight()/(float)image->getWidth();
-			image->resize(VIEW_W, (int)(VIEW_W*ratio));
+			Image *resized = image->resize(VIEW_W, (int)(VIEW_W*ratio));
+			if (resized)
+				image = resized;
 		}
 		else {
 			fprintf(stderr, "Error: Can not scale cutscene image with a width of 0.\n");

--- a/src/RenderDevice.h
+++ b/src/RenderDevice.h
@@ -119,7 +119,7 @@ public:
 	virtual void drawPixel(int x, int y, Uint32 color) = 0;
 	virtual Uint32 MapRGB(Uint8 r, Uint8 g, Uint8 b) = 0;
 	virtual Uint32 MapRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a) = 0;
-	virtual void resize(int width, int height) = 0;
+	virtual Image* resize(int width, int height) = 0;
 	virtual bool checkPixel(Point px) = 0;
 
 	class Sprite *createSprite(bool clipToSize = true);

--- a/src/SDLSoftwareRenderDevice.cpp
+++ b/src/SDLSoftwareRenderDevice.cpp
@@ -109,9 +109,13 @@ Uint32 SDLSoftwareImage::MapRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a) {
 	return SDL_MapRGBA(surface->format, r, g, b, a);
 }
 
-void SDLSoftwareImage::resize(int width, int height) {
+/**
+ * Resizes an image
+ * Deletes the original image and returns a pointer to the resized version
+ */
+Image* SDLSoftwareImage::resize(int width, int height) {
 	if(!surface || width <= 0 || height <= 0)
-		return;
+		return NULL;
 
 	SDLSoftwareImage *scaled = new SDLSoftwareImage(device);
 	scaled->surface = SDL_CreateRGBSurface(surface->flags, width, height,
@@ -138,12 +142,12 @@ void SDLSoftwareImage::resize(int width, int height) {
 				}
 			}
 		}
-		/* swap surface from scaled to source */
-		SDL_FreeSurface(surface);
-		surface = scaled->surface;
-		scaled->surface = NULL;
-		scaled->unref();
+		// delete the old image and return the new one
+		this->unref();
+		return scaled;
 	}
+
+	return NULL;
 }
 
 Uint32 SDLSoftwareImage::readPixel(int x, int y) {

--- a/src/SDLSoftwareRenderDevice.h
+++ b/src/SDLSoftwareRenderDevice.h
@@ -51,7 +51,7 @@ public:
 	void drawPixel(int x, int y, Uint32 color);
 	Uint32 MapRGB(Uint8 r, Uint8 g, Uint8 b);
 	Uint32 MapRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a);
-	void resize(int width, int height);
+	Image* resize(int width, int height);
 	bool checkPixel(Point px);
 
 	SDL_Surface *surface;


### PR DESCRIPTION
This fixes a bug where cached images were being resized. The place
I noticed this was when turning on "scale_gfx" in cutscenes/credits.txt.
Since we use the Flare logo on both the title screen and the default
credits, the image was resized on the title screen after viewing the
credits.
