### PR TITLE
Remove unused code for partial background rendering

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -481,9 +481,6 @@ bool EventManager::executeEvent(Event &ev) {
 					mapr->layers[index][ec->x][ec->y] = ec->z;
 				else
 					fprintf(stderr, "Error: mapmod at position (%d, %d) is out of bounds 0-255.\n", ec->x, ec->y);
-
-				if (ec->a < (int)(mapr->index_objectlayer))
-					mapr->repaint_background = true;
 			}
 			mapr->map_change = true;
 		}

--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -58,7 +58,6 @@ MapRenderer::MapRenderer()
 	, stash_pos()
 	, enemies_cleared(false)
 	, save_game(false)
-	, repaint_background(false)
 	, index_objectlayer(0) {
 }
 

--- a/src/MapRenderer.h
+++ b/src/MapRenderer.h
@@ -58,13 +58,6 @@ private:
 
 	void clearQueues();
 
-	// When the animated tiles are switched off, the background is
-	// not rendered all the time but everytime you have moved away too much.
-	// then the background is completely rendered, else it is just blit
-	// onto screen. units in tiles:
-	static const short movedistance_to_rerender = 4;
-
-
 	// some events are automatically triggered when the map is loaded
 	void executeOnLoadEvents();
 
@@ -156,9 +149,6 @@ public:
 	std::vector<SoundManager::SoundID> sids;
 
 	void loadMusic();
-
-	// force a rendering of the background in the next render step.
-	bool repaint_background;
 
 	/**
 	 * The index of the layer, which mixes with the objects on screen. Layers


### PR DESCRIPTION
Once upon a time we had an 'optimisation' to render the background
only when needed.

There was still some cruft left, which is removed in this commit.

Fixes #1135
