### PR TITLE
Always show quantity in tooltips when quantity > 1

### DIFF
--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -493,7 +493,7 @@ TooltipData ItemManager::getTooltip(ItemStack stack, StatBlock *stats, int conte
 
 	// name
 	stringstream ss;
-	if (stack.quantity < 1000)
+	if (stack.quantity == 1)
 		ss << items[stack.item].name;
 	else
 		ss << items[stack.item].name << " (" << stack.quantity << ")";


### PR DESCRIPTION
Sometimes, it's difficult to read the quantity that's displayed on the
icon, especially for quantities > 100. This provides some easier to read
text in the item tooltip.
