### PR TITLE
Equipment swap

### DIFF
--- a/src/InputState.cpp
+++ b/src/InputState.cpp
@@ -213,6 +213,7 @@ void InputState::loadKeyBindings() {
 		// @ATTR default.bar0|string, string, string : Keyboard/mouse 1, Keyboard/mouse 2, Joystick|Bindings for "Bar0".
 		// @ATTR default.main1|string, string, string : Keyboard/mouse 1, Keyboard/mouse 2, Joystick|Bindings for "Main1".
 		// @ATTR default.main2|string, string, string : Keyboard/mouse 1, Keyboard/mouse 2, Joystick|Bindings for "Main2".
+		// @ATTR default.swap|string, string, string : Keyboard/mouse 1, Keyboard/mouse 2, Joystick|Bindings for "Equipment swap".
 		// @ATTR default.character|string, string, string : Keyboard/mouse 1, Keyboard/mouse 2, Joystick|Bindings for "Character".
 		// @ATTR default.inventory|string, string, string : Keyboard/mouse 1, Keyboard/mouse 2, Joystick|Bindings for "Inventory".
 		// @ATTR default.powers|string, string, string : Keyboard/mouse 1, Keyboard/mouse 2, Joystick|Bindings for "Powers".
@@ -247,6 +248,7 @@ void InputState::loadKeyBindings() {
 		else if (infile.key == "bar0") cursor = Input::BAR_0;
 		else if (infile.key == "main1") cursor = Input::MAIN1;
 		else if (infile.key == "main2") cursor = Input::MAIN2;
+		else if (infile.key == "swap") cursor = Input::SWAP;
 		else if (infile.key == "character") cursor = Input::CHARACTER;
 		else if (infile.key == "inventory") cursor = Input::INVENTORY;
 		else if (infile.key == "powers") cursor = Input::POWERS;
@@ -318,6 +320,7 @@ void InputState::saveKeyBindings() {
 		outfile << "bar0=" << binding[Input::BAR_0] << "," << binding_alt[Input::BAR_0] << "," << binding_joy[Input::BAR_0] << "\n";
 		outfile << "main1=" << binding[Input::MAIN1] << "," << binding_alt[Input::MAIN1] << "," << binding_joy[Input::MAIN1] << "\n";
 		outfile << "main2=" << binding[Input::MAIN2] << "," << binding_alt[Input::MAIN2] << "," << binding_joy[Input::MAIN2] << "\n";
+		outfile << "swap=" << binding[Input::SWAP] << "," << binding_alt[Input::SWAP] << "," << binding_joy[Input::SWAP] << "\n";
 		outfile << "character=" << binding[Input::CHARACTER] << "," << binding_alt[Input::CHARACTER] << "," << binding_joy[Input::CHARACTER] << "\n";
 		outfile << "inventory=" << binding[Input::INVENTORY] << "," << binding_alt[Input::INVENTORY] << "," << binding_joy[Input::INVENTORY] << "\n";
 		outfile << "powers=" << binding[Input::POWERS] << "," << binding_alt[Input::POWERS] << "," << binding_joy[Input::POWERS] << "\n";
@@ -435,6 +438,7 @@ void InputState::setKeybindNames() {
 	binding_name[Input::LOG] = msg->get("Log");
 	binding_name[Input::MAIN1] = msg->get("Main1");
 	binding_name[Input::MAIN2] = msg->get("Main2");
+	binding_name[Input::SWAP] = msg->get("Equipment swap");
 	binding_name[Input::CTRL] = msg->get("Ctrl");
 	binding_name[Input::SHIFT] = msg->get("Shift");
 	binding_name[Input::ALT] = msg->get("Alt");

--- a/src/InputState.h
+++ b/src/InputState.h
@@ -49,15 +49,16 @@ namespace Input {
 		LOG = 19,
 		MAIN1 = 20,
 		MAIN2 = 21,
-		ACTIONBAR = 22,
-		ACTIONBAR_BACK = 23,
-		ACTIONBAR_FORWARD = 24,
-		ACTIONBAR_USE = 25,
-		DEVELOPER_MENU = 26,
-		CTRL = 27,
-		SHIFT = 28,
-		ALT = 29,
-		DEL = 30
+		SWAP = 22,
+		ACTIONBAR = 23,
+		ACTIONBAR_BACK = 24,
+		ACTIONBAR_FORWARD = 25,
+		ACTIONBAR_USE = 26,
+		DEVELOPER_MENU = 27,
+		CTRL = 28,
+		SHIFT = 29,
+		ALT = 30,
+		DEL = 31
 	};
 }
 
@@ -87,13 +88,13 @@ public:
 	};
 
 	static const bool GET_SHORT_STRING = true;
-	static const int KEY_COUNT = 31;
+	static const int KEY_COUNT = 32;
 	static const int KEY_COUNT_USER = KEY_COUNT - 4; // exclude CTRL, SHIFT, etc from keybinding menu
 	int binding[KEY_COUNT];
 	int binding_alt[KEY_COUNT];
 	int binding_joy[KEY_COUNT];
 
-	std::string binding_name[31];
+	std::string binding_name[KEY_COUNT];
 	std::string mouse_button[MOUSE_BUTTON_NAME_COUNT];
 
 	InputState(void);

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -360,6 +360,7 @@ void MenuInventory::logic() {
 			inpt->lock[Input::SWAP] = true;
 			applyNextEquipmentSet();
 			applyEquipment();
+			clearHighlight();
 		}
 	}
 
@@ -1303,6 +1304,15 @@ void MenuInventory::applyPreviousEquipmentSet() {
 }
 
 void MenuInventory::updateEquipmentSetWidgets() {
+	for (int i=0; i<MAX_EQUIPPED; i++) {
+		if (isActive(i)) {
+			inventory[EQUIPMENT].slots[i]->visible = true;
+		}
+		else {
+			inventory[EQUIPMENT].slots[i]->visible = false;
+		}
+	}
+
 	if (!equipmentSetButton.empty()) {
 		for (size_t i=0; i<equipmentSetButton.size(); i++) {
 			if (active_equipment_set > 0) {
@@ -1324,10 +1334,8 @@ void MenuInventory::updateEquipmentSetWidgets() {
 	}
 
 	if (active_equipment_set > 0) {
-		if (menu) {
-			std::stringstream ss;
-			ss << "Equipped set " << active_equipment_set << ".";
-			menu->hudlog->add(msg->get(ss.str()), MenuHUDLog::MSG_NORMAL);
+		if (!visible && menu && menu->hudlog) {
+			menu->hudlog->add(msg->get("Equipped set %d.", static_cast<int>(active_equipment_set)), MenuHUDLog::MSG_NORMAL);
 		}
 	}
 }

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -35,6 +35,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "ItemManager.h"
 #include "Menu.h"
 #include "MenuActionBar.h"
+#include "MenuHUDLog.h"
 #include "MenuInventory.h"
 #include "MenuManager.h"
 #include "MenuPowers.h"
@@ -184,13 +185,12 @@ MenuInventory::MenuInventory()
 	// create equipment swap buttons
 	std::map<unsigned, std::string>::iterator it;
 	for (it = raw_set_button.begin(); it != raw_set_button.end(); it++) {
-		std::cout << it->first << " " << it->second << std::endl;
-
 		int px = Parse::popFirstInt(it->second);
 		int py = Parse::popFirstInt(it->second);
 		std::string icon = Parse::popFirstString(it->second);
 		equipmentSetButton.push_back(new WidgetButton(icon));
 		equipmentSetButton.back()->setBasePos(px, py, Utils::ALIGN_TOPLEFT);
+		tablist.add(equipmentSetButton.back());
 	}
 	raw_set_button.clear();
 
@@ -200,6 +200,7 @@ MenuInventory::MenuInventory()
 		std::string icon = Parse::popFirstString(raw_previous);
 		equipmentSetPrevious = new WidgetButton(icon);
 		equipmentSetPrevious->setBasePos(px, py, Utils::ALIGN_TOPLEFT);
+		tablist.add(equipmentSetPrevious);
 	}
 
 	if (!raw_next.empty()) {
@@ -208,6 +209,7 @@ MenuInventory::MenuInventory()
 		std::string icon = Parse::popFirstString(raw_next);
 		equipmentSetNext = new WidgetButton(icon);
 		equipmentSetNext->setBasePos(px, py, Utils::ALIGN_TOPLEFT);
+		tablist.add(equipmentSetNext);
 	}
 
 	if (!raw_label.empty()) {
@@ -1319,6 +1321,14 @@ void MenuInventory::updateEquipmentSetWidgets() {
 		label << active_equipment_set << "/" << max_equipment_set;
 		equipmentSetLabel->setText(label.str());
 		equipmentSetLabel->setColor(font->getColor(FontEngine::COLOR_MENU_NORMAL));
+	}
+
+	if (active_equipment_set > 0) {
+		if (menu) {
+			std::stringstream ss;
+			ss << "Equipped set " << active_equipment_set << ".";
+			menu->hudlog->add(msg->get(ss.str()), MenuHUDLog::MSG_NORMAL);
+		}
 	}
 }
 

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -359,7 +359,7 @@ void MenuInventory::renderTooltips(const Point& position) {
 	tip_data.clear();
 
 	if (area == EQUIPMENT)
-		if (equipment_set[slot] != 0 && equipment_set[slot] != active_equipped_set)
+		if (!isActive(slot))
 			return;
 
 	if (inventory[area][slot].item > 0) {
@@ -952,7 +952,7 @@ void MenuInventory::applyEquipment() {
 		}
 
 		for (int i = 0; i < MAX_EQUIPPED; i++) {
-			if (equipment_set[i] == 0 || equipment_set[i] == active_equipped_set) {
+			if (isActive(i)) {
 				item_id = inventory[EQUIPMENT].storage[i].item;
 				const Item &item = items->items[item_id];
 				unsigned bonus_counter = 0;
@@ -973,7 +973,7 @@ void MenuInventory::applyEquipment() {
 		std::vector<int> quantity;
 
 		for (int i=0; i<MAX_EQUIPPED; i++) {
-			if (equipment_set[i] == 0 || equipment_set[i] == active_equipped_set) {
+			if (isActive(i)) {
 				item_id = inventory[EQUIPMENT].storage[i].item;
 				it = std::find(set.begin(), set.end(), items->items[item_id].set);
 				if (items->items[item_id].set > 0 && it != set.end()) {
@@ -1000,7 +1000,7 @@ void MenuInventory::applyEquipment() {
 		}
 		// check that each equipped item fit requirements
 		for (int i = 0; i < MAX_EQUIPPED; i++) {
-			if (equipment_set[i] == 0 || equipment_set[i] == active_equipped_set) {
+			if (isActive(i)) {
 				if (!items->requirementsMet(&pc->stats, inventory[EQUIPMENT].storage[i].item)) {
 					add(inventory[EQUIPMENT].storage[i], CARRIED, ItemStorage::NO_SLOT, ADD_PLAY_SOUND, !ADD_AUTO_EQUIP);
 					inventory[EQUIPMENT].storage[i].clear();
@@ -1080,7 +1080,7 @@ void MenuInventory::applyItemStats() {
 
 	// apply stats from all items
 	for (int i=0; i<MAX_EQUIPPED; i++) {
-		if (equipment_set[i] == 0 || equipment_set[i] == active_equipped_set) {
+		if (isActive(i)) {
 			ItemID item_id = inventory[EQUIPMENT].storage[i].item;
 			const Item &item = items->items[item_id];
 
@@ -1123,7 +1123,7 @@ void MenuInventory::applyItemSetBonuses() {
 	std::vector<int> quantity;
 
 	for (int i=0; i<MAX_EQUIPPED; i++) {
-		if (equipment_set[i] == 0 || equipment_set[i] == active_equipped_set) {
+		if (isActive(i)) {
 			ItemID item_id = inventory[EQUIPMENT].storage[i].item;
 			it = std::find(set.begin(), set.end(), items->items[item_id].set);
 			if (items->items[item_id].set > 0 && it != set.end()) {
@@ -1190,6 +1190,14 @@ void MenuInventory::applyEquipmentSet(unsigned set) {
 			active_equipped_set = static_cast<unsigned>(set);
 		}
 	}
+}
+
+bool MenuInventory::isActive(size_t equipped) {
+	if (equipment_set[equipped] == 0 || equipment_set[equipped]==active_equipped_set) {
+		return true;
+	}
+
+	return false;
 }
 
 int MenuInventory::getEquippedCount() {

--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -324,6 +324,14 @@ void MenuInventory::logic() {
 		}
 	}
 
+	if (max_equipment_set > 0) {
+		if (inpt->pressing[Input::SWAP] && !inpt->lock[Input::SWAP]) {
+			inpt->lock[Input::SWAP] = true;
+			applyNextEquipmentSet();
+			applyEquipment();
+		}
+	}
+
 	tap_to_activate_timer.tick();
 }
 

--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -48,6 +48,8 @@ private:
 	WidgetLabel label_inventory;
 	WidgetLabel label_currency;
 	WidgetButton *closeButton;
+
+	// equipment swap buttons
 	std::vector<WidgetButton*> equipmentSetButton;
 	WidgetButton* equipmentSetPrevious;
 	WidgetButton* equipmentSetNext;

--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -108,6 +108,7 @@ public:
 	void applyItemSetBonuses();
 	void applyBonus(const BonusData* bdata);
 	void applyEquipmentSet(unsigned set);
+	bool isActive(size_t equipped);
 
 	int getEquippedCount();
 	int getTotalSlotCount();

--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -47,6 +47,7 @@ private:
 	WidgetLabel label_inventory;
 	WidgetLabel label_currency;
 	WidgetButton *closeButton;
+	std::vector<WidgetButton*> equipmentSetButton;
 
 	int MAX_EQUIPPED;
 	int MAX_CARRIED;
@@ -106,6 +107,7 @@ public:
 	void applyItemStats();
 	void applyItemSetBonuses();
 	void applyBonus(const BonusData* bdata);
+	void applyEquipmentSet(unsigned set);
 
 	int getEquippedCount();
 	int getTotalSlotCount();
@@ -127,8 +129,10 @@ public:
 	Rect carried_area;
 	std::vector<Rect> equipped_area;
 	std::vector<std::string> slot_type;
+	std::vector<unsigned int> equipment_set;
 
 	MenuItemStorage inventory[2];
+	unsigned active_equipped_set;
 	int currency;
 	int drag_prev_src;
 

--- a/src/MenuInventory.h
+++ b/src/MenuInventory.h
@@ -42,12 +42,16 @@ private:
 
 	void loadGraphics();
 	void updateEquipment(int slot);
+	void updateEquipmentSetWidgets();
 	int getEquipSlotFromItem(ItemID item, bool only_empty_slots);
 
 	WidgetLabel label_inventory;
 	WidgetLabel label_currency;
 	WidgetButton *closeButton;
 	std::vector<WidgetButton*> equipmentSetButton;
+	WidgetButton* equipmentSetPrevious;
+	WidgetButton* equipmentSetNext;
+	WidgetLabel* equipmentSetLabel;
 
 	int MAX_EQUIPPED;
 	int MAX_CARRIED;
@@ -108,6 +112,8 @@ public:
 	void applyItemSetBonuses();
 	void applyBonus(const BonusData* bdata);
 	void applyEquipmentSet(unsigned set);
+	void applyNextEquipmentSet();
+	void applyPreviousEquipmentSet();
 	bool isActive(size_t equipped);
 
 	int getEquippedCount();
@@ -133,7 +139,8 @@ public:
 	std::vector<unsigned int> equipment_set;
 
 	MenuItemStorage inventory[2];
-	unsigned active_equipped_set;
+	unsigned active_equipment_set;
+	unsigned max_equipment_set;
 	int currency;
 	int drag_prev_src;
 

--- a/src/MenuItemStorage.cpp
+++ b/src/MenuItemStorage.cpp
@@ -161,7 +161,7 @@ int MenuItemStorage::slotOver(const Point& position) {
 	else if (nb_cols == 0) {
 		for (unsigned int i=0; i<slots.size(); i++) {
 			unsigned int eq_set = menu->inv->equipment_set[i];
-			if (eq_set == 0 || eq_set == menu->inv->active_equipped_set) {
+			if (eq_set == 0 || eq_set == menu->inv->active_equipment_set) {
 				if (Utils::isWithinRect(slots[i]->pos, position)) {
 					return i;
 				}

--- a/src/MenuItemStorage.cpp
+++ b/src/MenuItemStorage.cpp
@@ -25,9 +25,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 
 #include "EngineSettings.h"
 #include "ItemManager.h"
-#include "MenuInventory.h"
 #include "MenuItemStorage.h"
-#include "MenuManager.h"
 #include "Settings.h"
 #include "RenderDevice.h"
 #include "SharedResources.h"
@@ -115,40 +113,27 @@ void MenuItemStorage::render() {
 	Rect disabled_src;
 	disabled_src.x = disabled_src.y = 0;
 	disabled_src.w = disabled_src.h = eset->resolutions.icon_size;
-	bool render;
 
 	for (int i=0; i<slot_number; i++) {
-		render = false;
-
-		if (nb_cols > 0) {
-			render = true;
+		if (storage[i].item > 0) {
+			slots[i]->setIcon(items->items[storage[i].item].icon, items->getItemIconOverlay(storage[i].item));
+			slots[i]->setAmount(storage[i].quantity, items->items[storage[i].item].max_quantity);
 		}
-		else if (nb_cols == 0) {
-			if (menu->inv->isActive(i)) {
-				render = true;
+		else {
+			slots[i]->setIcon(WidgetSlot::NO_ICON, WidgetSlot::NO_OVERLAY);
+		}
+		slots[i]->render();
+		if (!slots[i]->enabled) {
+			if (overlay_disabled) {
+				overlay_disabled->setClipFromRect(disabled_src);
+				overlay_disabled->setDestFromRect(slots[i]->pos);
+				render_device->render(overlay_disabled);
 			}
 		}
-		if (render) {
-			if (storage[i].item > 0) {
-				slots[i]->setIcon(items->items[storage[i].item].icon, items->getItemIconOverlay(storage[i].item));
-				slots[i]->setAmount(storage[i].quantity, items->items[storage[i].item].max_quantity);
-			}
-			else {
-				slots[i]->setIcon(WidgetSlot::NO_ICON, WidgetSlot::NO_OVERLAY);
-			}
-			slots[i]->render();
-			if (!slots[i]->enabled) {
-				if (overlay_disabled) {
-					overlay_disabled->setClipFromRect(disabled_src);
-					overlay_disabled->setDestFromRect(slots[i]->pos);
-					render_device->render(overlay_disabled);
-				}
-			}
-			if (highlight[i] && !slots[i]->in_focus) {
-				if (highlight_image) {
-					highlight_image->setDestFromRect(slots[i]->pos);
-					render_device->render(highlight_image);
-				}
+		if (highlight[i] && !slots[i]->in_focus) {
+			if (highlight_image) {
+				highlight_image->setDestFromRect(slots[i]->pos);
+				render_device->render(highlight_image);
 			}
 		}
 	}
@@ -160,12 +145,8 @@ int MenuItemStorage::slotOver(const Point& position) {
 	}
 	else if (nb_cols == 0) {
 		for (unsigned int i=0; i<slots.size(); i++) {
-			unsigned int eq_set = menu->inv->equipment_set[i];
-			if (eq_set == 0 || eq_set == menu->inv->active_equipment_set) {
-				if (Utils::isWithinRect(slots[i]->pos, position)) {
-					return i;
-				}
-			}
+			if (slots[i]->visible)
+				if (Utils::isWithinRect(slots[i]->pos, position)) return i;
 		}
 	}
 	return -1;
@@ -242,7 +223,8 @@ void MenuItemStorage::itemReturn(ItemStack stack) {
 
 void MenuItemStorage::highlightMatching(const std::string& type) {
 	for (int i=0; i<slot_number; i++) {
-		if (slot_type[i] == type) highlight[i] = true;
+		if (slots[i]->visible)
+			if (slot_type[i] == type) highlight[i] = true;
 	}
 }
 

--- a/src/MenuItemStorage.cpp
+++ b/src/MenuItemStorage.cpp
@@ -124,8 +124,7 @@ void MenuItemStorage::render() {
 			render = true;
 		}
 		else if (nb_cols == 0) {
-			unsigned int eq_set = menu->inv->equipment_set[i];
-			if (eq_set == 0 || eq_set == menu->inv->active_equipped_set) {
+			if (menu->inv->isActive(i)) {
 				render = true;
 			}
 		}

--- a/src/MenuManager.cpp
+++ b/src/MenuManager.cpp
@@ -1493,15 +1493,17 @@ void MenuManager::pushMatchingItemsOf(const Point& hov_pos) {
 			if (tip_index >= TooltipManager::TOOLTIP_COUNT)
 				break; // can't show any more tooltips
 
-			if (inv->slot_type[i] == items->items[hov_stack.item].type) {
-				if (!inv->inventory[MenuInventory::EQUIPMENT].storage[i].empty()) {
-					Point match_pos(inv->equipped_area[i].x, inv->equipped_area[i].y);
+			if (inv->isActive(i)){
+				if (inv->slot_type[i] == items->items[hov_stack.item].type) {
+					if (!inv->inventory[MenuInventory::EQUIPMENT].storage[i].empty()) {
+						Point match_pos(inv->equipped_area[i].x, inv->equipped_area[i].y);
 
-					TooltipData match = inv->inventory[MenuInventory::EQUIPMENT].checkTooltip(match_pos, &pc->stats, ItemManager::PLAYER_INV);
-					match.addColoredText(msg->get("Equipped"), font->getColor(FontEngine::COLOR_ITEM_FLAVOR));
+						TooltipData match = inv->inventory[MenuInventory::EQUIPMENT].checkTooltip(match_pos, &pc->stats, ItemManager::PLAYER_INV);
+						match.addColoredText(msg->get("Equipped"), font->getColor(FontEngine::COLOR_ITEM_FLAVOR));
 
-					tooltipm->push(match, hov_pos, TooltipData::STYLE_FLOAT, tip_index);
-					tip_index++;
+						tooltipm->push(match, hov_pos, TooltipData::STYLE_FLOAT, tip_index);
+						tip_index++;
+					}
 				}
 			}
 		}

--- a/src/SDLInputState.cpp
+++ b/src/SDLInputState.cpp
@@ -146,6 +146,8 @@ void SDLInputState::defaultQwertyKeyBindings () {
 	binding[Input::MAIN1] = binding_alt[Input::MAIN1] = (SDL_BUTTON_LEFT+MOUSE_BIND_OFFSET) * (-1);
 	binding[Input::MAIN2] = binding_alt[Input::MAIN2] = (SDL_BUTTON_RIGHT+MOUSE_BIND_OFFSET) * (-1);
 
+	binding[Input::SWAP] = binding_alt[Input::SWAP] = SDLK_TAB;
+
 	binding[Input::CTRL] = SDLK_LCTRL;
 	binding_alt[Input::CTRL] = SDLK_RCTRL;
 	binding[Input::SHIFT] = SDLK_LSHIFT;

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -126,7 +126,7 @@ void SaveLoad::saveGame() {
 		outfile << "equipped=" << menu->inv->inventory[MenuInventory::EQUIPMENT].getItems() << "\n";
 
 		// active equipped set
-		outfile << "active_equipped_set=" << menu->inv->active_equipped_set << "\n";
+		outfile << "active_equipment_set=" << menu->inv->active_equipment_set << "\n";
 
 		// carried items
 		outfile << "carried_quantity=" << menu->inv->inventory[MenuInventory::CARRIED].getQuantities() << "\n";
@@ -348,7 +348,7 @@ void SaveLoad::loadGame() {
 			else if (infile.key == "equipped_quantity") {
 				menu->inv->inventory[MenuInventory::EQUIPMENT].setQuantities(infile.val);
 			}
-			else if (infile.key == "active_equipped_set") {
+			else if (infile.key == "active_equipment_set") {
 				menu->inv->applyEquipmentSet(Parse::toInt(infile.val));
 			}
 			else if (infile.key == "carried") {

--- a/src/SaveLoad.cpp
+++ b/src/SaveLoad.cpp
@@ -125,6 +125,9 @@ void SaveLoad::saveGame() {
 		outfile << "equipped_quantity=" << menu->inv->inventory[MenuInventory::EQUIPMENT].getQuantities() << "\n";
 		outfile << "equipped=" << menu->inv->inventory[MenuInventory::EQUIPMENT].getItems() << "\n";
 
+		// active equipped set
+		outfile << "active_equipped_set=" << menu->inv->active_equipped_set << "\n";
+
 		// carried items
 		outfile << "carried_quantity=" << menu->inv->inventory[MenuInventory::CARRIED].getQuantities() << "\n";
 		outfile << "carried=" << menu->inv->inventory[MenuInventory::CARRIED].getItems() << "\n";
@@ -344,6 +347,9 @@ void SaveLoad::loadGame() {
 			}
 			else if (infile.key == "equipped_quantity") {
 				menu->inv->inventory[MenuInventory::EQUIPMENT].setQuantities(infile.val);
+			}
+			else if (infile.key == "active_equipped_set") {
+				menu->inv->applyEquipmentSet(Parse::toInt(infile.val));
 			}
 			else if (infile.key == "carried") {
 				menu->inv->inventory[MenuInventory::CARRIED].setItems(infile.val);

--- a/src/WidgetSlot.cpp
+++ b/src/WidgetSlot.cpp
@@ -48,6 +48,7 @@ WidgetSlot::WidgetSlot(int _icon_id, int _ACTIVATE)
 	, checked(false)
 	, pressed(false)
 	, continuous(false)
+	, visible(true)
 {
 	focusable = true;
 	label_amount.setFromLabelInfo(eset->widgets.slot_quantity_label);
@@ -274,6 +275,8 @@ void WidgetSlot::setHotkey(int key) {
 }
 
 void WidgetSlot::render() {
+	if (!visible) return;
+
 	Rect src;
 
 	if (icon_id != -1 && icons) {
@@ -307,6 +310,8 @@ void WidgetSlot::render() {
  * We can use this function if slot is grayed out to refresh selection frame
  */
 void WidgetSlot::renderSelection() {
+	if (!visible) return;
+
 	if (in_focus) {
 		if (slot_checked && checked) {
 			slot_checked->local_frame = local_frame;

--- a/src/WidgetSlot.h
+++ b/src/WidgetSlot.h
@@ -81,6 +81,8 @@ public:
 	bool checked;
 	bool pressed;
 	bool continuous;	// allow holding key to keep slot activated
+
+	bool visible;
 };
 
 #endif


### PR DESCRIPTION
Hi @dorkster!

This is my attempt at completing this feature request: https://github.com/flareteam/flare-engine/issues/1499

Any number of equipment sets can be added by adding a `set_button` definition in `menus/inventory.txt`.
Each equipment set can have a different number of items. It is a normal `equipment_slot` definition plus the number of the equipment set at the end. For shared items the equipment set number is "0". Also defined in `menus/inventory.txt`.

A sample mod can be found here: https://github.com/r-a-cristian-93/flare-mod-equipmentsets


Obs: 
`TooltipManager` class has this member `static const size_t TOOLTIP_COUNT = 3;` that limits the number of tooltips displayed. If a modder wants to have 5 rings equipped at a time, when comparing items, not all the tooltips will be displayed.

Currently i am checking if this feature is used or not by evaluating `equipmentSetButton.empty()`. Would it be better to create a new engine setting (like equipment_sets=3) to indicate if this feature is used or not?

![Screenshot at 2021-11-10 22-24-06](https://user-images.githubusercontent.com/69315110/141188160-f229b1b9-f38b-4d2f-9261-90d9cd413b30.png)



