### PR TITLE
Fixed xp stat bar numbers to relate to current pc level

### DIFF
--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -283,9 +283,11 @@ void MenuManager::logic() {
 		xp->setCustomString(msg->get("XP: %d", pc->stats.xp));
 	}
 	else {
-		xp->setCustomString(msg->get("XP: %d/%d", pc->stats.xp, eset->xp.getLevelXP(pc->stats.level + 1)));
+		// displays xp relative to current pc level
+		xp->setCustomString(msg->get("XP: %d/%d", pc->stats.xp - eset->xp.getLevelXP(pc->stats.level), eset->xp.getLevelXP(pc->stats.level + 1) - eset->xp.getLevelXP(pc->stats.level)));
 	}
-	xp->update(eset->xp.getLevelXP(pc->stats.level), pc->stats.xp, eset->xp.getLevelXP(pc->stats.level + 1));
+	// xp relative to current level (from 0 to ammount need for next level)
+	xp->update(0, pc->stats.xp - eset->xp.getLevelXP(pc->stats.level), eset->xp.getLevelXP(pc->stats.level + 1) - eset->xp.getLevelXP(pc->stats.level));
 
 	// when selecting item quantities, don't process other menus
 	if (num_picker->visible) {


### PR DESCRIPTION
Currently **XP Stat bar** on mouse over (or when set to always show values on bars) shows numbers like:
`17530/32040`

In practice this can mean, that you gained 300 xp or 1300 xp on level 7, it is not obvious.

I have changed it to show:
`500/15600`

So now, numbers are related to current player level. If someone wants to check whole XP - it is shown as tooltip in Character menu (on level nr).