### PR TITLE
Fix equipment swap message displayed when feature is not used.

### DIFF
--- a/src/MenuInventory.cpp
+++ b/src/MenuInventory.cpp
@@ -64,7 +64,7 @@ MenuInventory::MenuInventory()
 	, activated_slot(-1)
 	, activated_item(0)
 	, active_equipment_set(0)
-	, max_equipment_set(1)
+	, max_equipment_set(0)
 	, currency(0)
 	, drag_prev_src(-1)
 	, changed_equipment(true)
@@ -224,7 +224,9 @@ MenuInventory::MenuInventory()
 		equipmentSetLabel->setColor(font->getColor(FontEngine::COLOR_MENU_NORMAL));
 	}
 
-	applyEquipmentSet(1);
+	if (max_equipment_set > 0) {
+		applyEquipmentSet(1);
+	}
 
 	align();
 }


### PR DESCRIPTION
The equipment swap message was displayed even if the feature was not used.

Equipment set 1 was applied even if the feature was not used. Even though it did not cause any issue it was misleading. https://github.com/flareteam/flare-engine/blob/ebf1fd75737b55926eb195d4add778f510472dc5/src/MenuInventory.cpp#L227

max_equipment_set was 1 by default and the Input::SWAP key was evaluated even if the feature was not used.
https://github.com/flareteam/flare-engine/blob/ebf1fd75737b55926eb195d4add778f510472dc5/src/MenuInventory.cpp#L360-L363

