### PR TITLE
Fix local dir on linux

### DIFF
--- a/src/Platform.h
+++ b/src/Platform.h
@@ -105,7 +105,6 @@ public:
 	void setExitEventFilter();
 	bool dirCreate(const std::string& path);
 	bool dirRemove(const std::string& path);
-	std::string dirGetLocal();
 
 	void FSInit();
 	bool FSCheckReady();

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -105,6 +105,7 @@ public:
 	void setExitEventFilter();
 	bool dirCreate(const std::string& path);
 	bool dirRemove(const std::string& path);
+	std::string dirGetLocal();
 
 	void FSInit();
 	bool FSCheckReady();

--- a/src/PlatformLinux.cpp
+++ b/src/PlatformLinux.cpp
@@ -186,10 +186,9 @@ bool Platform::dirRemove(const std::string& path) {
 std::string Platform::dirGetLocal() {
     char abs_path[1024];
     ssize_t len = readlink("/proc/self/exe", abs_path, 1024);
-    if(len < 0|| len >= 1024)  {
+    if (len < 0 || len >= 1024)
         return "./";
-    }
-    //remove executable name from abs_path
+    // remove executable name from abs_path
     char break_point = '/';
     char break_string = '\0';
     for(ssize_t i = len; i >= 0; --i) {

--- a/src/PlatformLinux.cpp
+++ b/src/PlatformLinux.cpp
@@ -162,7 +162,22 @@ void Platform::setPaths() {
 	if (!path_data && Filesystem::pathExists(settings->path_data)) path_data = true;
 
 	// finally assume the local folder
-	if (!path_data)	settings->path_data = dirGetLocal();
+	if (!path_data)	{
+		char abs_path[1024];
+		ssize_t len = readlink("/proc/self/exe", abs_path, 1024);
+		if (len < 0 || len >= 1024)	settings->path_data =  "./";
+		
+		// remove executable name from abs_path
+		const char BREAK_POINT = '/';
+		const char BREAK_STRING = '\0';
+		for(ssize_t i = len; i >= 0; --i) {
+			if(abs_path[i] == BREAK_POINT) {
+				abs_path[i + 1] = BREAK_STRING;
+				break;
+			}
+		}
+		settings->path_data = std::string(abs_path);
+	}
 }
 
 bool Platform::dirCreate(const std::string& path) {
@@ -181,23 +196,6 @@ bool Platform::dirRemove(const std::string& path) {
 		return false;
 	}
 	return true;
-}
-
-std::string Platform::dirGetLocal() {
-	char abs_path[1024];
-	ssize_t len = readlink("/proc/self/exe", abs_path, 1024);
-	if (len < 0 || len >= 1024)	return "./";
-	
-	// remove executable name from abs_path
-	const char BREAK_POINT = '/';
-	const char BREAK_STRING = '\0';
-	for(ssize_t i = len; i >= 0; --i) {
-		if(abs_path[i] == BREAK_POINT) {
-			abs_path[i + 1] = BREAK_STRING;
-			break;
-		}
-	}
-	return abs_path;
 }
 
 // unused

--- a/src/PlatformLinux.cpp
+++ b/src/PlatformLinux.cpp
@@ -162,7 +162,7 @@ void Platform::setPaths() {
 	if (!path_data && Filesystem::pathExists(settings->path_data)) path_data = true;
 
 	// finally assume the local folder
-	if (!path_data)	settings->path_data = "./";
+	if (!path_data)	settings->path_data = dirGetLocal();
 }
 
 bool Platform::dirCreate(const std::string& path) {
@@ -181,6 +181,24 @@ bool Platform::dirRemove(const std::string& path) {
 		return false;
 	}
 	return true;
+}
+
+std::string Platform::dirGetLocal() {
+    char abs_path[1024];
+    ssize_t len = readlink("/proc/self/exe", abs_path, 1024);
+    if(len < 0|| len >= 1024)  {
+        return "./";
+    }
+    //remove executable name from abs_path
+    char break_point = '/';
+    char break_string = '\0';
+    for(ssize_t i = len; i >= 0; --i) {
+        if(abs_path[i] == break_point) {
+            abs_path[i + 1] = break_string;
+            break;
+        }
+    }
+    return abs_path;
 }
 
 // unused

--- a/src/PlatformLinux.cpp
+++ b/src/PlatformLinux.cpp
@@ -184,20 +184,20 @@ bool Platform::dirRemove(const std::string& path) {
 }
 
 std::string Platform::dirGetLocal() {
-    char abs_path[1024];
-    ssize_t len = readlink("/proc/self/exe", abs_path, 1024);
-    if (len < 0 || len >= 1024)
-        return "./";
-    // remove executable name from abs_path
-    char break_point = '/';
-    char break_string = '\0';
-    for(ssize_t i = len; i >= 0; --i) {
-        if(abs_path[i] == break_point) {
-            abs_path[i + 1] = break_string;
-            break;
-        }
-    }
-    return abs_path;
+	char abs_path[1024];
+	ssize_t len = readlink("/proc/self/exe", abs_path, 1024);
+	if (len < 0 || len >= 1024)	return "./";
+	
+	// remove executable name from abs_path
+	const char BREAK_POINT = '/';
+	const char BREAK_STRING = '\0';
+	for(ssize_t i = len; i >= 0; --i) {
+		if(abs_path[i] == BREAK_POINT) {
+			abs_path[i + 1] = BREAK_STRING;
+			break;
+		}
+	}
+	return abs_path;
 }
 
 // unused


### PR DESCRIPTION
Presuming you have the data files(mods dir) in the same directory with the executable:

```
/opt/flare
├── flare
└── mods
```

If you try to run **flare** form outside it's parent directory,  it will set **PATH_DATA** to **"./"** after not finding other default paths, which is the path to the current working directory and not the path to the **flare executable** location, and it will not run.