### PR TITLE
Fix the manual chapter of flare(6)

### DIFF
--- a/distribution/flare.man
+++ b/distribution/flare.man
@@ -1,6 +1,6 @@
 .\" -*- nroff -*-
 
-.TH FLARE 1 "November 2014"
+.TH FLARE 6 "November 2014"
 
 .SH NAME
 flare \- action role-playing engine


### PR DESCRIPTION
Since it's a game, flare must be in the sixth chapter of the UNIX manual. It's a bit weird, but that's the way it is...