### PR TITLE
Compare frame counts against parent AnimationSet

### DIFF
--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -89,6 +89,8 @@ void Animation::setupUncompressed(Point _render_size, Point _render_offset, int 
 }
 
 void Animation::setup(unsigned short _frames, unsigned short _duration, unsigned short _maxkinds) {
+	frame_count = _frames;
+
 	calculateFrames(frames, _frames, _duration);
 
 	if (!frames.empty()) number_frames = frames.back()+1;

--- a/src/Animation.h
+++ b/src/Animation.h
@@ -76,6 +76,8 @@ protected:
 
 	unsigned short elapsed_frames; // counts the total number of frames for back-forth animations
 
+	unsigned frame_count; // the frame count as it appears in the data files (i.e. not converted to engine frames)
+
 public:
 	Animation(const std::string &_name, const std::string &_type, Image *_sprite);
 
@@ -130,6 +132,8 @@ public:
 	void setActiveFrames(const std::vector<short> &_active_frames);
 
 	bool isCompleted();
+
+	unsigned getFrameCount() { return frame_count; }
 };
 
 #endif

--- a/src/AnimationSet.h
+++ b/src/AnimationSet.h
@@ -35,6 +35,7 @@ private:
 	std::string imagefile;
 	Animation *defaultAnimation; // has always a non-null animation, in case of successfull load it contains the first animation in the animation file.
 	bool loaded;
+	AnimationSet *parent;
 
 	void load();
 
@@ -62,8 +63,14 @@ public:
 	 */
 	Animation *getAnimation();
 
+	unsigned getAnimationFrames(const std::string &_name);
+
 	const std::string &getName() {
 		return name;
+	}
+
+	void setParent(AnimationSet *other) {
+		parent = other;
 	}
 };
 

--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -211,6 +211,7 @@ void Avatar::loadGraphics(std::vector<Layer_gfx> _img_gfx) {
 			string name = "animations/avatar/"+stats.gfx_base+"/"+_img_gfx[i].gfx+".txt";
 			anim->increaseCount(name);
 			animsets.push_back(anim->getAnimationSet(name));
+			animsets.back()->setParent(animationSet);
 			anims.push_back(animsets.back()->getAnimation(activeAnimation->getName()));
 			if(!anims.back()->syncTo(activeAnimation)) {
 				logError("Avatar: Error syncing animation in '%s' to 'animations/hero.txt'.\n", animsets.back()->getName().c_str());


### PR DESCRIPTION
This checks the frame counts as they appear in the animation definition
files. It's mainly for Avatar animations, where all equipment animations
need to match the parent animations in frame count. An error message
will be printed when there is a mismatch.
