### PR TITLE
Add in-code documentation for EffectManager.cpp and Stats.cpp

### DIFF
--- a/extract_xml.sh
+++ b/extract_xml.sh
@@ -3,15 +3,15 @@ IFS=$'\n'
 HAVE_CLASS=0
 echo "<?xml version=\"1.0\"?>"
 echo "<classes>"
-for line in `grep '@CLASS\|@ATTR' src/*.cpp | sed s/^.*@//g | sed 's/CLASS /CLASS|/g' | sed 's/ATTR /ATTR|/g'`
+for line in `grep '@CLASS\|@ATTR\|@TYPE' src/*.cpp | sed s/^.*@//g | sed 's/CLASS /CLASS|/g' | sed 's/ATTR /ATTR|/g' | sed 's/TYPE /TYPE|/g'`
 do
     IFS='|'
     fields=($line)
-    # Handle CLASS 
+    # Handle CLASS
     if [ "${fields[0]}" == "CLASS" ]; then
-	if [ $HAVE_CLASS -eq 1 ]; then 
+	if [ $HAVE_CLASS -eq 1 ]; then
 	    echo '  </attributes>'
-	    echo '</class>' 
+	    echo '</class>'
 	fi
 	echo '<class name="'${fields[1]}'">'
 	HAVE_CLASS=1
@@ -21,6 +21,10 @@ do
     # Handle ATTR
     if [ "${fields[0]}" == "ATTR" ]; then
 	echo '    <attribute name="'${fields[1]}'" type="'${fields[2]}'">'${fields[3]}'</attribute>'
+    fi
+    # Handle TYPE
+    if [ "${fields[0]}" == "TYPE" ]; then
+	echo '    <type name="'${fields[1]}'">'${fields[2]}'</type>'
     fi
 done
 

