### PR TITLE
Add clear() to few more places

### DIFF
--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -76,6 +76,7 @@ bool FileParser::open(const string& _filename, bool locateFileName, const string
 		else {
 			if (!errormessage.empty())
 				logError("FileParser: %s: %s\n", errormessage.c_str(), filenames[i-1].c_str());
+			infile.clear();
 		}
 	}
 
@@ -138,11 +139,11 @@ bool FileParser::next() {
 
 		line_number = 0;
 		const string current_filename = filenames[current_index];
-		infile.clear();
 		infile.open(current_filename.c_str(), ios::in);
 		if (!infile.is_open()) {
 			if (!errormessage.empty())
 				logError("FileParser: %s: %s\n", errormessage.c_str(), current_filename.c_str());
+			infile.clear();
 			return false;
 		}
 		// a new file starts a new section


### PR DESCRIPTION
@dorkster.

Check please the code. I guess we do not reuse stream data flags (like is_good() ) after clearing. Otherwise we should not clear()

See here http://www.cplusplus.com/reference/ios/ios/clear/
