### PR TITLE
Use syntax from "enemy" map layer for spawn powers/events

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -729,13 +729,24 @@ void Avatar::transform() {
 	// calling a transform power locks the actionbar, so we unlock it here
 	inpt->unlockActionBar();
 
+	delete charmed_stats;
+	charmed_stats = NULL;
+
+	Enemy_Level el = enemyg->getRandomEnemy(stats.transform_type, 0, 0);
+
+	if (el.type != "") {
+		charmed_stats = new StatBlock();
+		charmed_stats->load(el.type);
+	}
+	else {
+		logError("Avatar: Could not transform into creature type '%s'\n", stats.transform_type.c_str());
+		stats.transform_type = "";
+		return;
+	}
+
 	transform_triggered = true;
 	stats.transformed = true;
 	setPowers = true;
-
-	delete charmed_stats;
-	charmed_stats = new StatBlock();
-	charmed_stats->load(stats.transform_type);
 
 	// temporary save hero stats
 	delete hero_stats;

--- a/src/EnemyManager.cpp
+++ b/src/EnemyManager.cpp
@@ -182,7 +182,18 @@ void EnemyManager::handleSpawn() {
 
 		e->type = espawn.type;
 		e->stats.direction = espawn.direction;
-		e->stats.load(espawn.type);
+
+		Enemy_Level el = enemyg->getRandomEnemy(espawn.type, 0, 0);
+
+		if (el.type != "") {
+			e->stats.load(el.type);
+		}
+		else {
+			logError("EnemyManager: Could not spawn creature type '%s'\n", espawn.type.c_str());
+			delete e;
+			return;
+		}
+
 		if (e->stats.animations != "") {
 			// load the animation file if specified
 			anim->increaseCount(e->stats.animations);


### PR DESCRIPTION
Fixes #1282

This change gives some benefits:
- no crashes, since we've already established a list of valid enemy file
  names
- "fuzzy" enemy type selection. For example, we can spawn any type of
  antlion by using "spawn_type=antlion"

So to spawn a normal antlion, we used to have:
    spawn_type=enemies/antlion.txt
Now we'll use:
    spawn_type=antlion_normal
