### PR TITLE
Nicer fullscreen when using SDL 2

### DIFF
--- a/src/InputState.cpp
+++ b/src/InputState.cpp
@@ -255,9 +255,9 @@ void InputState::saveKeyBindings() {
 void InputState::handle(bool dump_event) {
 	SDL_Event event;
 
-#ifndef __ANDROID__
-	SDL_GetMouseState(&mouse.x, &mouse.y);
-#endif
+	if (! SDL_VERSION_ATLEAST(2,0,0)) {
+		SDL_GetMouseState(&mouse.x, &mouse.y);
+	}
 
 	inkeys = "";
 
@@ -308,6 +308,10 @@ void InputState::handle(bool dump_event) {
 		switch (event.type) {
 
 #if SDL_VERSION_ATLEAST(2,0,0)
+			case SDL_MOUSEMOTION:
+				mouse.x = event.motion.x;
+				mouse.y = event.motion.y;
+				break;
 			case SDL_MOUSEWHEEL:
 				if (event.wheel.y > 0) {
 					scroll_up = true;
@@ -316,6 +320,8 @@ void InputState::handle(bool dump_event) {
 				}
 				break;
 			case SDL_MOUSEBUTTONDOWN:
+				mouse.x = event.button.x;
+				mouse.y = event.button.y;
 				for (int key=0; key<key_count; key++) {
 					if (event.button.button == binding[key] || event.button.button == binding_alt[key]) {
 						pressing[key] = true;
@@ -324,6 +330,8 @@ void InputState::handle(bool dump_event) {
 				}
 				break;
 			case SDL_MOUSEBUTTONUP:
+				mouse.x = event.button.x;
+				mouse.y = event.button.y;
 				for (int key=0; key<key_count; key++) {
 					if (event.button.button == binding[key] || event.button.button == binding_alt[key]) {
 						un_press[key] = true;

--- a/src/SDLHardwareRenderDevice.cpp
+++ b/src/SDLHardwareRenderDevice.cpp
@@ -162,18 +162,30 @@ SDLHardwareRenderDevice::SDLHardwareRenderDevice()
 }
 
 int SDLHardwareRenderDevice::createContext(int width, int height) {
+	int window_w = width;
+	int window_h = height;
+
+	if (FULLSCREEN) {
+		// make the window the same size as the desktop resolution
+		SDL_DisplayMode desktop;
+		if (SDL_GetDesktopDisplayMode(0, &desktop) == 0) {
+			window_w = desktop.w;
+			window_h = desktop.h;
+		}
+	}
+
 	if (is_initialized) {
 		SDL_DestroyRenderer(renderer);
 		Uint32 flags = 0;
 
-		if (FULLSCREEN) flags = SDL_WINDOW_FULLSCREEN;
+		if (FULLSCREEN) flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
 		else flags = SDL_WINDOW_SHOWN;
 
 		SDL_DestroyWindow(screen);
 		screen = SDL_CreateWindow(msg->get(WINDOW_TITLE).c_str(),
 									SDL_WINDOWPOS_CENTERED,
 									SDL_WINDOWPOS_CENTERED,
-									width, height,
+									window_w, window_h,
 									flags);
 
 		if (HWSURFACE) flags = SDL_RENDERER_ACCELERATED | SDL_RENDERER_TARGETTEXTURE;
@@ -183,17 +195,21 @@ int SDLHardwareRenderDevice::createContext(int width, int height) {
 
 		renderer = SDL_CreateRenderer(screen, -1, flags);
 
+		if (renderer && FULLSCREEN && (window_w != width || window_h != height)) {
+			SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
+			SDL_RenderSetLogicalSize(renderer, width, height);
+		}
 	}
 	else {
 		Uint32 flags = 0;
 
-		if (FULLSCREEN) flags = SDL_WINDOW_FULLSCREEN;
+		if (FULLSCREEN) flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
 		else flags = SDL_WINDOW_SHOWN;
 
 		screen = SDL_CreateWindow(msg->get(WINDOW_TITLE).c_str(),
 									SDL_WINDOWPOS_CENTERED,
 									SDL_WINDOWPOS_CENTERED,
-									width, height,
+									window_w, window_h,
 									flags);
 
 		if (HWSURFACE) flags = SDL_RENDERER_ACCELERATED | SDL_RENDERER_TARGETTEXTURE;
@@ -202,6 +218,11 @@ int SDLHardwareRenderDevice::createContext(int width, int height) {
 		if (DOUBLEBUF) flags = flags | SDL_RENDERER_PRESENTVSYNC;
 
 		if (screen != NULL) renderer = SDL_CreateRenderer(screen, -1, flags);
+
+		if (FULLSCREEN && (window_w != width || window_h != height)) {
+			SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
+			SDL_RenderSetLogicalSize(renderer, width, height);
+		}
 	}
 
 	if (screen != NULL && renderer != NULL) {


### PR DESCRIPTION
We now use the native screen resolution at all times and use SDL to
scale to that resolution. The old method of changing video mode didn't
work well in some cases (I got a weird bug where X wanted to make
800x600 require panning on my monitor). This also makes ALT-Tabbing
better, since there's no flicker of resolution change (or worse, getting
the desktop stuck at a non-native resolution).

We can also run Flare at fullscreen resolutions _higher_ than the user's
desktop resolution. Since I use a generic TV as a monitor through VGA,
SDL reports that I can use 1792x1344 as a resolution (the native
resolution is 1360x768). I can now use that resolution in fullscreen if
I want to (everything is really tiny :) ).
