### PR TITLE
Use SDL_Scancode for keyboard binding

### DIFF
--- a/src/InputState.cpp
+++ b/src/InputState.cpp
@@ -66,7 +66,7 @@ InputState::InputState(void)
 	, current_touch()
 	, dump_event(false)
 	, file_version(new Version())
-	, file_version_min(new Version(1, 6, 28))
+	, file_version_min(new Version(1, 6, 29))
 {
 }
 

--- a/src/InputState.cpp
+++ b/src/InputState.cpp
@@ -66,7 +66,7 @@ InputState::InputState(void)
 	, current_touch()
 	, dump_event(false)
 	, file_version(new Version())
-	, file_version_min(new Version(1, 6, 29))
+	, file_version_min(new Version(1, 9, 20))
 {
 }
 

--- a/src/SDLInputState.cpp
+++ b/src/SDLInputState.cpp
@@ -154,6 +154,12 @@ void SDLInputState::defaultQwertyKeyBindings () {
 	binding[Input::ACTIONBAR_USE] = binding_alt[Input::ACTIONBAR_USE] = SDLK_n;
 
 	binding[Input::DEVELOPER_MENU] = binding_alt[Input::DEVELOPER_MENU] = SDLK_F5;
+
+	// Convert SDL_Keycode to SDL_Scancode, skip mouse binding
+	for (int key=0; key<KEY_COUNT; key++) {
+		if (SDL_GetScancodeFromKey(binding[key]) > 0) binding[key] = SDL_GetScancodeFromKey(binding[key]);
+		if (SDL_GetScancodeFromKey(binding_alt[key]) > 0) binding_alt[key] = SDL_GetScancodeFromKey(binding_alt[key]);
+	}
 }
 
 void SDLInputState::setFixedKeyBindings() {
@@ -177,6 +183,7 @@ void SDLInputState::setFixedKeyBindings() {
 }
 
 void SDLInputState::validateFixedKeyBinding(int action, int key, int bindings_list) {
+	key = SDL_GetScancodeFromKey(key);
 	for (int i = 0; i < KEY_COUNT; ++i) {
 		if (i == action) {
 			if (bindings_list == InputState::BINDING_DEFAULT)
@@ -344,7 +351,7 @@ void SDLInputState::handle() {
 					last_is_joystick = false;
 
 				for (int key=0; key<KEY_COUNT; key++) {
-					if (event.key.keysym.sym == binding[key] || event.key.keysym.sym == binding_alt[key]) {
+					if (event.key.keysym.scancode == binding[key] || event.key.keysym.scancode == binding_alt[key]) {
 						pressing[key] = true;
 						un_press[key] = false;
 					}
@@ -358,11 +365,11 @@ void SDLInputState::handle() {
 					last_is_joystick = false;
 
 				for (int key=0; key<KEY_COUNT; key++) {
-					if (event.key.keysym.sym == binding[key] || event.key.keysym.sym == binding_alt[key]) {
+					if (event.key.keysym.scancode == binding[key] || event.key.keysym.scancode == binding_alt[key]) {
 						un_press[key] = true;
 					}
 				}
-				last_key = event.key.keysym.sym;
+				last_key = event.key.keysym.scancode;
 
 				if (event.key.keysym.sym == SDLK_UP) pressing_up = false;
 				if (event.key.keysym.sym == SDLK_DOWN) pressing_down = false;
@@ -616,6 +623,7 @@ std::string SDLInputState::getJoystickName(int index) {
 }
 
 std::string SDLInputState::getKeyName(int key) {
+	key = SDL_GetKeyFromScancode(static_cast<SDL_Scancode>(key));
 	// first, we try to provide a translation of the key
 	switch (static_cast<SDL_Keycode>(key)) {
 		case SDLK_BACKSPACE:    return msg->get("Backspace");

--- a/src/Version.cpp
+++ b/src/Version.cpp
@@ -30,7 +30,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include <SDL.h>
 
-Version VersionInfo::ENGINE(1, 9, 17);
+Version VersionInfo::ENGINE(1, 9, 20);
 Version VersionInfo::MIN(0, 0, 0);
 Version VersionInfo::MAX(USHRT_MAX, USHRT_MAX, USHRT_MAX);
 


### PR DESCRIPTION
If start game with russian (or any non-english) keyboard layout: keyboard bindings not work. Its not obvious and uncomfortably.
Patch replace SDL_Keycode to SDL_Scancode as primary ident PHYSICAL location of a keyboard key.
Without backward compatibility (keybindings.txt) and needed review. Thanks for Flare.

http://wiki.libsdl.org/SDL_Scancode
