### PR TITLE
Fix segmentation fault

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,12 +118,14 @@ static void init(const CmdLineArgs& cmd_line_args) {
 	font = getFontEngine();
 	anim = new AnimationManager();
 	comb = new CombatText();
-	inpt = getInputManager();
-	icons = NULL;
-
+	
 	// Load miscellaneous settings
 	eset = new EngineSettings();
 	eset->load();
+	
+	inpt = getInputManager();
+	icons = NULL;
+
 	Stats::init();
 
 	// platform-specific default screen size


### PR DESCRIPTION
If enabled mod "gcw0_defaults" game crashes on startup with "Segmentation fault" error (linux).
Crash on use variable "eset->misc.save_prefix" in src/InputState.cpp (function loadKeyBindings)
Patch move "eset" initialisation before usage from getInputManager().