### PR TITLE
 Add error handler on critical exception in map data 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ Set (FLARE_HEADERS
 	./src/EnemyGroupManager.h
 	./src/EnemyManager.h
 	./src/EngineSettings.h
+	./src/ErrorHandler.h
 	./src/EventManager.h
 	./src/FileParser.h
 	./src/FontEngine.h

--- a/src/ErrorHandler.h
+++ b/src/ErrorHandler.h
@@ -1,0 +1,30 @@
+/*
+This file is part of FLARE.
+
+FLARE is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License as published by the Free Software Foundation,
+either version 3 of the License, or (at your option) any later version.
+
+FLARE is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+FLARE.  If not, see http://www.gnu.org/licenses/
+*/
+
+#ifndef ERRORHANDLER_H
+#define ERRORHANDLER_H
+
+#include "CommonIncludes.h"
+#include "Utils.h"
+
+class ErrorHandler {
+public:
+	enum {
+		STATUS_OK = 0,
+		CRITICAL_ERROR_NPC_FILE_NOT_FOUND = 1
+	};
+};
+
+#endif // ERRORHANDLER_H

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -16,6 +16,7 @@ You should have received a copy of the GNU General Public License along with
 FLARE.  If not, see http://www.gnu.org/licenses/
 */
 
+#include "ErrorHandler.h"
 #include "GameState.h"
 #include "MessageEngine.h"
 #include "RenderDevice.h"
@@ -30,6 +31,7 @@ GameState::GameState()
 	, force_refresh_background(false)
 	, save_settings_on_exit(true)
 	, load_counter(0)
+	, critical_error_num(ErrorHandler::STATUS_OK)
 	, requestedGameState(NULL)
 	, exitRequested(false)
 	, loading_tip(new WidgetTooltip())
@@ -54,6 +56,7 @@ GameState& GameState::operator=(const GameState& other) {
 	load_counter = other.load_counter;
 	requestedGameState = other.requestedGameState;
 	exitRequested = other.exitRequested;
+	critical_error_num = other.critical_error_num;
 	loading_tip = new WidgetTooltip();
 	loading_tip_buf.addText(msg->get("Loading..."));
 

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -21,6 +21,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #define GAMESTATE_H
 
 #include "CommonIncludes.h"
+#include "ErrorHandler.h"
 #include "WidgetTooltip.h"
 
 class GameState {
@@ -51,6 +52,7 @@ public:
 	bool save_settings_on_exit;
 
 	int load_counter;
+	int critical_error_num;
 
 protected:
 	GameState* requestedGameState;

--- a/src/GameStatePlay.cpp
+++ b/src/GameStatePlay.cpp
@@ -347,6 +347,12 @@ void GameStatePlay::checkTeleport() {
 			// enemies and npcs should be initialized AFTER on_load events execute
 			enemym->handleNewMap();
 			npcs->handleNewMap();
+
+			if (npcs->critical_error_num) {
+				critical_error_num = npcs->critical_error_num;
+				return;
+			}
+
 			resetNPC();
 
 			menu->mini->prerender(&mapr->collider, mapr->w, mapr->h);
@@ -421,6 +427,12 @@ void GameStatePlay::checkCancel() {
 
 		snd->stopMusic();
 		exitRequested = true;
+	}
+
+	if (critical_error_num != ErrorHandler::STATUS_OK) {
+		menu->closeAll();
+		snd->stopMusic();
+		setRequestedGameState(new GameStateTitle());
 	}
 }
 
@@ -913,6 +925,9 @@ void GameStatePlay::logic() {
 	checkSaveEvent();
 	checkNotifications();
 	checkCancel();
+
+	if (critical_error_num != ErrorHandler::STATUS_OK)
+		return;
 
 	mapr->logic(isPaused());
 	mapr->enemies_cleared = enemym->isCleared();

--- a/src/GameStateTitle.cpp
+++ b/src/GameStateTitle.cpp
@@ -126,6 +126,11 @@ GameStateTitle::GameStateTitle()
 	label_version->setText(VersionInfo::createVersionStringFull());
 	label_version->setColor(font->getColor(FontEngine::COLOR_MENU_NORMAL));
 
+	label_error = new WidgetLabel();
+	label_error->setJustify(FontEngine::JUSTIFY_CENTER);
+	label_error->setColor(font->getColor(FontEngine::COLOR_MENU_PENALTY));
+	label_error->setPos((settings->view_w / 2), (settings->view_h / 5));
+
 	// Setup tab order
 	tablist.ignore_no_mouse = true;
 	tablist.add(button_play);
@@ -144,7 +149,7 @@ GameStateTitle::GameStateTitle()
 }
 
 void GameStateTitle::logic() {
-	if (inpt->window_resized)
+	if (inpt->window_resized || critical_error_num != ErrorHandler::STATUS_OK)
 		refreshWidgets();
 
 	button_play->enabled = eset->gameplay.enable_playgame;
@@ -191,6 +196,16 @@ void GameStateTitle::logic() {
 	}
 }
 
+void GameStateTitle::criticalErrorWidget() {
+	if (critical_error_num == ErrorHandler::CRITICAL_ERROR_NPC_FILE_NOT_FOUND) {
+		label_error->setText("Unable load NPC file");
+	}
+	else if (critical_error_num != ErrorHandler::STATUS_OK) {
+		label_error->setText("UNKNOWN ERROR");
+	}
+	critical_error_num = ErrorHandler::STATUS_OK;
+}
+
 void GameStateTitle::refreshWidgets() {
 	if (logo) {
 		Rect r;
@@ -208,6 +223,8 @@ void GameStateTitle::refreshWidgets() {
 	button_exit->setPos(0, 0);
 
 	label_version->setPos(settings->view_w, 0);
+
+	criticalErrorWidget();
 }
 
 void GameStateTitle::render() {
@@ -224,6 +241,8 @@ void GameStateTitle::render() {
 
 	// version number
 	label_version->render();
+
+	label_error->render();
 }
 
 GameStateTitle::~GameStateTitle() {

--- a/src/GameStateTitle.h
+++ b/src/GameStateTitle.h
@@ -29,6 +29,7 @@ class WidgetLabel;
 class GameStateTitle : public GameState {
 private:
 	void refreshWidgets();
+	void criticalErrorWidget();
 
 	Sprite *logo;
 	WidgetButton *button_play;
@@ -36,6 +37,7 @@ private:
 	WidgetButton *button_cfg;
 	WidgetButton *button_credits;
 	WidgetLabel *label_version;
+	WidgetLabel *label_error;
 
 	TabList tablist;
 

--- a/src/GameSwitcher.cpp
+++ b/src/GameSwitcher.cpp
@@ -71,6 +71,7 @@ GameSwitcher::GameSwitcher()
 
 	label_fps = new WidgetLabel();
 	done = false;
+	critical_error_num = ErrorHandler::STATUS_OK;
 	loadMusic();
 	loadFPS();
 
@@ -189,7 +190,7 @@ void GameSwitcher::logic() {
 				loadMusic();
 
 		// if this game state shows a background image, load it here
-		if (currentState->has_background)
+		if (currentState->has_background && critical_error_num == ErrorHandler::STATUS_OK)
 			loadBackgroundImage();
 		else
 			freeBackground();
@@ -201,7 +202,15 @@ void GameSwitcher::logic() {
 		currentState->force_refresh_background = false;
 	}
 
+	if (critical_error_num != ErrorHandler::STATUS_OK) {
+		// critical_error_num way : Childs -> GameStatePlay -> GameSwitcher -> GameStateTitle
+		currentState->critical_error_num = critical_error_num;
+		critical_error_num = ErrorHandler::STATUS_OK;
+	}
+
 	currentState->logic();
+
+	critical_error_num = currentState->critical_error_num;
 
 	// Check if the GameState wants to quit the application
 	done = currentState->isExitRequested();

--- a/src/GameSwitcher.h
+++ b/src/GameSwitcher.h
@@ -74,6 +74,7 @@ public:
 	void showFPS(float fps);
 	void saveUserSettings();
 	bool done;
+	int critical_error_num;
 };
 
 #endif

--- a/src/NPC.cpp
+++ b/src/NPC.cpp
@@ -26,6 +26,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "AnimationManager.h"
 #include "AnimationSet.h"
 #include "CampaignManager.h"
+#include "ErrorHandler.h"
 #include "EventManager.h"
 #include "FileParser.h"
 #include "ItemManager.h"
@@ -62,6 +63,7 @@ void NPC::load(const std::string& npc_id) {
 
 	FileParser infile;
 	ItemStack stack;
+	critical_error_num = ErrorHandler::STATUS_OK;
 
 	portrait_filenames.resize(1);
 
@@ -256,6 +258,10 @@ void NPC::load(const std::string& npc_id) {
 			}
 		}
 		infile.close();
+	}
+	else {
+		critical_error_num = ErrorHandler::CRITICAL_ERROR_NPC_FILE_NOT_FOUND;
+		return;
 	}
 	loadGraphics();
 

--- a/src/NPC.h
+++ b/src/NPC.h
@@ -26,6 +26,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "CommonIncludes.h"
 #include "Entity.h"
+#include "ErrorHandler.h"
 #include "ItemStorage.h"
 #include "Utils.h"
 
@@ -97,6 +98,8 @@ public:
 	// outer vector is addressing the dialog and the inner vector is
 	// addressing the events during one dialog
 	std::vector<std::vector<EventComponent> > dialog;
+
+	int critical_error_num;
 };
 
 #endif

--- a/src/NPCManager.cpp
+++ b/src/NPCManager.cpp
@@ -26,6 +26,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "Animation.h"
 #include "CampaignManager.h"
+#include "ErrorHandler.h"
 #include "EventManager.h"
 #include "ItemManager.h"
 #include "MapRenderer.h"
@@ -53,6 +54,7 @@ void NPCManager::handleNewMap() {
 
 	Map_NPC mn;
 	ItemStack item_roll;
+	critical_error_num = ErrorHandler::STATUS_OK;
 
 	// remove existing NPCs
 	for (unsigned i=0; i<npcs.size(); i++)
@@ -80,6 +82,12 @@ void NPCManager::handleNewMap() {
 
 		NPC *npc = new NPC();
 		npc->load(mn.id);
+
+		if (npc->critical_error_num != ErrorHandler::STATUS_OK) {
+			critical_error_num = npc->critical_error_num;
+			return;
+		}
+
 		npc->pos.x = mn.pos.x;
 		npc->pos.y = mn.pos.y;
 

--- a/src/NPCManager.h
+++ b/src/NPCManager.h
@@ -48,6 +48,7 @@ public:
 	void logic();
 	void addRenders(std::vector<Renderable> &r);
 	int getID(const std::string& npcName);
+	int critical_error_num;
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "CombatText.h"
 #include "DeviceList.h"
 #include "EngineSettings.h"
+#include "ErrorHandler.h"
 #include "GameSwitcher.h"
 #include "InputState.h"
 #include "MessageEngine.h"
@@ -196,6 +197,11 @@ static void mainLoop () {
 				break;
 
 			gswitch->logic();
+
+			// Skip frame if found critical error in map verification
+			if (gswitch->critical_error_num != ErrorHandler::STATUS_OK)
+				break;
+
 			inpt->resetScroll();
 
 			// Engine done means the user escapes the main game menu.
@@ -220,6 +226,10 @@ static void mainLoop () {
 				break;
 			}
 		}
+
+		// Skip frame if found critical error in map verification
+		if (gswitch->critical_error_num != ErrorHandler::STATUS_OK)
+			continue;
 
 		if (!inpt->window_minimized) {
 			render_device->blankScreen();


### PR DESCRIPTION
I modify Flare map in Tiled editor and run game for testing.
Interface frozzen and game crash with: Segmentation fault.
Its no userfrendly for newbee modder/maphacker ;-)

Patch:
Make hierarchy for handle critical errors in map verification.
Game soft stoped and redirected in TitleMenu if found critical error (see screenshot).
![screen](https://user-images.githubusercontent.com/3074285/54886688-ddd2fc00-4e9b-11e9-9b2a-f7eac81e8fba.png)

p.s. Sorry for my English

Console and GDB output:
ERROR: FileParser: Could not open text file: npcs/wonderland_obelisk.txt: No such file or directory!

Program received signal SIGSEGV, Segmentation fault.
...
0x081ac1c4 in Animation::getCurrentFrame(int) ()
0x082b90c6 in NPCManager::handleNewMap() ()
0x08203d6f in GameStatePlay::checkTeleport() ()
0x082060ba in GameStatePlay::logic() ()
0x0820e1b2 in GameSwitcher::logic() ()
0x083101b2 in mainLoop() ()
0x08310ff3 in main ()
