### PR TITLE
Allow adding multiple image entities in animation definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ Set (FLARE_SOURCES
 	./src/BehaviorAlly.cpp
 	./src/Entity.cpp
 	./src/Animation.cpp
+	./src/AnimationMedia.cpp
 	./src/AnimationManager.cpp
 	./src/AnimationSet.cpp
 	./src/AStarContainer.cpp
@@ -210,6 +211,7 @@ Set (FLARE_HEADERS
 	./src/BehaviorAlly.h
 	./src/Entity.h
 	./src/Animation.h
+	./src/AnimationMedia.h
 	./src/AnimationManager.h
 	./src/AnimationSet.h
 	./src/AStarContainer.h

--- a/src/Animation.h
+++ b/src/Animation.h
@@ -33,6 +33,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "CommonIncludes.h"
 #include "Utils.h"
+#include "AnimationMedia.h"
 
 class Animation {
 protected:
@@ -40,7 +41,7 @@ protected:
 
 	const std::string name;
 	const int type;
-	Image *sprite;
+	AnimationMedia *sprite;
 	uint8_t blend_mode;
 	uint8_t alpha_mod;
 	Color color_mod;
@@ -63,7 +64,7 @@ protected:
 
 	// Frame data, all vectors must have the same length:
 	// These are indexed as 8*cur_frame_index + direction.
-	std::vector<Rect> gfx; // position on the spritesheet to be used.
+	std::vector<std::pair<std::string, Rect> > gfx; // position on the spritesheet to be used.
 	std::vector<Point> render_offset; // "virtual point on the floor"
 	std::vector<unsigned short> frames; // a list of frames to play on each tick
 
@@ -86,7 +87,7 @@ protected:
 	};
 
 public:
-	Animation(const std::string &_name, const std::string &_type, Image *_sprite, uint8_t _blend_mode, uint8_t _alpha_mod, Color _color_mod);
+	Animation(const std::string &_name, const std::string &_type, AnimationMedia *_sprite, uint8_t _blend_mode, uint8_t _alpha_mod, Color _color_mod);
 
 	// Traditional way to create an animation.
 	// The frames are stored in a grid like fashion, so the individual frame
@@ -101,7 +102,7 @@ public:
 	void setup(unsigned short _frames, unsigned short _duration, unsigned short _maxkinds = 8);
 
 	// kind can be used for direction(enemies, hero) or randomness(powers)
-	void addFrame(unsigned short index, unsigned short kind, const Rect& rect, const Point& _render_offset);
+	void addFrame(unsigned short index, unsigned short kind, const Rect& rect, const Point& _render_offset, const std::string &key);
 
 	// advance the animation one frame
 	void advanceFrame();

--- a/src/AnimationMedia.cpp
+++ b/src/AnimationMedia.cpp
@@ -1,0 +1,46 @@
+#include "AnimationMedia.h"
+#include "RenderDevice.h"
+#include "SharedResources.h"
+#include <libgen.h>
+
+AnimationMedia::AnimationMedia()
+    : firstKey("")
+{
+}
+
+AnimationMedia::~AnimationMedia()
+{
+}
+
+void AnimationMedia::loadImage(std::string path)
+{
+    char *temp = Utils::strdup(path);
+    std::string key = basename(temp);
+    free(temp);
+
+    sprites[key] = render_device->loadImage(path, RenderDevice::ERROR_NORMAL);
+
+    if (sprites.size() == 1)
+    {
+        firstKey = key;
+    }
+}
+
+std::string AnimationMedia::getFirstKey()
+{
+    return firstKey;
+}
+
+void AnimationMedia::unref()
+{
+    std::map<std::string, Image *>::iterator iter;
+    for (iter = sprites.begin(); iter != sprites.end(); iter++)
+    {
+        iter->second->unref();
+    }
+}
+
+Image *AnimationMedia::getImage(std::string key)
+{
+    return sprites[key];
+}

--- a/src/AnimationMedia.h
+++ b/src/AnimationMedia.h
@@ -1,0 +1,20 @@
+#ifndef ANIMATION_MEDIA_H
+#define ANIMATION_MEDIA_H
+
+#include "CommonIncludes.h"
+
+class AnimationMedia {
+private:
+    std::map<std::string, Image *> sprites;
+    std::string firstKey;
+
+public:
+    AnimationMedia();
+    ~AnimationMedia();
+    Image *getImage(std::string key);
+    void loadImage(std::string path);
+    std::string getFirstKey();
+    void unref();
+};
+
+#endif

--- a/src/AnimationSet.cpp
+++ b/src/AnimationSet.cpp
@@ -57,9 +57,9 @@ AnimationSet::AnimationSet(const std::string &animationname)
 	: name(animationname)
 	, loaded(false)
 	, parent(NULL)
-	, animations()
-	, sprite(NULL) {
-	defaultAnimation = new Animation("default", "play_once", NULL, Renderable::BLEND_NORMAL, 255, Color(255,255,255));
+	, animations() {
+	sprite = new AnimationMedia();
+	defaultAnimation = new Animation("default", "play_once", sprite, Renderable::BLEND_NORMAL, 255, Color(255,255,255));
 	defaultAnimation->setupUncompressed(Point(), Point(), 0, 1, 0);
 }
 
@@ -112,14 +112,7 @@ void AnimationSet::load() {
 		if (parser.section.empty()) {
 			if (parser.key == "image") {
 				// @ATTR image|filename|Filename of sprite-sheet image.
-				if (sprite != NULL) {
-					parser.error("AnimationSet: Multiple images specified. Dragons be here!");
-					Utils::logErrorDialog("AnimationSet: Multiple images specified. Dragons be here!");
-					mods->resetModConfig();
-					Utils::Exit(128);
-				}
-
-				sprite = render_device->loadImage(parser.val, RenderDevice::ERROR_NORMAL);
+				sprite->loadImage(parser.val);
 			}
 			else if (parser.key == "render_size") {
 				// @ATTR render_size|int, int : Width, Height|Width and height of animation.
@@ -202,7 +195,7 @@ void AnimationSet::load() {
 					animations.push_back(newanim);
 					compressed_loading = true;
 				}
-				// frame = index, direction, x, y, w, h, offsetx, offsety
+				// frame = index, direction, x, y, w, h, offsetx, offsety, image
 				Rect r;
 				Point offset;
 				const unsigned short index = static_cast<unsigned short>(Parse::popFirstInt(parser.val));
@@ -213,7 +206,8 @@ void AnimationSet::load() {
 				r.h = Parse::popFirstInt(parser.val);
 				offset.x = Parse::popFirstInt(parser.val);
 				offset.y = Parse::popFirstInt(parser.val);
-				newanim->addFrame(index, direction, r, offset);
+				std::string key = parser.val;
+				newanim->addFrame(index, direction, r, offset, key);
 			}
 			else {
 				parser.error("AnimationSet: '%s' is not a valid key.", parser.key.c_str());
@@ -250,5 +244,6 @@ AnimationSet::~AnimationSet() {
 	for (unsigned i = 0; i < animations.size(); ++i)
 		delete animations[i];
 	delete defaultAnimation;
+	delete sprite;
 }
 

--- a/src/AnimationSet.h
+++ b/src/AnimationSet.h
@@ -21,6 +21,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #define ANIMATION_SET_H
 
 #include "CommonIncludes.h"
+#include "AnimationMedia.h"
 
 class Animation;
 
@@ -45,7 +46,7 @@ public:
 
 	std::vector<Animation*> animations;
 
-	Image *sprite;
+	AnimationMedia *sprite;
 
 	explicit AnimationSet(const std::string &animationname);
 	AnimationSet(const AnimationSet &a); // copy constructor not implemented.


### PR DESCRIPTION
because Large texture and size limits, we need split one large texture to mutiple. so i add this function support.

just an example:

In animation definition folder:  mod/animations/*

we can now:

```
image=images/npcs/peasant_man1.png
image=images/npcs/peasant_man2.png
image=images/npcs/peasant_man3.png
image=images/npcs/peasant_man4.png
# we can add multiple image entities now
[stance]
frames=1
duration=1s
type=looped
frame=0,0,0,0,27,56,8,49,peasant_man1.png
frame=0,0,0,0,27,56,8,49,peasant_man2.png
frame=0,0,0,0,27,56,8,49,peasant_man3.png
frame=0,0,0,0,27,56,8,49,peasant_man4.png
# additional parameter to specify which texture we will use
```
and compatible old format.
