### PR TITLE
Fix memory leak of tab control in stash menu

### DIFF
--- a/src/MenuStash.cpp
+++ b/src/MenuStash.cpp
@@ -392,5 +392,6 @@ void MenuStash::defocusTabLists() {
 
 MenuStash::~MenuStash() {
 	delete closeButton;
+	delete tab_control;
 }
 


### PR DESCRIPTION
Besides memory leaks this also fixes mods not being able to override tab control images as they remain cached forever. Reproduction steps:
1. Get in-game (to construct the stash menu).
2. Return to the main menu and load a different mod that overrides tab control images.
3. The tab control images are not changed.

I've noticed this when switching between the Empyrean Campaign and Polymorphable.