### PR TITLE
Fix incorrect animations when spawning as a transformed creature

### DIFF
--- a/src/Avatar.h
+++ b/src/Avatar.h
@@ -121,11 +121,13 @@ public:
 	bool isTransforming() {
 		return transform_triggered;
 	}
+	void checkTransform();
 	bool setPowers;
 	bool revertPowers;
 	int untransform_power;
 	StatBlock *hero_stats;
 	StatBlock *charmed_stats;
+	FPoint transform_pos;
 
 	virtual void resetActiveAnimation();
 	virtual Renderable getRender() {

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -300,8 +300,8 @@ void GameStatePlay::checkTeleport() {
 
 			// store this as the new respawn point
 			mapr->respawn_map = teleport_mapname;
-			mapr->respawn_point.x = pc->stats.pos.x;
-			mapr->respawn_point.y = pc->stats.pos.y;
+			mapr->respawn_point = pc->stats.pos;
+			pc->transform_pos = pc->stats.pos;
 
 			// return to title (permadeath) OR auto-save
 			if (pc->stats.permadeath && pc->stats.corpse) {
@@ -886,6 +886,7 @@ void GameStatePlay::logic() {
 	mapr->enemies_cleared = enemies->isCleared();
 	quests->logic();
 
+	pc->checkTransform();
 
 	// change hero powers on transformation
 	if (pc->setPowers) {


### PR DESCRIPTION
Closes #1310

In addition, untransforming on an invalid tile (possible with the Bat in
Polymorphable) will warp the player back to where they initially
transformed. If the transformed on a different map, they'll be
teleported to the spawn position on that map.
