### PR TITLE
Allow variable amount of actionbar slots

### DIFF
--- a/src/GameStatePlay.h
+++ b/src/GameStatePlay.h
@@ -88,7 +88,7 @@ private:
 	void checkStash();
 	void checkCutscene();
 	void checkSaveEvent();
-	void updateActionBar(int index = 0);
+	void updateActionBar(unsigned index = 0);
 	void showLoading();
 	void loadTitles();
 

--- a/src/MenuActionBar.h
+++ b/src/MenuActionBar.h
@@ -42,6 +42,8 @@ const int MENU_INVENTORY = 1;
 const int MENU_POWERS = 2;
 const int MENU_LOG = 3;
 
+const int ACTIONBAR_MAIN = 10;
+
 class MenuActionBar : public Menu {
 private:
 	void alignElements();
@@ -55,8 +57,11 @@ private:
 	Avatar *hero;
 	Rect src;
 
-	WidgetLabel *labels[16];
+	std::vector<WidgetLabel *> labels;
+	WidgetLabel * menu_labels[4];
+
 	Point last_mouse;
+	void addSlot(unsigned index, int x, int y);
 
 public:
 
@@ -67,34 +72,32 @@ public:
 	void logic();
 	void render();
 	void checkAction(std::vector<ActionData> &action_queue);
-	int checkDrag(Point mouse);
+	int checkDrag(const Point& mouse);
 	void checkMenu(bool &menu_c, bool &menu_i, bool &menu_p, bool &menu_l);
-	void drop(Point mouse, int power_index, bool rearranging);
+	void drop(const Point& mouse, int power_index, bool rearranging);
 	void actionReturn(int power_index);
-	void remove(Point mouse);
-	void set(int power_id[12]);
+	void remove(const Point& mouse);
+	void set(std::vector<int> power_id);
 	void clear();
 	void resetSlots();
-	void setItemCount(int index, int count, bool is_equipped = false);
+	void setItemCount(unsigned index, int count, bool is_equipped = false);
 
-	TooltipData checkTooltip(Point mouse);
+	TooltipData checkTooltip(const Point& mouse);
+	bool isWithinSlots(const Point& mouse);
+	bool isWithinMenus(const Point& mouse);
 
-	int hotkeys[12]; // refer to power_index in PowerManager
-	int hotkeys_temp[12]; // temp for shapeshifting
-	int hotkeys_mod[12]; // hotkeys can be changed by items
-	bool locked[12]; // if slot is locked, you cannot drop it
-	WidgetSlot *slots[12]; // hotkey slots
+	unsigned slots_count;
+	std::vector<int> hotkeys; // refer to power_index in PowerManager
+	std::vector<int> hotkeys_temp; // temp for shapeshifting
+	std::vector<int> hotkeys_mod; // hotkeys can be changed by items
+	std::vector<bool> locked; // if slot is locked, you cannot drop it
+	std::vector<WidgetSlot *> slots; // hotkey slots
 	WidgetSlot *menus[4]; // menu buttons
-	int slot_item_count[12]; // -1 means this power isn't item based.  0 means out of items.  1+ means sufficient items.
-	bool slot_enabled[12];
+	std::vector<int> slot_item_count; // -1 means this power isn't item based.  0 means out of items.  1+ means sufficient items.
+	std::vector<bool> slot_enabled;
 	bool requires_attention[4];
-	bool slot_activated[12];
+	std::vector<bool> slot_activated;
 
-	// these store the area occupied by these hotslot sections.
-	// useful for detecting mouse interactions on those locations
-	Rect numberArea;
-	Rect mouseArea;
-	Rect menuArea;
 	int drag_prev_slot;
 	bool updated;
 	int twostep_slot;

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -761,7 +761,7 @@ void MenuManager::logic() {
 				}
 			}
 			// action bar
