### PR TITLE
Always update avatar graphics when changing equipment (even artifacts)

### DIFF
--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -520,7 +520,7 @@ void GameStatePlay::checkTitle() {
 
 void GameStatePlay::checkEquipmentChange() {
 	// force the actionbar to update when we change gear
-	if (menu->inv->changed_equipment || menu->inv->changed_artifact) {
+	if (menu->inv->changed_equipment) {
 		menu->act->updated = true;
 	}
 
@@ -562,7 +562,6 @@ void GameStatePlay::checkEquipmentChange() {
 	}
 
 	menu->inv->changed_equipment = false;
-	menu->inv->changed_artifact = false;
 }
 
 void GameStatePlay::checkLootDrop() {

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -51,7 +51,6 @@ MenuInventory::MenuInventory(StatBlock *_stats) {
 
 	drag_prev_src = -1;
 	changed_equipment = true;
-	changed_artifact = true;
 	log_msg = "";
 	show_book = "";
 
@@ -742,11 +741,8 @@ void MenuInventory::updateEquipment(int slot) {
 		// This should never happen, but ignore it if it does
 		return;
 	}
-	else if (slot_type[slot] != "artifact") {
-		changed_equipment = true;
-	}
 	else {
-		changed_artifact = true;
+		changed_equipment = true;
 	}
 }
 

--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -110,10 +110,7 @@ public:
 	int currency;
 	int drag_prev_src;
 
-	// the following two are separate because artifacts don't display on the hero.
-	// so we only update the hero sprites when non-artifact changes occur.
 	bool changed_equipment;
-	bool changed_artifact;
 
 	std::string log_msg;
 	std::string show_book;

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -938,7 +938,7 @@ void MenuManager::logic() {
 	}
 
 	// handle equipment changes affecting hero stats
-	if (inv->changed_equipment || inv->changed_artifact) {
+	if (inv->changed_equipment) {
 		inv->applyEquipment(inv->inventory[EQUIPMENT].storage);
 		// the equipment flags get reset in GameStatePlay
 	}


### PR DESCRIPTION
Fixes #1213

Some artifacts can determine which items can be equipped (e.g. Owl
Figurine lets us equip Mage gear with a base Mental of 1). We need to
update the player graphics when removing such artifacts to reflect the
removal of dependent gear.
