### PR TITLE
Fix bugs with 46fb43

### DIFF
--- a/src/GameStateLoad.cpp
+++ b/src/GameStateLoad.cpp
@@ -45,6 +45,7 @@ GameStateLoad::GameStateLoad() : GameState()
 	, loading_requested(false)
 	, loading(false)
 	, loaded(false)
+	, delete_items(true)
 	, current_frame(0)
 	, frame_ticker(0)
 	, stance_ticks_per_frame(1)
@@ -52,7 +53,10 @@ GameStateLoad::GameStateLoad() : GameState()
 	, stance_type(PLAY_ONCE)
 	, load_game(false)
 	, selected_slot(-1) {
-	items = new ItemManager();
+
+	if (items == NULL)
+		items = new ItemManager();
+
 	label_loading = new WidgetLabel();
 
 	for (int i = 0; i < GAME_SLOT_MAX; i++) {
@@ -437,6 +441,7 @@ void GameStateLoad::logic() {
 				GameStateNew* newgame = new GameStateNew();
 				newgame->game_slot = selected_slot + 1;
 				requestedGameState = newgame;
+				delete_items = false;
 			}
 			else {
 				loading_requested = true;
@@ -510,6 +515,7 @@ void GameStateLoad::logic() {
 
 void GameStateLoad::logicLoading() {
 	// load an existing game
+	delete_items = false;
 	GameStatePlay* play = new GameStatePlay();
 	play->resetGame();
 	play->game_slot = selected_slot + 1;
@@ -680,8 +686,10 @@ GameStateLoad::~GameStateLoad() {
 	delete button_action;
 	delete button_alternate;
 
-	if (!loaded)
+	if (delete_items) {
 		delete items;
+		items = NULL;
+	}
 
 	for (int slot=0; slot<GAME_SLOT_MAX; slot++) {
 		for (unsigned int i=0; i<sprites[slot].size(); i++) {

--- a/src/GameStateLoad.h
+++ b/src/GameStateLoad.h
@@ -77,6 +77,7 @@ private:
 	bool loading_requested;
 	bool loading;
 	bool loaded;
+	bool delete_items;
 
 	LabelInfo name_pos;
 	LabelInfo level_pos;

--- a/src/GameStateNew.cpp
+++ b/src/GameStateNew.cpp
@@ -32,6 +32,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "GameStateLoad.h"
 #include "GameStatePlay.h"
 #include "Settings.h"
+#include "SharedGameResources.h"
 #include "SharedResources.h"
 #include "TooltipData.h"
 #include "UtilsParsing.h"
@@ -52,6 +53,7 @@ GameStateNew::GameStateNew()
 	, portrait_border(NULL)
 	, show_classlist(true)
 	, modified_name(false)
+	, delete_items(true)
 	, game_slot(0)
 {
 	// set up buttons
@@ -293,20 +295,23 @@ void GameStateNew::logic() {
 	}
 
 	if ((inpt->pressing[CANCEL] && !inpt->lock[CANCEL]) || button_exit->checkClick()) {
-		inpt->lock[CANCEL] = true;
+		delete_items = false;
+		if (inpt->pressing[CANCEL])
+			inpt->lock[CANCEL] = true;
 		delete requestedGameState;
 		requestedGameState = new GameStateLoad();
 	}
 
 	if (button_create->checkClick()) {
 		// start the new game
+		delete_items = false;
 		GameStatePlay* play = new GameStatePlay();
-		Avatar *pc = play->getAvatar();
-		pc->stats.gfx_base = base[current_option];
-		pc->stats.gfx_head = head[current_option];
-		pc->stats.gfx_portrait = portrait[current_option];
-		pc->stats.name = input_name->getText();
-		pc->stats.permadeath = button_permadeath->isChecked();
+		Avatar *avatar = play->getAvatar();
+		avatar->stats.gfx_base = base[current_option];
+		avatar->stats.gfx_head = head[current_option];
+		avatar->stats.gfx_portrait = portrait[current_option];
+		avatar->stats.name = input_name->getText();
+		avatar->stats.permadeath = button_permadeath->isChecked();
 		play->game_slot = game_slot;
 		play->resetGame();
 		play->loadClass(class_list->getSelected());
@@ -400,6 +405,11 @@ GameStateNew::~GameStateNew() {
 
 	if (portrait_border)
 		delete portrait_border;
+
+	if (delete_items) {
+		delete items;
+		items = NULL;
+	}
 
 	delete button_exit;
 	delete button_create;

--- a/src/GameStateNew.h
+++ b/src/GameStateNew.h
@@ -81,6 +81,7 @@ private:
 	bool show_classlist;
 	TooltipData tip_buf;
 	bool modified_name;
+	bool delete_items;
 
 	Color color_normal;
 


### PR DESCRIPTION
Fixes #1186

Sorry about this one. Needed to reset items to NULL after
deconstructing. Also, GameStateNew now reuses the ItemManager if it was
constructed in GameStateLoad.
