### PR TITLE
Fix off-by-one error when adding frames to Animations

### DIFF
--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -119,7 +119,7 @@ void Animation::addFrame(	unsigned short index,
 							Rect rect,
 							Point _render_offset) {
 
-	if (index > gfx.size()/max_kinds) {
+	if (index >= gfx.size()/max_kinds) {
 		logError("Animation: Animation(%s) adding rect(%d, %d, %d, %d) to frame index(%u) out of bounds. must be in [0, %d]\n",
 				name.c_str(), rect.x, rect.y, rect.w, rect.h, index, (int)gfx.size()/max_kinds);
 		return;

--- a/src/AnimationSet.cpp
+++ b/src/AnimationSet.cpp
@@ -177,6 +177,7 @@ void AnimationSet::load() {
 		}
 		_name = parser.section;
 	}
+	parser.close();
 
 	if (!compressed_loading) {
 		// add final animation


### PR DESCRIPTION
Also, close a FileParser that was left open in AnimationSet parsing.
