### PR TITLE
package_osx.sh copy deps from homebrew and mods from flare-game

### DIFF
--- a/package_osx.sh
+++ b/package_osx.sh
@@ -55,10 +55,13 @@ elif [ $FLARE_DEPS_SRC == "homebrew" ]; then
   cp /usr/local/opt/sdl2_mixer/lib/libSDL2_mixer-2.0.0.dylib $LIB
   cp /usr/local/opt/sdl2_ttf/lib/libSDL2_ttf-2.0.0.dylib $LIB
   # VORBIS
-  cp /usr/local/opt/libvorbis/lib/COPYING $LIB/VORBIS-COPYING
-  cp /usr/local/opt/libvorbis/lib/libvorbisfile.0.dylib $LIB
+  cp /usr/local/opt/libvorbis/COPYING $LIB/VORBIS-COPYING
+  cp /usr/local/opt/libvorbis/lib/libvorbis.0.dylib $LIB
   cp /usr/local/opt/libvorbis/lib/libvorbisenc.2.dylib $LIB
   cp /usr/local/opt/libvorbis/lib/libvorbisfile.3.dylib $LIB
+  # OGG
+  cp /usr/local/opt/libogg/COPYING $LIB/OGG-COPYING
+  cp /usr/local/opt/libogg/lib/libogg.0.dylib $LIB
 else
   echo "'$FLARE_DEPS_SRC' unknown dependency source"
   exit 1
@@ -71,5 +74,5 @@ chmod +x ${DST}/start.sh
 
 echo "packaging"
 tar -zcf flare_osx.tar.gz -C ${DST} .
-#rm -fr ${DST}
+rm -fr ${DST}
 echo "done"

--- a/package_osx.sh
+++ b/package_osx.sh
@@ -66,6 +66,26 @@ elif [ ${FLARE_DEPS_SRC} == "homebrew" ]; then
   # OGG
   cp /usr/local/opt/libogg/COPYING ${LIB}/OGG-COPYING
   cp /usr/local/opt/libogg/lib/libogg.0.dylib ${LIB}
