### PR TITLE
Fix regression in ModManager::list()

### DIFF
--- a/src/ModManager.cpp
+++ b/src/ModManager.cpp
@@ -184,6 +184,9 @@ vector<string> ModManager::list(const string &path, bool full_paths) {
 		}
 	}
 
+	// we don't need to check for duplicates if there are no paths
+	if (ret.empty()) return ret;
+
 	if (!full_paths) {
 		// reduce the each file path down to be relative to mods/
 		for (unsigned i=0; i<ret.size(); ++i) {
@@ -191,11 +194,11 @@ vector<string> ModManager::list(const string &path, bool full_paths) {
 		}
 
 		// remove duplicates
-		for (unsigned i=ret.size()-1; i != 0; i--) {
-			for (unsigned j = i; j != 0; j--) {
-				if (ret[i] == ret[j]) {
+		for (unsigned i=ret.size(); i != 0; i--) {
+			for (unsigned j=0; j<i-1; j++) {
+				if (ret[i-1] == ret[j]) {
 					ret.erase(ret.begin()+j);
-					break;
+					j--;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #1103

There was two things wrong here
- The i loop would never hit ret[0]. This is resolved by setting
  `i=ret.size()` and accessing with `ret[i-1]`.
- The j loop didn't need to be changed, since it's incrementing up. The
  `j--` line is only used to re-execute the iteration.
