### PR TITLE
Improve the Polish translation of the home screen

### DIFF
--- a/mods/default/languages/engine.pl.po
+++ b/mods/default/languages/engine.pl.po
@@ -6,6 +6,7 @@
 # Translators:
 # Justin Jacobs <jajdorkster@gmail.com>, 2019
 # Błażej Pęksyk <b.peksyk@gmail.com>, 2020
+# Grzegorz Szymaszek <gszymaszek@short.pl>, 2021
 # 
 #, fuzzy
 msgid ""
@@ -13,8 +14,8 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-05-23 20:34-0400\n"
-"PO-Revision-Date: 2018-03-28 19:16+0000\n"
-"Last-Translator: Błażej Pęksyk <b.peksyk@gmail.com>, 2020\n"
+"PO-Revision-Date: 2021-05-27 19:39+0200\n"
+"Last-Translator: Grzegorz Szymaszek <gszymaszek@short.pl>, 2021\n"
 "Language-Team: Polish (https://www.transifex.com/flareorg/teams/84925/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -240,11 +241,11 @@ msgstr "Konfiguracja"
 
 #: ../../../src/GameStateTitle.cpp:117
 msgid "Credits"
-msgstr "Lista płac"
+msgstr "Zasługi"
 
 #: ../../../src/GameStateTitle.cpp:120
 msgid "Exit Game"
-msgstr "Wyjdź z Gry"
+msgstr "Wyjdź z gry"
 
 #: ../../../src/InputState.cpp:417
 msgid "Accept"


### PR DESCRIPTION
Fix the translation of “Credits”. Do not capitalize the translation of “Game”.