### PR TITLE
Remove virtual readPixel() function from RenderDevice

### DIFF
--- a/src/MenuMiniMap.cpp
+++ b/src/MenuMiniMap.cpp
@@ -114,7 +114,7 @@ void MenuMiniMap::prerender(MapCollision *collider, int map_w, int map_h) {
 
 	map_size.x = map_w;
 	map_size.y = map_h;
-	map_surface->getGraphics()->fillWithColor(NULL, map_surface->getGraphics()->MapRGBA(0,0,0,0));
+	map_surface->getGraphics()->fillWithColor(map_surface->getGraphics()->MapRGBA(0,0,0,0));
 
 	if (TILESET_ORIENTATION == TILESET_ISOMETRIC)
 		prerenderIso(collider);

--- a/src/MenuNPCActions.cpp
+++ b/src/MenuNPCActions.cpp
@@ -197,7 +197,7 @@ void MenuNPCActions::update() {
 		Image *graphics = render_device->createImage(w,h);
 		if (graphics) {
 			Uint32 bg = graphics->MapRGBA(background_color.r, background_color.g, background_color.b, background_color.a);
-			graphics->fillWithColor(NULL, bg);
+			graphics->fillWithColor(bg);
 			action_menu = graphics->createSprite();
 		}
 	}

--- a/src/RenderDevice.h
+++ b/src/RenderDevice.h
@@ -114,7 +114,7 @@ public:
 	virtual int getWidth() const;
 	virtual int getHeight() const;
 
-	virtual void fillWithColor(Rect *dstrect, Uint32 color) = 0;
+	virtual void fillWithColor(Uint32 color) = 0;
 	virtual void drawPixel(int x, int y, Uint32 color) = 0;
 	virtual Uint32 MapRGB(Uint8 r, Uint8 g, Uint8 b) = 0;
 	virtual Uint32 MapRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a) = 0;

--- a/src/SDLSoftwareRenderDevice.cpp
+++ b/src/SDLSoftwareRenderDevice.cpp
@@ -47,16 +47,10 @@ int SDLSoftwareImage::getHeight() const {
 	return surface ? surface->h : 0;
 }
 
-void SDLSoftwareImage::fillWithColor(Rect *dstrect, Uint32 color) {
+void SDLSoftwareImage::fillWithColor(Uint32 color) {
 	if (!surface) return;
 
-	if (dstrect) {
-		SDL_Rect dest = *dstrect;
-		SDL_FillRect(surface, &dest, color);
-	}
-	else {
-		SDL_FillRect(surface, NULL, color);
-	}
+	SDL_FillRect(surface, NULL, color);
 }
 
 /*

--- a/src/SDLSoftwareRenderDevice.h
+++ b/src/SDLSoftwareRenderDevice.h
@@ -46,7 +46,7 @@ public:
 	int getWidth() const;
 	int getHeight() const;
 
-	void fillWithColor(Rect *dstrect, Uint32 color);
+	void fillWithColor(Uint32 color);
 	void drawPixel(int x, int y, Uint32 color);
 	Uint32 MapRGB(Uint8 r, Uint8 g, Uint8 b);
 	Uint32 MapRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a);

--- a/src/WidgetScrollBox.cpp
+++ b/src/WidgetScrollBox.cpp
@@ -159,7 +159,7 @@ void WidgetScrollBox::resize(int h) {
 	}
 
 	if (contents && !transparent) {
-		contents->getGraphics()->fillWithColor(NULL, contents->getGraphics()->MapRGB(bg.r,bg.g,bg.b));
+		contents->getGraphics()->fillWithColor(contents->getGraphics()->MapRGB(bg.r,bg.g,bg.b));
 	}
 
 	cursor = 0;
@@ -186,7 +186,7 @@ void WidgetScrollBox::refresh() {
 		}
 
 		if (contents && !transparent) {
-			contents->getGraphics()->fillWithColor(NULL, contents->getGraphics()->MapRGB(bg.r,bg.g,bg.b));
+			contents->getGraphics()->fillWithColor(contents->getGraphics()->MapRGB(bg.r,bg.g,bg.b));
 		}
 	}
 

--- a/src/WidgetTooltip.cpp
+++ b/src/WidgetTooltip.cpp
@@ -157,7 +157,7 @@ bool WidgetTooltip::createBuffer(TooltipData &tip) {
 
 	// style the tooltip background
 	// currently this is plain black
-	graphics->fillWithColor(NULL, graphics->MapRGB(0,0,0));
+	graphics->fillWithColor(graphics->MapRGB(0,0,0));
 
 	int cursor_y = margin;
 


### PR DESCRIPTION
This function is only used by SDLSoftwareRenderDevice, so it doesn't
need to be declared for all render devices.

UPDATE: Added commit to remove unused parameter from `Image::fillWithColor()`
