### PR TITLE
"Revive" the player when their saved HP equals zero

### DIFF
--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -329,7 +329,7 @@ void GameStatePlay::loadGame() {
 
 	// trigger passive effects here? Saved HP/MP values might depend on passively boosted HP/MP
 	// powers->activatePassives(pc->stats);
-	if (SAVE_HPMP) {
+	if (SAVE_HPMP && saved_hp != 0) {
 		if (saved_hp < 0 || saved_hp > pc->stats.get(STAT_HP_MAX)) {
 			logError("SaveLoad: HP value is out of bounds, setting to maximum\n");
 			pc->stats.hp = pc->stats.get(STAT_HP_MAX);


### PR DESCRIPTION
If the player exited the game when they were dead in Polymorphable,
their HP of 0 would be saved, causing them to die again when loading
their save. This patch fixes that.