--- a/src/EffectManager.cpp
+++ b/src/EffectManager.cpp
@@ -121,24 +121,39 @@ void EffectManager::logic() {
 	clearStatus();
 
 	for (unsigned i=0; i<effect_list.size(); i++) {
+		// @CLASS EffectManager|Description of "type" in powers/effects.txt
 		// expire timed effects and total up magnitudes of active effects
 		if (effect_list[i].duration >= 0) {
+			// @TYPE damage|Damage per second
 			if (effect_list[i].type == "damage" && effect_list[i].ticks % MAX_FRAMES_PER_SEC == 1) damage += effect_list[i].magnitude;
+			// @TYPE hpot|HP restored per second
 			else if (effect_list[i].type == "hpot" && effect_list[i].ticks % MAX_FRAMES_PER_SEC == 1) hpot += effect_list[i].magnitude;
+			// @TYPE mpot|MP restored per second
 			else if (effect_list[i].type == "mpot" && effect_list[i].ticks % MAX_FRAMES_PER_SEC == 1) mpot += effect_list[i].magnitude;
+			// @TYPE speed|Changes movement speed. A magnitude of 100 is 100% speed (aka normal speed).
 			else if (effect_list[i].type == "speed") speed = (effect_list[i].magnitude * speed) / 100;
+			// @TYPE immunity|Removes and prevents bleed, slow, stun, and immobilize. Magnitude is ignored.
 			else if (effect_list[i].type == "immunity") immunity = true;
+			// @TYPE stun|Can't move or attack. Being attacked breaks stun.
 			else if (effect_list[i].type == "stun") stun = true;
+			// @TYPE revive|Revives the player. Typically attached to a power that triggers when the player dies.
 			else if (effect_list[i].type == "revive") revive = true;
+			// @TYPE convert|Causes an enemy or an ally to switch allegiance
 			else if (effect_list[i].type == "convert") convert = true;
+			// @TYPE fear|Causes enemies to run away
 			else if (effect_list[i].type == "fear") fear = true;
+			// @TYPE offense|Increase Offense stat.
 			else if (effect_list[i].type == "offense") bonus_offense += effect_list[i].magnitude;
+			// @TYPE defense|Increase Defense stat.
 			else if (effect_list[i].type == "defense") bonus_defense += effect_list[i].magnitude;
+			// @TYPE physical|Increase Physical stat.
 			else if (effect_list[i].type == "physical") bonus_physical += effect_list[i].magnitude;
+			// @TYPE mental|Increase Mental stat.
 			else if (effect_list[i].type == "mental") bonus_mental += effect_list[i].magnitude;
 			else {
 				bool found_key = false;
 
+				// @TYPE $STATNAME|Increases $STATNAME, where $STATNAME is any of the base stats. Examples: hp, dmg_melee_min, xp_gain
 				for (unsigned j=0; j<STAT_COUNT; j++) {
 					if (effect_list[i].type == STAT_NAME[j]) {
 						bonus[j] += effect_list[i].magnitude;
@@ -147,6 +162,7 @@ void EffectManager::logic() {
 				}
 
 				if (!found_key) {
+					// @TYPE $ELEMENT_resist|Increase Resistance % to $ELEMENT, where $ELEMENT is any found in engine/elements.txt. Example: fire_resist
 					for (unsigned j=0; j<bonus_resist.size(); j++) {
 						if (effect_list[i].type == ELEMENTS[j].name + "_resist")
 							bonus_resist[j] += effect_list[i].magnitude;
@@ -158,6 +174,7 @@ void EffectManager::logic() {
 				if (effect_list[i].ticks > 0) effect_list[i].ticks--;
 				if (effect_list[i].ticks == 0) {
 					//death sentence is only applied at the end of the timer
+					// @TYPE death_sentence|Causes sudden death at the end of the effect duration.
 					if (effect_list[i].type == "death_sentence") death_sentence = true;
 					removeEffect(i);
 					i--;
@@ -167,6 +184,7 @@ void EffectManager::logic() {
 		}
 		// expire shield effects
 		if (effect_list[i].magnitude_max > 0 && effect_list[i].magnitude == 0) {
+			// @TYPE shield|Create a damage absorbing barrier based on Mental damage stat. Duration is ignored.
 			if (effect_list[i].type == "shield") {
 				removeEffect(i);
 				i--;
@@ -175,6 +193,7 @@ void EffectManager::logic() {
 		}
 		// expire effects based on animations
 		if ((effect_list[i].animation && effect_list[i].animation->isLastFrame()) || !effect_list[i].animation) {
+			// @TYPE heal|Restore HP based on Mental damage stat.
 			if (effect_list[i].type == "heal") {
 				removeEffect(i);
 				i--;

--- a/src/Stats.cpp
+++ b/src/Stats.cpp
@@ -22,27 +22,51 @@ std::string STAT_NAME[STAT_COUNT];
 // these names aren't visible in-game
 // but they are used for parsing config files like engine/stats.txt
 void setStatNames() {
+	// @CLASS Stats|Description of the base stats, aka $STATNAME
+
+	// @TYPE dmg_melee_min|Minimum melee damage
 	STAT_NAME[STAT_DMG_MELEE_MIN] = "dmg_melee_min";
+	// @TYPE dmg_melee_max|Maximum melee damage
 	STAT_NAME[STAT_DMG_MELEE_MAX] = "dmg_melee_max";
+	// @TYPE dmg_ranged_min|Minimum ranged damage
 	STAT_NAME[STAT_DMG_RANGED_MIN] = "dmg_ranged_min";
+	// @TYPE dmg_ranged_max|Maximum ranged damage
 	STAT_NAME[STAT_DMG_RANGED_MAX] = "dmg_ranged_max";
+	// @TYPE dmg_ment_min|Minimum mental damage
 	STAT_NAME[STAT_DMG_MENT_MIN] = "dmg_ment_min";
+	// @TYPE dmg_ment_max|Maximum mental damage
 	STAT_NAME[STAT_DMG_MENT_MAX] = "dmg_ment_max";
+	// @TYPE absorb_min|Minimum damage absorption
 	STAT_NAME[STAT_ABS_MIN] = "absorb_min";
+	// @TYPE absorb_max|Maximum damage absorption
 	STAT_NAME[STAT_ABS_MAX] = "absorb_max";
+	// @TYPE hp|Hit points
 	STAT_NAME[STAT_HP_MAX] = "hp";
+	// @TYPE hp_regen|HP restored per minute
 	STAT_NAME[STAT_HP_REGEN] = "hp_regen";
+	// @TYPE hp_percent|Base HP altered by percentage
 	STAT_NAME[STAT_HP_PERCENT] = "hp_percent";
+	// @TYPE mp|Magic points
 	STAT_NAME[STAT_MP_MAX] = "mp";
+	// @TYPE mp_regen|MP restored per minute
 	STAT_NAME[STAT_MP_REGEN] = "mp_regen";
+	// @TYPE mp_percent|Base MP altered by percentage
 	STAT_NAME[STAT_MP_PERCENT] = "mp_percent";
+	// @TYPE accuracy|Accuracy %. Higher values mean less likely to miss.
 	STAT_NAME[STAT_ACCURACY] = "accuracy";
+	// @TYPE avoidance|Avoidance %. Higher values means more likely to not get hit.
 	STAT_NAME[STAT_AVOIDANCE] = "avoidance";
+	// @TYPE crit|Critical hit chance %
 	STAT_NAME[STAT_CRIT] = "crit";
+	// @TYPE xp_gain|Percentage boost to the amount of experience points gained per kill.
 	STAT_NAME[STAT_XP_GAIN] = "xp_gain";
+	// @TYPE currency_find|Percentage boost to the amount of gold dropped per loot event.
 	STAT_NAME[STAT_CURRENCY_FIND] = "currency_find";
+	// @TYPE item_find|Increases the chance of finding items in loot.
 	STAT_NAME[STAT_ITEM_FIND] = "item_find";
+	// @TYPE stealth|Decrease the distance required to alert enemies by %
 	STAT_NAME[STAT_STEALTH] = "stealth";
+	// @TYPE poise|Reduced % chance of entering "hit" animation when damaged
 	STAT_NAME[STAT_POISE] = "poise";
 }
 

--- a/wiki.xslt
+++ b/wiki.xslt
@@ -12,6 +12,10 @@
 **<xsl:value-of select="@name"/>**, _<xsl:value-of select="@type"/>_, <xsl:value-of select="."/>
 <xsl:text>&#xa;</xsl:text>
     </xsl:for-each>
+    <xsl:for-each select="attributes/type">
+**<xsl:value-of select="@name"/>**, <xsl:value-of select="."/>
+<xsl:text>&#xa;</xsl:text>
+    </xsl:for-each>
 <xsl:text>&#xa;</xsl:text>
   </xsl:for-each>
 <xsl:text>&#xa;</xsl:text>


### PR DESCRIPTION
This commit adds "TYPE" to our attribute documentation parsing. Unlike
ATTR, TYPE only has two fields: name and description. Otherwise, its
usage is the same as ATTR.
