### PR TITLE
Add appdata file for the Fedora Software center

### DIFF
--- a/distribution/appdata
+++ b/distribution/appdata
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+ <id type="desktop">flare-engine.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-2.0+ and GFDL-1.3</project_license>
+ <name>Flare</name>
+ <summary></summary>
+ <description>
+  <p>
+   This is a Free Libre Action Roleplay game Engine. It drives games such as:
+  </p>
+  <ul>
+   <li>Flare-game</li>
+   <li>Polymorphable</li>
+   <li>Wandercall</li>
+  </ul>
+ </description>
+ <screenshots>
+  <screenshot type="default" width="640" height="480">https://github.com/bjorn/tiled/wiki/images/Osare.jpg</screenshot>
+ </screenshots>
+ <url type="homepage">http://flarerpg.org/</url>
+ <updatecontact>https://github.com/clintbellanger/flare-engine/issues</updatecontact>
+</application>


### PR DESCRIPTION
Solves #960

@Ablu Would such an appdata file be sufficient?

Anyway we should have our own quality screenshots in our wiki, not linking to tiled.