+  # PNG
+  cp /usr/local/opt/libpng/lib/libpng16.16.dylib ${LIB}
+
+  # Verify all homebrew deps using using otool
+  for DYLIB in ${LIB}/*.dylib; do
+    #echo "dylib: ${DYLIB}"
+    for LINE in $(otool -L ${DYLIB}); do
+      #echo "line: ${LINE}"
+      if [[ $LINE == *"/usr/local/opt/"* ]]; then
+	NEED=$(basename ${LINE})
+	#echo "${DYLIB} need: ${NEED}"
+	FILE="${LIB}/${NEED}"
+	if [ ! -f "${FILE}" ]; then
+          echo "${NEED} not found, copying"
+	  cp ${LINE} ${LIB}
+        fi
+      fi
+    done
+  done
+
 else
   echo "'${FLARE_DEPS_SRC}' unknown dependency source"
   exit 1

--- a/package_osx.sh
+++ b/package_osx.sh
@@ -2,13 +2,14 @@
 
 FLARE_EXE=$1
 FLARE_DEPS_SRC="http"
+FLARE_GAME=""
 
-if [ -z "$FLARE_EXE" ]; then
+if [ -z "${FLARE_EXE}" ]; then
   echo "usage: $0 <path to flare executable>"
   exit 1
 fi
 if [ ! -f ${FLARE_EXE} ]; then
-  echo "no Flare executable found at $FLARE_EXE. Please follow README in order to build Flare engine first"
+  echo "no Flare executable found at ${FLARE_EXE}. Please follow README in order to build Flare engine first"
   exit 1
 fi
 if [ `otool -L ${FLARE_EXE} | egrep libSDL2 | wc -l` -lt 1 ]; then
@@ -19,15 +20,18 @@ fi
 if [ "$2" != "" ]; then
  FLARE_DEPS_SRC=$2
 fi
-if [ $FLARE_DEPS_SRC == "http" ]; then
+if [ ${FLARE_DEPS_SRC} == "http" ]; then
   echo "download dependencies from website"
-elif [ $FLARE_DEPS_SRC == "homebrew" ]; then
+elif [ ${FLARE_DEPS_SRC} == "homebrew" ]; then
   echo "copy dependencies from homebrew"
 else
   echo "usage: $0 <path to flare executable> <http|homebrew>"
   exit 1
 fi
 
+if [ "$3" != "" ]; then
+ FLARE_GAME=$3
+fi
 
 DST=/tmp/___flare.build
 rm -fr ${DST} && mkdir -p ${DST}
@@ -39,32 +43,46 @@ cp -r RELEASE_NOTES.txt \
   ${FLARE_EXE} \
   mods ${DST}
 
-if [ $FLARE_DEPS_SRC == "http" ]; then
+if [ ${FLARE_DEPS_SRC} == "http" ]; then
   #feel free to build dependencies by yourself btw
   wget 'http://files.ruads.org/flare_osx_dependencies.tar.gz' -P ${DST}
   tar -zxf ${DST}/flare_osx_dependencies.tar.gz -C ${DST}
   rm -f ${DST}/flare_osx_dependencies.tar.gz
-elif [ $FLARE_DEPS_SRC == "homebrew" ]; then
+elif [ ${FLARE_DEPS_SRC} == "homebrew" ]; then
   LIB=${DST}/lib
-  mkdir $LIB
+  mkdir ${LIB}
   # SDL2
-  cp /usr/local/opt/sdl2/COPYING.txt $LIB/SDL2-COPYING.txt
-  cp /usr/local/opt/sdl2/README.txt $LIB/SDL2-README.txt
-  cp /usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib $LIB
-  cp /usr/local/opt/sdl2_image/lib/libSDL2_image-2.0.0.dylib $LIB
-  cp /usr/local/opt/sdl2_mixer/lib/libSDL2_mixer-2.0.0.dylib $LIB
-  cp /usr/local/opt/sdl2_ttf/lib/libSDL2_ttf-2.0.0.dylib $LIB
+  cp /usr/local/opt/sdl2/COPYING.txt ${LIB}/SDL2-COPYING.txt
+  cp /usr/local/opt/sdl2/README.txt ${LIB}/SDL2-README.txt
+  cp /usr/local/opt/sdl2/lib/libSDL2-2.0.0.dylib ${LIB}
+  cp /usr/local/opt/sdl2_image/lib/libSDL2_image-2.0.0.dylib ${LIB}
+  cp /usr/local/opt/sdl2_mixer/lib/libSDL2_mixer-2.0.0.dylib ${LIB}
+  cp /usr/local/opt/sdl2_ttf/lib/libSDL2_ttf-2.0.0.dylib ${LIB}
   # VORBIS
-  cp /usr/local/opt/libvorbis/COPYING $LIB/VORBIS-COPYING
-  cp /usr/local/opt/libvorbis/lib/libvorbis.0.dylib $LIB
-  cp /usr/local/opt/libvorbis/lib/libvorbisenc.2.dylib $LIB
-  cp /usr/local/opt/libvorbis/lib/libvorbisfile.3.dylib $LIB
+  cp /usr/local/opt/libvorbis/COPYING ${LIB}/VORBIS-COPYING
+  cp /usr/local/opt/libvorbis/lib/libvorbis.0.dylib ${LIB}
+  cp /usr/local/opt/libvorbis/lib/libvorbisenc.2.dylib ${LIB}
+  cp /usr/local/opt/libvorbis/lib/libvorbisfile.3.dylib ${LIB}
   # OGG
-  cp /usr/local/opt/libogg/COPYING $LIB/OGG-COPYING
-  cp /usr/local/opt/libogg/lib/libogg.0.dylib $LIB
+  cp /usr/local/opt/libogg/COPYING ${LIB}/OGG-COPYING
+  cp /usr/local/opt/libogg/lib/libogg.0.dylib ${LIB}
 else
-  echo "'$FLARE_DEPS_SRC' unknown dependency source"
+  echo "'${FLARE_DEPS_SRC}' unknown dependency source"
   exit 1
+fi
+
+if [ "${FLARE_GAME}" != "" ]; then
+  FLARE_ENGINE_MOD_LIST=mods/mods.txt
+  FLARE_GAME_MOD=${FLARE_GAME}/mods
+  while IFS= read -r MOD; do
+    MOD_DIR=${FLARE_GAME_MOD}/${MOD}
+    if [ "${MOD}" != "" ] && [ -d "${MOD_DIR}" ]; then
+      cp -r ${MOD_DIR} ${DST}/mods
+      echo "copied ${MOD}"
+    fi
+  done < "${FLARE_ENGINE_MOD_LIST}"
+  cp ${FLARE_GAME}/CREDITS.txt ${DST}
+  cp ${FLARE_GAME}/LICENSE.txt ${DST}
 fi
 
 echo '#!/bin/sh' >> ${DST}/start.sh


### PR DESCRIPTION
With this changes `package_osx.sh` can now be called as normal to only package the engine and collect dependencies from website:

```sh
$ ./package_osx.sh flare
download dependencies from website
...
--2019-09-05 11:56:20--  http://files.ruads.org/flare_osx_dependencies.tar.gz
Resolving files.ruads.org (files.ruads.org)... 5.9.52.199
Connecting to files.ruads.org (files.ruads.org)|5.9.52.199|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4969402 (4.7M) [application/octet-stream]
...
2019-09-05 11:56:22 (2.91 MB/s) - ‘/tmp/___flare.build/flare_osx_dependencies.tar.gz’ saved [4969402/4969402]

packaging
done
```

Or package the engine with dependencies from homebrew:

```sh
$ ./package_osx.sh flare homebrew
copy dependencies from homebrew
packaging
done
```

And finally to package the engine with mods specified in `flare-engine/mods/mods.txt`:

```sh
 ./package_osx.sh flare homebrew ../flare-game/ # or `./package_osx.sh flare http ../flare-game/`
copy dependencies from homebrew
copied fantasycore
copied empyrean_campaign
packaging
done
```

I'm not sure why the website dependancies have the `*.a` files and `libfreetype`, because it does not seem to be needed and just add bloat to the `lib/` directory, but I can just be naive, so will ask in issue #1583.

After packaging using homebrew I did uninstall all dependancies and tested the package: 

```sh
brew uninstall --ignore-dependencies cmake libvorbis sdl2 sdl2_image sdl2_mixer sdl2_ttf libogg
```

I uploaded the packages here(sorry for using a free service, hope it works):

- ~~[flare_osx-engine-190905.tar.gz]() (5.5M MD5 10de931da8d4d0d51f36a21ac137b2ed)~~
- ~~[flare_osx-game-190905.tar.gz]() (124M MD5 7db07d162d563d6eb9f1465621e3cc62)~~

Let me know if I need to change something.