### PR TITLE
Limit configuration menu options for Android

### DIFF
--- a/src/GameStateConfig.h
+++ b/src/GameStateConfig.h
@@ -32,6 +32,13 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "GameState.h"
 #include "TooltipData.h"
 
+#ifdef __ANDROID__
+enum CONFIG_TAB {
+	AUDIO_TAB = 0,
+	INTERFACE_TAB = 1,
+	MODS_TAB = 2
+};
+#else
 enum CONFIG_TAB {
 	VIDEO_TAB = 0,
 	AUDIO_TAB = 1,
@@ -40,6 +47,7 @@ enum CONFIG_TAB {
 	KEYBINDS_TAB = 4,
 	MODS_TAB = 5
 };
+#endif
 
 class MenuConfirm;
 class Widget;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -757,6 +757,7 @@ bool loadSettings() {
 	// try read from file
 	FileParser infile;
 	if (!infile.open(PATH_CONF + FILE_SETTINGS, false, "")) {
+		loadAndroidDefaults();
 		if (!infile.open("engine/default_settings.txt", true, "")) {
 			saveSettings();
 			return true;
@@ -772,6 +773,8 @@ bool loadSettings() {
 		}
 	}
 	infile.close();
+
+	loadAndroidDefaults();
 
 	return true;
 }
@@ -820,6 +823,8 @@ bool loadDefaults() {
 	VIEW_W_HALF = VIEW_W / 2;
 	VIEW_H_HALF = VIEW_H / 2;
 
+	loadAndroidDefaults();
+
 	return true;
 }
 
@@ -840,4 +845,17 @@ bool compareVersions(int maj0, int min0, int maj1, int min1) {
 		return min0 > min1;
 	else
 		return maj0 > maj1;
+}
+
+/**
+ * Set required settings for Android
+ */
+void loadAndroidDefaults() {
+#ifdef __ANDROID__
+	MOUSE_MOVE = true;
+	MOUSE_AIM = true;
+	NO_MOUSE = false;
+	ENABLE_JOYSTICK = false;
+	HARDWARE_CURSOR = true;
+#endif
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -190,6 +190,7 @@ void loadMiscSettings();
 bool loadSettings();
 bool saveSettings();
 bool loadDefaults();
+void loadAndroidDefaults();
 
 // version information
 std::string getVersionString();


### PR DESCRIPTION
This makes only the following tabs visible
- Audio
- Interface (hardware mouse cursor is locked)
- Mods

Apologies for the amount of #ifdefs added. I tried to rearrange things
to limit the #ifdef usage a bit.
