### PR TITLE
Update logic_ticks when game is paused

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -163,8 +163,10 @@ static void mainLoop (bool debug_event) {
 			loops++;
 
 			// don't skip frames if the game is paused
-			if (gswitch->isPaused())
+			if (gswitch->isPaused()) {
+				logic_ticks = now_ticks;
 				break;
+			}
 		}
 
 		render_device->blankScreen();


### PR DESCRIPTION
Closes #1321

This was missing from 9b0e128. I hadn't tested that commit on a slow system, so the bug wasn't actually fixed. I have tested this commit on my netbook (where I could reproduce the issue) and it is completely gone.
