### PR TITLE
Improve minimap performance.

### DIFF
--- a/src/MenuMiniMap.h
+++ b/src/MenuMiniMap.h
@@ -32,6 +32,14 @@ class Sprite;
 class WidgetButton;
 class WidgetLabel;
 
+class PixelEntity {
+public:
+	int x;
+	int y;
+	Color* color;
+	PixelEntity(int _x, int _y, Color* _color);
+};
+
 class MenuMiniMap : public Menu {
 private:
 	enum {
@@ -62,10 +70,11 @@ private:
 	Rect map_area;
 	WidgetButton* button_config;
 
+	float visible_radius;
 	int current_zoom;
 	bool lock_zoom_change;
 
-	std::vector< std::vector<unsigned short> > entities;
+	std::vector<PixelEntity*> entities;
 
 	void createMapSurface(Sprite** target_surface, int w, int h);
 	void renderMapSurface(const FPoint& hero_pos);
@@ -73,8 +82,8 @@ private:
 	void prerenderIso(MapCollision *collider, Sprite** tile_surface, Sprite** entity_surface, int zoom);
 	void updateIso(MapCollision *collider, Sprite** tile_surface, int zoom, Rect *bounds);
 	void updateOrtho(MapCollision *collider, Sprite** tile_surface, int zoom, Rect *bounds);
-	void renderEntitiesOrtho(Sprite* entity_surface, int zoom);
-	void renderEntitiesIso(Sprite* entity_surface, int zoom);
+	void renderEntitiesOrtho(Sprite* entity_surface, int zoom, const Point& entity_offset);
+	void renderEntitiesIso(Sprite* entity_surface, int zoom, const Point& entity_offset);
 	void clearEntities();
 	void fillEntities();
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -82,6 +82,11 @@ FPoint::FPoint(Point _p)
 	, y(static_cast<float>(_p.y))
 {}
 
+FPoint::FPoint(int _x, int _y)
+	: x(static_cast<float>(_x))
+	, y(static_cast<float>(_y))
+{}
+
 void FPoint::align() {
 	// this rounds the float values to the nearest multiple of 1/(2^4)
 	// 1/(2^4) was chosen because it's a "nice" floating point number, removing 99% of rounding errors

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -57,6 +57,7 @@ public:
 	FPoint();
 	FPoint(float _x, float _y);
 	explicit FPoint(Point _p);
+	FPoint(int _x, int _y);
 	void align();
 };
 


### PR DESCRIPTION
Now the `map_surface_entities` texture is of fixed size to reduce drawing time and improve performance on big maps.
Only entities that are within minimap widget visible area will be added to the `entities` vector which will be drawn.
The color of entity tile is set from inside the `fillEntities()` function.
Functions `renderEntitiesOrtho()` and `renderEntitiesIso()` have been simplified.

OBS: this does not improve performance when using fog of war on big maps. I will try to fix it if possible.