### PR TITLE
Targeting improvements

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -55,7 +55,8 @@ Avatar::Avatar()
 	, drag_walking(false)
 	, respawn(false)
 	, close_menus(false)
-	, allow_movement(true) {
+	, allow_movement(true)
+	, enemy_pos(FPoint(-1,-1)) {
 
 	init();
 
@@ -316,6 +317,11 @@ void Avatar::handlePower(int actionbar_power) {
 			return;
 		if (!powers->hasValidTarget(actionbar_power,&stats,target))
 			return;
+
+		// automatically target the selected enemy with melee attacks
+		if (power.type == POWTYPE_FIXED && power.starting_pos == STARTING_POS_MELEE && enemy_pos.x != -1 && enemy_pos.y != -1) {
+			target = enemy_pos;
+		}
 
 		// draw a target on the ground if we're attacking
 		if (!power.buff && !power.buff_teleport && power.type != POWTYPE_TRANSFORM && power.new_state != POWSTATE_BLOCK) {

--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -142,6 +142,7 @@ public:
 	bool close_menus;
 	bool allow_movement;
 	std::vector<int> hero_cooldown;
+	FPoint enemy_pos; // positon of the highlighted enemy
 };
 
 #endif

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -183,6 +183,14 @@ void GameStatePlay::checkEnemyFocus() {
 		}
 	}
 
+	// save the highlighted enemy position for auto-targeting purposes
+	if (enemy) {
+		pc->enemy_pos = enemy->stats.pos;
+	}
+	else {
+		pc->enemy_pos.x = -1;
+		pc->enemy_pos.y = -1;
+	}
 }
 
 /**


### PR DESCRIPTION
Related to #143
- For offensive powers, an animation is now displayed on the ground where the target is. This makes it more clear where your attacks will land. I made a simple animation that I'll submit to the flare-game repo.
- If the player was using software cursors, the "attack" cursor often disappeared due to moving their mouse off the enemy. To make this feel better, the attack cursor is now kept on as long as the player is holding the attack button.
- Melee attacks should not be using `aim_assist` The `aim_assist` variable only makes sense for projectiles, where the actual target is slightly below the projectile animation. However, we still it so that when the player clicks on the torso of a human-sized enemy with a melee attack, their attack gets aimed properly. So I implemented some slight auto-targeting for melee attacks. If the mouse is over an enemy and a melee attack is used, the position of that enemy becomes target.
