### PR TITLE
Fix a crash when removing duplicates on the ModList

### DIFF
--- a/src/ModManager.cpp
+++ b/src/ModManager.cpp
@@ -191,11 +191,11 @@ vector<string> ModManager::list(const string &path, bool full_paths) {
 		}
 
 		// remove duplicates
-		for (unsigned i=ret.size(); i>0; i--) {
-			for (unsigned j=0; j<i-1; j++) {
-				if (ret[i-1] == ret[j]) {
+		for (unsigned i=ret.size()-1; i != 0; i--) {
+			for (unsigned j = i; j != 0; j--) {
+				if (ret[i] == ret[j]) {
 					ret.erase(ret.begin()+j);
-					j--;
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
When having unsigned data types comparing > 0 is a tricky business.
This is tested and seems to work

Reported-By: tomreyn
