### PR TITLE
Suppress warning about "orientation" key in map header

### DIFF
--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -168,6 +168,9 @@ void Map::loadHeader(FileParser &infile) {
 	else if (infile.key == "tileheight") {
 		// @ATTR tileheight|integer|Inherited from Tiled map file. Unused by engine.
 	}
+	else if (infile.key == "orientation") {
+		// this is only used by Tiled when importing Flare maps
+	}
 	else {
 		infile.error("Map: '%s' is not a valid key.", infile.key.c_str());
 	}


### PR DESCRIPTION
I've submitted [a ~~pending~~ patch](https://github.com/bjorn/tiled/pull/771) to Tiled to fix the bug with importing/exporting Flare maps on new versions of Tiled. To properly handle importing Flare maps, we need to know what orientation the map is.

This PR tells Flare to ignore the new `orientation` key in the header of maps.
