### PR TITLE
Update disabled slots when returning an equipped item

### DIFF
--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -372,6 +372,7 @@ void MenuInventory::drop(Point position, ItemStack stack) {
 		else {
 			// equippable items only belong to one slot, for the moment
 			itemReturn(stack); // cancel
+			updateEquipment(slot);
 		}
 	}
 	else if (area == CARRIED) {


### PR DESCRIPTION
Looks like I missed this when implementing the ability to disable
equipment slots.
