### PR TITLE
Remove TODOs related to settings parsing

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -384,6 +384,8 @@ static ConfigEntry * getConfigEntry(const char * name) {
 	for (int i = 0; i < config_size; i++) {
 		if (std::strcmp(config[i].name, name) == 0) return config + i;
 	}
+
+	fprintf(stderr, "Error: '%s' is not a valid configuration key.\n", name);
 	return NULL;
 }
 
@@ -731,7 +733,6 @@ bool loadSettings() {
 
 	// init defaults
 	for (int i = 0; i < config_size; i++) {
-		// TODO: handle errors
 		ConfigEntry * entry = config + i;
 		tryParseValue(*entry->type, entry->default_val, entry->storage);
 	}
@@ -750,7 +751,6 @@ bool loadSettings() {
 
 		ConfigEntry * entry = getConfigEntry(infile.key);
 		if (entry) {
-			// TODO: handle errors
 			tryParseValue(*entry->type, infile.val, entry->storage);
 		}
 	}
@@ -795,7 +795,6 @@ bool loadDefaults() {
 
 	// HACK init defaults except video
 	for (int i = 3; i < config_size; i++) {
-		// TODO: handle errors
 		ConfigEntry * entry = config + i;
 		tryParseValue(*entry->type, entry->default_val, entry->storage);
 	}

--- a/src/UtilsParsing.cpp
+++ b/src/UtilsParsing.cpp
@@ -157,7 +157,6 @@ bool tryParseValue(const type_info & type, const std::string & value, void * out
 
 	stringstream stream(value);
 
-	// TODO: add additional type parsing
 	if (type == typeid(bool)) {
 		stream>>(bool&)*((bool*)output);
 	}
@@ -197,7 +196,6 @@ std::string toString(const type_info & type, void * value) {
 
 	stringstream stream;
 
-	// TODO: add additional type parsing
 	if (type == typeid(bool)) {
 		stream<<*((bool*)value);
 	}


### PR DESCRIPTION
- The types we use in the config entries is hard-coded, so the types
  that tryParseValue() checks are sufficient
- An error message has been added for when there's an invalid key for
  a setting
