### PR TITLE
Fix crash when interacting with event-called NPC

### DIFF
--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -656,7 +656,7 @@ void GameStatePlay::checkNPCInteraction() {
 	}
 
 	if (mapr->event_npc != "") {
-		npc_id = npcs->getID(mapr->event_npc);
+		npc_id = mapr->npc_id = npcs->getID(mapr->event_npc);
 		if (npc_id != -1) {
 			eventDialogOngoing = true;
 			eventPendingDialog = true;

--- a/src/MapRenderer.cpp
+++ b/src/MapRenderer.cpp
@@ -723,8 +723,8 @@ void MapRenderer::checkHotspots() {
 
 							if (isWithin(dest, inpt->mouse)) {
 								matched = true;
-								tip_pos.x = dest.x + dest.w/2;
-								tip_pos.y = dest.y;
+								tip_pos = map_to_screen(it->center.x, it->center.y, shakycam.x, shakycam.y);
+								tip_pos.y -= TILE_H;
 							}
 						}
 					}

--- a/src/MenuTalker.cpp
+++ b/src/MenuTalker.cpp
@@ -132,7 +132,7 @@ void MenuTalker::logic() {
 	closeButton->enabled = false;
 
 	// determine active button
-	if (event_cursor < npc->dialog[dialog_node].size()-1) {
+	if ((unsigned)dialog_node < npc->dialog.size() && !npc->dialog[dialog_node].empty() && event_cursor < npc->dialog[dialog_node].size()-1) {
 		if (npc->dialog[dialog_node][event_cursor+1].type != "") {
 			advanceButton->enabled = true;
 			tablist.remove(closeButton);
@@ -187,7 +187,8 @@ void MenuTalker::logic() {
 }
 
 void MenuTalker::createBuffer() {
-	if (event_cursor >= npc->dialog[dialog_node].size()) return;
+	if ((unsigned)dialog_node >= npc->dialog.size() || event_cursor >= npc->dialog[dialog_node].size())
+		return;
 
 	std::string line;
 
@@ -243,30 +244,32 @@ void MenuTalker::render() {
 	setBackgroundDest(dest);
 	Menu::render();
 
-	// show active portrait
-	std::string etype = npc->dialog[dialog_node][event_cursor].type;
-	if (etype == "him" || etype == "her") {
-		Sprite *r = npc->portrait;
-		if (r) {
-			src.w = dest.w = portrait_he.w;
-			src.h = dest.h = portrait_he.h;
-			dest.x = offset_x + portrait_he.x;
-			dest.y = offset_y + portrait_he.y;
+	if ((unsigned)dialog_node < npc->dialog.size() && event_cursor < npc->dialog[dialog_node].size()) {
+		// show active portrait
+		std::string etype = npc->dialog[dialog_node][event_cursor].type;
+		if (etype == "him" || etype == "her") {
+			Sprite *r = npc->portrait;
+			if (r) {
+				src.w = dest.w = portrait_he.w;
+				src.h = dest.h = portrait_he.h;
+				dest.x = offset_x + portrait_he.x;
+				dest.y = offset_y + portrait_he.y;
 
-			r->setClip(src);
-			r->setDest(dest);
-			render_device->render(r);
+				r->setClip(src);
+				r->setDest(dest);
+				render_device->render(r);
+			}
 		}
-	}
-	else if (etype == "you") {
-		if (portrait) {
-			src.w = dest.w = portrait_you.w;
-			src.h = dest.h = portrait_you.h;
-			dest.x = offset_x + portrait_you.x;
-			dest.y = offset_y + portrait_you.y;
-			portrait->setClip(src);
-			portrait->setDest(dest);
-			render_device->render(portrait);
+		else if (etype == "you") {
+			if (portrait) {
+				src.w = dest.w = portrait_you.w;
+				src.h = dest.h = portrait_you.h;
+				dest.x = offset_x + portrait_you.x;
+				dest.y = offset_y + portrait_you.y;
+				portrait->setClip(src);
+				portrait->setDest(dest);
+				render_device->render(portrait);
+			}
 		}
 	}
 
@@ -275,7 +278,7 @@ void MenuTalker::render() {
 	textbox->render();
 
 	// show advance button if there are more event components, or close button if not
-	if (event_cursor < npc->dialog[dialog_node].size()-1) {
+	if ((unsigned)dialog_node < npc->dialog.size() && !npc->dialog[dialog_node].empty() && event_cursor < npc->dialog[dialog_node].size()-1) {
 		if (npc->dialog[dialog_node][event_cursor+1].type != "") {
 			advanceButton->render();
 		}

--- a/src/NPC.cpp
+++ b/src/NPC.cpp
@@ -340,9 +340,11 @@ std::string NPC::getDialogTopic(unsigned int dialog_node) {
  * Check if the hero can move during this dialog branch
  */
 bool NPC::checkMovement(unsigned int dialog_node) {
-	for (unsigned int i=0; i<dialog[dialog_node].size(); i++) {
-		if (dialog[dialog_node][i].type == "allow_movement")
-			return toBool(dialog[dialog_node][i].s);
+	if (dialog_node < dialog.size()) {
+		for (unsigned int i=0; i<dialog[dialog_node].size(); i++) {
+			if (dialog[dialog_node][i].type == "allow_movement")
+				return toBool(dialog[dialog_node][i].s);
+		}
 	}
 	return true;
 }
@@ -353,6 +355,8 @@ bool NPC::checkMovement(unsigned int dialog_node) {
  * Return false if the dialog has ended
  */
 bool NPC::processDialog(unsigned int dialog_node, unsigned int &event_cursor) {
+	if (dialog_node >= dialog.size())
+		return false;
 
 	while (event_cursor < dialog[dialog_node].size()) {
 
@@ -401,11 +405,11 @@ void NPC::processEvent(unsigned int dialog_node, unsigned int cursor) {
 
 	Event ev;
 
-	if (cursor < dialog[dialog_node].size() && isDialogType(dialog[dialog_node][cursor].type)) {
+	if (dialog_node < dialog.size() && cursor < dialog[dialog_node].size() && isDialogType(dialog[dialog_node][cursor].type)) {
 		cursor++;
 	}
 
-	while (cursor < dialog[dialog_node].size() && !isDialogType(dialog[dialog_node][cursor].type)) {
+	while (dialog_node < dialog.size() && cursor < dialog[dialog_node].size() && !isDialogType(dialog[dialog_node][cursor].type)) {
 		ev.components.push_back(dialog[dialog_node][cursor]);
 		cursor++;
 	}


### PR DESCRIPTION
Closes #1315

The actual fix is the change in GameStatePlay.cpp. However, I've also
added some bounds checking to MenuTalker.cpp and NPC.cpp to help prevent
some crashes.

Also fixed are the positions of mouse-over tooltips for events. They
should be positioned the same as tooltips when using no mouse.
