### PR TITLE
Implement an action queue and allow potion use at any time

### DIFF
--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -90,7 +90,7 @@ private:
 	vector<FPoint> path;
 	FPoint prev_target;
 
-	void handlePower(const ActionData& action);
+	void handlePower(std::vector<ActionData> &action_queue);
 
 	// visible power target
 	FPoint target_pos;
@@ -111,7 +111,7 @@ public:
 	void loadGraphics(std::vector<Layer_gfx> _img_gfx);
 	void loadStepFX(const std::string& stepname);
 
-	void logic(const ActionData& action, bool restrictPowerUse);
+	void logic(std::vector<ActionData> &action_queue, bool restrictPowerUse);
 	bool pressing_move();
 	void set_direction();
 	std::string log_msg;
@@ -121,6 +121,7 @@ public:
 	// transformation handling
 	void transform();
 	void untransform();
+	bool isTransforming() { return transform_triggered; }
 	bool setPowers;
 	bool revertPowers;
 	int untransform_power;

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -861,13 +861,13 @@ void GameStatePlay::logic() {
 		}
 		checkTitle();
 
-		ActionData action_data = menu->act->checkAction();
-		pc->logic(action_data, restrictPowerUse());
+		menu->act->checkAction(action_queue);
+		pc->logic(action_queue, restrictPowerUse());
 
 		// Transform powers change the actionbar layout,
 		// so we need to prevent accidental clicks if a new power is placed under the slot we clicked on.
 		// It's a bit hacky, but it works
-		if (powers->powers[action_data.power].type == POWTYPE_TRANSFORM) {
+		if (pc->isTransforming()) {
 			menu->act->resetSlots();
 		}
 

--- a/src/GameStatePlay.h
+++ b/src/GameStatePlay.h
@@ -29,6 +29,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "CommonIncludes.h"
 #include "GameState.h"
+#include "PowerManager.h"
 #include "Utils.h"
 
 class Avatar;
@@ -38,6 +39,8 @@ class MenuManager;
 class NPCManager;
 class QuestLog;
 class WidgetLabel;
+
+class ActionData;
 
 class Title {
 public:
@@ -99,6 +102,8 @@ private:
 	std::vector<Title> titles;
 
 	int nearest_npc;
+
+	std::vector<ActionData> action_queue;
 
 public:
 	GameStatePlay();

--- a/src/MenuActionBar.h
+++ b/src/MenuActionBar.h
@@ -66,7 +66,7 @@ public:
 	void renderAttention(int menu_id);
 	void logic();
 	void render();
-	ActionData checkAction();
+	void checkAction(std::vector<ActionData> &action_queue);
 	int checkDrag(Point mouse);
 	void checkMenu(bool &menu_c, bool &menu_i, bool &menu_p, bool &menu_l);
 	void drop(Point mouse, int power_index, bool rearranging);

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -38,6 +38,7 @@ class Animation;
 class AnimationSet;
 class Hazard;
 class MapCollision;
+class Map_Enemy;
 class StatBlock;
 
 const int POWTYPE_FIXED = 0;
@@ -108,10 +109,14 @@ public:
 class ActionData {
 public:
 	int power;
+	int hotkey;
+	bool instant_item;
 	FPoint target;
 
 	ActionData()
 		: power(0)
+		, hotkey(0)
+		, instant_item(false)
 		, target(FPoint()) {
 	}
 };


### PR DESCRIPTION
Fixes #1049

This commit primarily fixes two things:
- Instant powers that consume an item (aka potions) can now be used when
  attacking, being hit, or blocking without interrupting that action.
- Previously, power activation depended on its position in the action
  bar. For example, if the player pressed 6 first and then pressed 1, the
  power attached to slot 6 would be activated. However, if the player
  pressed 6 first and then pressed 9, the power on slot 9 would be
  activated. This commit fixes that so that the power in slot 6 would be
  activated in both cases (since it was pressed first).
