### PR TITLE
Fix bug where correct hero sounds weren't loading

### DIFF
--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -411,6 +411,7 @@ void GameStatePlay::applyPlayerData() {
 
 	// initialize vars
 	pc->stats.recalc();
+	pc->stats.loadHeroSFX();
 	menu->inv->applyEquipment(menu->inv->inventory[EQUIPMENT].storage);
 	pc->stats.logic(); // run stat logic once to apply items bonuses
 

--- a/src/StatBlock.cpp
+++ b/src/StatBlock.cpp
@@ -731,8 +731,11 @@ void StatBlock::loadHeroStats() {
 		infile.close();
 	}
 	max_spendable_stat_points = xp_table.size() * stat_points_per_level;
+}
 
+void StatBlock::loadHeroSFX() {
 	// load the paths to base sound effects
+	FileParser infile;
 	if (infile.open("engine/avatar/"+gfx_base+".txt", true, "")) {
 		while(infile.next()) {
 			loadSfxStat(&infile);

--- a/src/StatBlock.h
+++ b/src/StatBlock.h
@@ -100,6 +100,10 @@ public:
 	void applyEffects();
 	void calcBase();
 	void logic();
+	void removeFromSummons();
+	bool summonLimitReached(int power_id) const;
+	void setWanderArea(int r);
+	void loadHeroSFX();
 
 	bool alive;
 	bool corpse; // creature is dead and done animating
@@ -333,12 +337,6 @@ public:
 	StatBlock* summoner;
 
 	bool attacking;
-
-	void removeFromSummons();
-
-	bool summonLimitReached(int power_id) const;
-
-	void setWanderArea(int r);
 };
 
 #endif


### PR DESCRIPTION
Since Avatar is initialized before GameStatePlay::loadGame(), sounds
were being loaded with the default "male" gfx_base. This patch fixes
that by loading the approriate SFX file in loadGame().