-			if (!inpt->touch_locked && (isWithin(act->numberArea,inpt->mouse) || isWithin(act->mouseArea,inpt->mouse) || isWithin(act->menuArea, inpt->mouse))) {
+			if (!inpt->touch_locked && (act->isWithinSlots(inpt->mouse) || act->isWithinMenus(inpt->mouse))) {
 				inpt->lock[MAIN1] = true;
 
 				// ctrl-click action bar to clear that slot
@@ -769,7 +769,7 @@ void MenuManager::logic() {
 					act->remove(inpt->mouse);
 				}
 				// allow drag-to-rearrange action bar
-				else if (!isWithin(act->menuArea, inpt->mouse)) {
+				else if (!act->isWithinMenus(inpt->mouse)) {
 					drag_power = act->checkDrag(inpt->mouse);
 					if (drag_power > 0) {
 						mouse_dragging = true;
@@ -794,14 +794,14 @@ void MenuManager::logic() {
 
 			// putting a power on the Action Bar
 			if (drag_src == DRAG_SRC_POWERS) {
-				if (isWithin(act->numberArea,inpt->mouse) || isWithin(act->mouseArea,inpt->mouse)) {
+				if (act->isWithinSlots(inpt->mouse)) {
 					act->drop(inpt->mouse, drag_power, 0);
 				}
 			}
 
 			// rearranging the action bar
 			else if (drag_src == DRAG_SRC_ACTIONBAR) {
-				if (isWithin(act->numberArea,inpt->mouse) || isWithin(act->mouseArea,inpt->mouse)) {
+				if (act->isWithinSlots(inpt->mouse)) {
 					act->drop(inpt->mouse, drag_power, 1);
 					// for locked slots forbid power dropping
 				}
@@ -817,7 +817,7 @@ void MenuManager::logic() {
 				if (inv->visible && isWithin(inv->window_area, inpt->mouse)) {
 					inv->drop(inpt->mouse, drag_stack);
 				}
-				else if (isWithin(act->numberArea,inpt->mouse) || isWithin(act->mouseArea,inpt->mouse)) {
+				else if (act->isWithinSlots(inpt->mouse)) {
 					// The action bar is not storage!
 					inv->itemReturn(drag_stack);
 
@@ -929,13 +929,13 @@ void MenuManager::logic() {
 	}
 
 	// for action-bar powers that represent items, lookup the current item count
-	for (int i=0; i<12; i++) {
+	for (unsigned i = 0; i < act->slots_count; i++) {
 		act->slot_enabled[i] = true;
 		act->setItemCount(i, -1);
 
 		if (act->hotkeys[i] != -1) {
 			// first check if we're using a two-step power
-			if (act->twostep_slot != -1 && act->twostep_slot != i) {
+			if (act->twostep_slot != -1 && (unsigned)act->twostep_slot != i) {
 				act->slot_enabled[i] = false;
 				continue;
 			}

--- a/src/PowerManager.h
+++ b/src/PowerManager.h
@@ -104,7 +104,7 @@ public:
 class ActionData {
 public:
 	int power;
-	int hotkey;
+	unsigned hotkey;
 	bool instant_item;
 	FPoint target;
 

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -106,10 +106,17 @@ void GameStatePlay::saveGame() {
 
 		// action bar
 		outfile << "actionbar=";
-		for (int i=0; i<12; i++) {
-			if (pc->stats.transformed) outfile << menu->act->hotkeys_temp[i];
-			else outfile << menu->act->hotkeys[i];
-			if (i<11) outfile << ",";
+		for (unsigned i = 0; i < ACTIONBAR_MAX; i++) {
+			if (i < menu->act->slots_count)
+			{
+				if (pc->stats.transformed) outfile << menu->act->hotkeys_temp[i];
+				else outfile << menu->act->hotkeys[i];
+			}
+			else
+			{
+				outfile << 0;
+			}
+			if (i < ACTIONBAR_MAX - 1) outfile << ",";
 		}
 		outfile << "\n";
 
@@ -196,11 +203,7 @@ void GameStatePlay::loadGame() {
 	if (game_slot == 0) return;
 
 	FileParser infile;
-	int hotkeys[12];
-
-	for (int i=0; i<12; i++) {
-		hotkeys[i] = -1;
-	}
+	std::vector<int> hotkeys(ACTIONBAR_MAX, -1);
 
 	std::stringstream ss;
 	ss.str("");
@@ -281,7 +284,7 @@ void GameStatePlay::loadGame() {
 				}
 			}
 			else if (infile.key == "actionbar") {
-				for (int i=0; i<12; i++) {
+				for (int i = 0; i < ACTIONBAR_MAX; i++) {
 					hotkeys[i] = toInt(infile.nextValue());
 					if (hotkeys[i] < 0) {
 						logError("SaveLoad: Hotkey power on position %d has negative id, skipping\n", i);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -246,9 +246,9 @@ void setPaths() {
 	PATH_USER = std::string(SDL_AndroidGetInternalStoragePath()) + "/saves";
 	createDir(PATH_CONF);
 	createDir(PATH_USER);
-	
+
 	std::string mods_folder = "data/org.flare.app/files";
-	
+
 	if (SDL_AndroidGetExternalStorageState() != 0)
 	{
 		PATH_DATA = std::string(SDL_AndroidGetExternalStoragePath());

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -36,6 +36,8 @@ public:
 	std::string description;
 };
 
+const int ACTIONBAR_MAX = 12; // maximum number of slots in MenuActionBar
+
 class HeroClass {
 public:
 	std::string name;
@@ -46,7 +48,7 @@ public:
 	int mental;
 	int offense;
 	int defense;
-	int hotkeys[12];
+	std::vector<int> hotkeys;
 	std::vector<int> powers;
 	std::vector<std::string> statuses;
 	std::string power_tree;
@@ -61,9 +63,7 @@ public:
 		, offense(0)
 		, defense(0)
 		, power_tree("") {
-		for (int i=0; i<12; i++) {
-			hotkeys[i] = 0;
-		}
+		hotkeys = std::vector<int>(ACTIONBAR_MAX, 0);
 		powers.clear();
 	}
 };


### PR DESCRIPTION
Closes #1303

Changes in menus/actionbar.txt:
- numberArea, mouseArea, and menuArea are obsolete
- Numbered slots have a new syntax. Instead of `slot1=x,y,w,h`, we use
  `slot=1,x,y`. Width and height are whatever the icon size is (32 for
  fantasycore)
- Like numbered slots, mouse slots and menu slots don't require width and height to be
  specified.
