### PR TITLE
Add two-click process when clicking on actionbar icons

### DIFF
--- a/src/MenuActionBar.h
+++ b/src/MenuActionBar.h
@@ -97,6 +97,7 @@ public:
 	Rect menuArea;
 	int drag_prev_slot;
 	bool updated;
+	int twostep_slot;
 
 	TabList tablist;
 

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -506,7 +506,10 @@ void MenuManager::logic() {
 		if (inpt->pressing[CANCEL] && !inpt->lock[CANCEL]) {
 			inpt->lock[CANCEL] = true;
 			key_lock = true;
-			if (menus_open) {
+			if (act->twostep_slot != -1) {
+				act->twostep_slot = -1;
+			}
+			else if (menus_open) {
 				closeAll();
 			}
 			else {
@@ -946,6 +949,12 @@ void MenuManager::logic() {
 		act->slot_item_count[i] = -1;
 
 		if (act->hotkeys[i] != -1) {
+			// first check if we're using a two-step power
+			if (act->twostep_slot != -1 && act->twostep_slot != i) {
+				act->slot_enabled[i] = false;
+				continue;
+			}
+
 			int item_id = powers->powers[act->hotkeys[i]].requires_item;
 			int equipped_item_id = powers->powers[act->hotkeys[i]].requires_equipped_item;
 
@@ -966,6 +975,7 @@ void MenuManager::logic() {
 					act->slot_enabled[i] = false;
 				}
 			}
+
 		}
 	}
 


### PR DESCRIPTION
Example uses in flare-game are Burn and Teleport. Right clicking on one
of these powers in the actionbar will disable the rest of the actionbar.
We can cancel this be pressing the key bound to CANCEL, or we can use
the power that is queued up by MAIN1 clicking in the playing field.

Closes #1168

P.S. here's a bonus [video demonstration](http://a.pomf.se/ultkao.webm)
