### PR TITLE
[WIP] add define for math.h on windows to M_PI can be used

### DIFF
--- a/src/RenderDevice.cpp
+++ b/src/RenderDevice.cpp
@@ -22,6 +22,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "SharedResources.h"
 
 #include <assert.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
 


### PR DESCRIPTION
On my windows dev environment I had to add this define so that M_PI was available for use. 

Not sure if that one should be wrapped in a conditional #ifdef for Windows?