### PR TITLE
Suppress tilewidth and tileheight messages when loading maps

### DIFF
--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -124,6 +124,12 @@ void Map::loadHeader(FileParser &infile) {
 		spawn.y = toInt(infile.nextValue()) + 0.5f;
 		spawn_dir = toInt(infile.nextValue());
 	}
+	else if (infile.key == "tilewidth") {
+		// @ATTR tilewidth|integer|Inherited from Tiled map file. Unused by engine.
+	}
+	else if (infile.key == "tileheight") {
+		// @ATTR tileheight|integer|Inherited from Tiled map file. Unused by engine.
+	}
 	else {
 		infile.error("Map: '%s' is not a valid key.", infile.key.c_str());
 	}


### PR DESCRIPTION
I was orginally going to change the Tiled Flare plugin to remove these
values from the export process. While these properties are not used by
the engine, they _are_ used when importing maps to Tiled.
