### PR TITLE
Refactor triggering NPC interactions

### DIFF
--- a/src/EventManager.cpp
+++ b/src/EventManager.cpp
@@ -605,6 +605,9 @@ bool EventManager::executeEvent(Event &ev) {
 		else if (ec->type == "save_game") {
 			mapr->save_game = toBool(ec->s);
 		}
+		else if (ec->type == "npc_id") {
+			mapr->npc_id = ec->x;
+		}
 	}
 	return !ev.keep_after_trigger;
 }

--- a/src/Map.h
+++ b/src/Map.h
@@ -115,8 +115,6 @@ protected:
 	void clearLayers();
 	void clearQueues();
 
-	// map events
-	std::vector<Event> events;
 	std::queue<Map_Group> enemy_groups;
 	std::vector<StatBlock> statblocks;
 
@@ -124,6 +122,8 @@ protected:
 	std::string tileset;
 
 	int load(std::string filename);
+
+	int collision_layer;
 public:
 	Map();
 
@@ -139,6 +139,9 @@ public:
 
 	// npc load handling
 	std::queue<Map_NPC> npcs;
+
+	// map events
+	std::vector<Event> events;
 
 	// vars
 	std::string title;

--- a/src/MapRenderer.h
+++ b/src/MapRenderer.h
@@ -83,6 +83,8 @@ private:
 	FPoint shakycam;
 	TileSet tset;
 
+	int npc_tooltip_margin;
+
 public:
 	// functions
 	MapRenderer();
@@ -149,6 +151,9 @@ public:
 
 	// map soundids
 	std::vector<SoundManager::SoundID> sids;
+
+	// npc handling
+	int npc_id;
 
 	void loadMusic();
 

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -1376,13 +1376,14 @@ void MenuManager::closeLeft() {
 	resetDrag();
 	chr->visible = false;
 	log->visible = false;
-	vendor->visible = false;
-	talker->visible = false;
 	exit->visible = false;
 	stash->visible = false;
-	npc->visible = false;
 	book->visible = false;
 	book->book_name = "";
+
+	npc->setNPC(NULL);
+	talker->setNPC(NULL);
+	vendor->setNPC(NULL);
 
 	if (DEV_MODE && devconsole->visible) {
 		devconsole->visible = false;
@@ -1394,11 +1395,12 @@ void MenuManager::closeRight() {
 	resetDrag();
 	inv->visible = false;
 	pow->visible = false;
-	talker->visible = false;
 	exit->visible = false;
-	npc->visible = false;
 	book->visible = false;
 	book->book_name = "";
+
+	npc->setNPC(NULL);
+	talker->setNPC(NULL);
 
 	if (DEV_MODE && devconsole->visible) {
 		devconsole->visible = false;

--- a/src/MenuNPCActions.cpp
+++ b/src/MenuNPCActions.cpp
@@ -216,8 +216,10 @@ void MenuNPCActions::setNPC(NPC *pnpc) {
 
 	npc = pnpc;
 
-	if (npc == NULL)
+	if (npc == NULL) {
+		visible = false;
 		return;
+	}
 
 	// reset selection
 	dialog_selected = vendor_selected = cancel_selected = false;

--- a/src/MenuTalker.cpp
+++ b/src/MenuTalker.cpp
@@ -182,8 +182,7 @@ void MenuTalker::logic() {
 			menu->npc->setNPC(NULL);
 
 		// end dialog
-		npc = NULL;
-		visible = false;
+		setNPC(NULL);
 	}
 }
 
@@ -318,6 +317,19 @@ std::string MenuTalker::parseLine(const std::string &line) {
 	if (index != std::string::npos) new_line.replace(index, 2, hero_class);
 
 	return new_line;
+}
+
+void MenuTalker::setNPC(NPC* _npc) {
+	npc = _npc;
+
+	if (_npc == NULL) {
+		visible = false;
+		return;
+	}
+
+	if (!visible) {
+		visible = true;
+	}
 }
 
 MenuTalker::~MenuTalker() {

--- a/src/MenuTalker.h
+++ b/src/MenuTalker.h
@@ -78,6 +78,7 @@ public:
 	void render();
 	void setHero(StatBlock &stats);
 	void createBuffer();
+	void setNPC(NPC* _npc);
 
 	WidgetButton *advanceButton;
 	WidgetButton *closeButton;

--- a/src/MenuVendor.cpp
+++ b/src/MenuVendor.cpp
@@ -142,7 +142,7 @@ void MenuVendor::logic() {
 	}
 
 	if (closeButton->checkClick()) {
-		visible = false;
+		setNPC(NULL);
 		snd->play(sfx_close);
 	}
 }
@@ -265,6 +265,23 @@ void MenuVendor::sort(int type) {
 
 int MenuVendor::getRowsCount() {
 	return slots_rows;
+}
+
+void MenuVendor::setNPC(NPC* _npc) {
+	npc = _npc;
+
+	if (_npc == NULL) {
+		visible = false;
+		return;
+	}
+
+	setTab(0);
+	setInventory();
+	if (!visible) {
+		visible = true;
+		snd->play(sfx_open);
+		npc->playSound(NPC_VOX_INTRO);
+	}
 }
 
 MenuVendor::~MenuVendor() {

--- a/src/MenuVendor.h
+++ b/src/MenuVendor.h
@@ -74,8 +74,8 @@ public:
 	void setInventory();
 	void saveInventory();
 	void sort(int type);
-
 	int getRowsCount();
+	void setNPC(NPC* _npc);
 
 	Rect slots_area;
 

--- a/src/NPCManager.h
+++ b/src/NPCManager.h
@@ -37,7 +37,6 @@ private:
 	WidgetTooltip *tip;
 	StatBlock *stats;
 	TooltipData tip_buf;
-	int tooltip_margin;
 
 public:
 	NPCManager(StatBlock *stats);
@@ -49,9 +48,6 @@ public:
 	void logic();
 	void addRenders(std::vector<Renderable> &r);
 	int getID(std::string npcName);
-	int checkNPCClick(Point mouse, FPoint cam);
-	int getNearestNPC(FPoint pos);
-	void renderTooltips(FPoint cam, Point mouse, int nearest);
 };
 
 #endif


### PR DESCRIPTION
Closes #1306

When placing NPCs on the map, we now create a 1x1 event at the NPC's
feet. This means that selecting NPCs with the mouse or the keyboard
behaves the same as other events.

It's worth noting that the event we create is of the "on_trigger" type
and will repeat indefinitely. This means we can't let the player stand
on the same tile as the NPC, or else they won't be able to escape NPC
interaction. I've added a check for collision on NPC tiles. A warning
will be printed and the tile will be blocked if there is no collision
tile where an NPC is located.
