### PR TITLE
Don't use pixel-precision for event hotspots

### DIFF
--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -690,14 +690,7 @@ void MapRenderer::checkHotspots() {
 						dest.h = tset.tiles[current_tile].tile->getClip().h;
 
 						if (isWithin(dest, inpt->mouse)) {
-							// Now that the mouse is within the rectangle of the tile, we can check for
-							// pixel precision. We need to have checked the rectangle first, because
-							// otherwise the pixel precise check might hit a neighbouring tile in the
-							// tileset. We need to calculate the point relative to the
-							Point p1;
-							p1.x = inpt->mouse.x - dest.x + tset.tiles[current_tile].tile->getClip().x;
-							p1.y = inpt->mouse.y - dest.y + tset.tiles[current_tile].tile->getClip().y;
-							matched |= tset.sprites->getGraphics()->checkPixel(p1);
+							matched = true;
 							tip_pos.x = dest.x + dest.w/2;
 							tip_pos.y = dest.y;
 						}

--- a/src/RenderDevice.h
+++ b/src/RenderDevice.h
@@ -120,7 +120,6 @@ public:
 	virtual Uint32 MapRGB(Uint8 r, Uint8 g, Uint8 b) = 0;
 	virtual Uint32 MapRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a) = 0;
 	virtual Image* resize(int width, int height) = 0;
-	virtual bool checkPixel(Point px) = 0;
 
 	class Sprite *createSprite(bool clipToSize = true);
 

--- a/src/SDLSoftwareRenderDevice.cpp
+++ b/src/SDLSoftwareRenderDevice.cpp
@@ -194,66 +194,6 @@ Uint32 SDLSoftwareImage::readPixel(int x, int y) {
 	return pixel;
 }
 
-/*
- * Returns false if a pixel at Point px is transparent
- *
- * Source: SDL Documentation
- * http://www.libsdl.org/cgi/docwiki.cgi/Introduction_to_SDL_Video#getpixel
- */
-bool SDLSoftwareImage::checkPixel(Point px) {
-	if (!surface) return false;
-
-	SDL_LockSurface(surface);
-
-	int bpp = surface->format->BytesPerPixel;
-	/* Here p is the address to the pixel we want to retrieve */
-	Uint8 *p = (Uint8 *)surface->pixels + px.y * surface->pitch + px.x * bpp;
-	Uint32 pixel;
-
-	switch (bpp) {
-		case 1:
-			pixel = *p;
-			break;
-
-		case 2:
-			pixel = *(Uint16 *)p;
-			break;
-
-		case 3:
-#if (SDL_BYTEORDER == SDL_BIG_ENDIAN)
-			pixel = p[0] << 16 | p[1] << 8 | p[2];
-#else
-			pixel = p[0] | p[1] << 8 | p[2] << 16;
-#endif
-			break;
-
-		case 4:
-			pixel = *(Uint32 *)p;
-			break;
-
-		default:
-			SDL_UnlockSurface(surface);
-			return false;
-	}
-
-	Uint8 r,g,b,a;
-	SDL_GetRGBA(pixel, surface->format, &r, &g, &b, &a);
-
-	if (r == 255 && g == 0 && b ==255 && a == 255) {
-		SDL_UnlockSurface(surface);
-		return false;
-	}
-	if (a == 0) {
-		SDL_UnlockSurface(surface);
-		return false;
-	}
-
-	SDL_UnlockSurface(surface);
-
-	return true;
-}
-
-
 SDLSoftwareRenderDevice::SDLSoftwareRenderDevice()
 	: screen(NULL)
 #if SDL_VERSION_ATLEAST(2,0,0)

--- a/src/SDLSoftwareRenderDevice.h
+++ b/src/SDLSoftwareRenderDevice.h
@@ -52,7 +52,6 @@ public:
 	Uint32 MapRGB(Uint8 r, Uint8 g, Uint8 b);
 	Uint32 MapRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 	Image* resize(int width, int height);
-	bool checkPixel(Point px);
 
 	SDL_Surface *surface;
 


### PR DESCRIPTION
This was originally implemented as a solution to a bug with event
hotspots not being accurate (I believe flare-game's "stash" chest
brought it to light). However, flare-engine-next's SDL 2 hardware
renderer does not have an implementation of RenderDevice::checkPixel().
flare-engine-next still functions properly, so I believe that checking
for pixel-precision was a solution to a red herring. It can be safely
removed.

It's also worth mentioning that having pixel-precision for hotspots
actually made it _more_ difficult to click on them in some cases. For
example, the floor grates that trigger spike traps in the Ancient Temple
map have a lot of transparent pixels, so clicks would go "through" the
grates.
