### PR TITLE
Fix hero and camera wiggle

### DIFF
--- a/src/Avatar.cpp
+++ b/src/Avatar.cpp
@@ -833,29 +833,21 @@ void Avatar::logic(std::vector<ActionData> &action_queue, bool restrict_power_us
 
 	// calc new cam position from player position
 	// cam is focused at player position
-	float cam_dx = (Utils::calcDist(FPoint(mapr->cam.x, stats.pos.y), stats.pos)) / eset->misc.camera_speed;
-	float cam_dy = (Utils::calcDist(FPoint(stats.pos.x, mapr->cam.y), stats.pos)) / eset->misc.camera_speed;
+	float cam_dx = (mapr->cam.x - stats.pos.x) / eset->misc.camera_speed;
+	float cam_dy = (mapr->cam.y - stats.pos.y) / eset->misc.camera_speed;
 
-	if (mapr->cam.x < stats.pos.x) {
-		mapr->cam.x += cam_dx;
-		if (mapr->cam.x > stats.pos.x)
-			mapr->cam.x = stats.pos.x;
+	if (stats.cur_state == StatBlock::AVATAR_STANCE) {
+		Point hero_scr = Utils::mapToScreen(stats.pos.x, stats.pos.y, mapr->cam.x, mapr->cam.y);
+		Point cam_scr = Utils::mapToScreen(mapr->cam.x, mapr->cam.y, mapr->cam.x, mapr->cam.y);
+		float scr_delta = Utils::calcDist(FPoint(hero_scr.x, hero_scr.y), FPoint(cam_scr.x, cam_scr.y));
+
+		if (scr_delta < eset->misc.camera_speed / 2) {
+			cam_dx = cam_dy = 0;
+		}
 	}
-	else if (mapr->cam.x > stats.pos.x) {
-		mapr->cam.x -= cam_dx;
-		if (mapr->cam.x < stats.pos.x)
-			mapr->cam.x = stats.pos.x;
-	}
-	if (mapr->cam.y < stats.pos.y) {
-		mapr->cam.y += cam_dy;
-		if (mapr->cam.y > stats.pos.y)
-			mapr->cam.y = stats.pos.y;
-	}
-	else if (mapr->cam.y > stats.pos.y) {
-		mapr->cam.y -= cam_dy;
-		if (mapr->cam.y < stats.pos.y)
-			mapr->cam.y = stats.pos.y;
-	}
+
+	mapr->cam.x -= cam_dx;
+	mapr->cam.y -= cam_dy;
 
 	// check for map events
 	mapr->checkEvents(stats.pos);


### PR DESCRIPTION
I have noticed that when the hero stops moving the camera tries to catchup with the hero position. When the camera gets closer to the hero position it start to wiggle, also the hero wiggles relative to the map and it's kind of annoying. I believe this happens because of the conversion of map coordinates and screen coordinate (same pixel can represent multiple map coordinates) using **Utils::mapToScreen()** and **Utils::screenToMap()**.

The only workaround that i have found so far is to stop updating the camera position when it is close enough to the hero position. Currently it will stop when the difference of the screen position of the camera and hero is less than **camera_speed/2**. I found this to be good enough for slow and fast cameras too.