### PR TITLE
Improved minimap performance when using fow on big maps

### DIFF
--- a/src/RenderDevice.cpp
+++ b/src/RenderDevice.cpp
@@ -70,8 +70,12 @@ Sprite *Image::createSprite() {
 void Image::beginPixelBatch() {
 }
 
+void Image::beginPixelBatch(Rect& bounds) {
+}
+
 void Image::endPixelBatch() {
 }
+
 
 /*
  * Sprite

--- a/src/RenderDevice.h
+++ b/src/RenderDevice.h
@@ -115,6 +115,7 @@ public:
 	virtual void drawPixel(int x, int y, const Color& color) = 0;
 	virtual void drawLine(int x0, int y0, int x1, int y1, const Color& color) = 0;
 	virtual void beginPixelBatch();
+	virtual void beginPixelBatch(Rect& bounds);
 	virtual void endPixelBatch();
 	virtual Image* resize(int width, int height) = 0;
 

--- a/src/SDLHardwareRenderDevice.h
+++ b/src/SDLHardwareRenderDevice.h
@@ -48,6 +48,7 @@ public:
 	void drawPixel(int x, int y, const Color& color);
 	void drawLine(int x0, int y0, int x1, int y1, const Color& color);
 	void beginPixelBatch();
+	void beginPixelBatch(Rect& bounds);
 	void endPixelBatch();
 	Image* resize(int width, int height);
 
@@ -55,6 +56,18 @@ public:
 	SDL_Texture *surface;
 
 	SDL_Surface *pixel_batch_surface;
+	int pixel_batch_type;
+	Rect pixel_batch_area;
+
+private:
+	 enum {
+		 PIXEL_BATCH_NONE = 0,
+		 PIXEL_BATCH_ALL = 1,
+		 PIXEL_BATCH_AREA = 2,
+	};
+
+	void drawPixelSingle(int x, int y, const Color& color);
+	void drawPixelBatch(int x, int y, const Color& color);
 };
 
 class SDLHardwareRenderDevice : public RenderDevice {

--- a/src/SDLSoftwareRenderDevice.cpp
+++ b/src/SDLSoftwareRenderDevice.cpp
@@ -569,7 +569,7 @@ Image *SDLSoftwareRenderDevice::createImage(int width, int height) {
 		return NULL;
 
 	Uint32 rmask, gmask, bmask, amask;
-	setSDL_RGBA(&rmask, &gmask, &bmask, &amask);
+	Utils::setSDL_RGBA(&rmask, &gmask, &bmask, &amask);
 
 	image->surface = SDL_CreateRGBSurface(0, width, height, BITS_PER_PIXEL, rmask, gmask, bmask, amask);
 
@@ -641,20 +641,6 @@ Image *SDLSoftwareRenderDevice::loadImage(const std::string& filename, int error
 	// store image to cache
 	cacheStore(filename, image);
 	return image;
-}
-
-void SDLSoftwareRenderDevice::setSDL_RGBA(Uint32 *rmask, Uint32 *gmask, Uint32 *bmask, Uint32 *amask) {
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-	*rmask = 0xff000000;
-	*gmask = 0x00ff0000;
-	*bmask = 0x0000ff00;
-	*amask = 0x000000ff;
-#else
-	*rmask = 0x000000ff;
-	*gmask = 0x0000ff00;
-	*bmask = 0x00ff0000;
-	*amask = 0xff000000;
-#endif
 }
 
 void SDLSoftwareRenderDevice::getWindowSize(short unsigned *screen_w, short unsigned *screen_h) {

--- a/src/SDLSoftwareRenderDevice.h
+++ b/src/SDLSoftwareRenderDevice.h
@@ -91,7 +91,6 @@ protected:
 private:
 	Uint32 MapRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 	void getWindowSize(short unsigned *screen_w, short unsigned *screen_h);
-	void setSDL_RGBA(Uint32 *rmask, Uint32 *gmask, Uint32 *bmask, Uint32 *amask);
 
 	SDL_Surface* screen;
 	SDL_Window* window;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -863,3 +863,17 @@ void Utils::lockFileCheck() {
 	lockFileWrite(1);
 }
 
+void Utils::setSDL_RGBA(Uint32 *rmask, Uint32 *gmask, Uint32 *bmask, Uint32 *amask) {
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+	*rmask = 0xff000000;
+	*gmask = 0x00ff0000;
+	*bmask = 0x0000ff00;
+	*amask = 0x000000ff;
+#else
+	*rmask = 0x000000ff;
+	*gmask = 0x0000ff00;
+	*bmask = 0x00ff0000;
+	*amask = 0xff000000;
+#endif
+}
+

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -178,6 +178,8 @@ namespace Utils {
 	void lockFileRead();
 	void lockFileWrite(int increment);
 	void lockFileCheck();
+
+	void setSDL_RGBA(Uint32 *rmask, Uint32 *gmask, Uint32 *bmask, Uint32 *amask);
 }
 
 #endif


### PR DESCRIPTION
The `updateIso` and `updateOrtho` functions of the minimap are called every time the player uncovers tile. These two functions were calling `beginPixelBatch()` and `endPixelBatch()` which are recreating the entire texture from scratch. Now only parts of the texture are updated without recreating it from scratch.

I don't know a lot of SDL and i can't tell if the batch rendering method should be faster. If it is faster them a similar method could be implemented here too, something like `beginPixelBatch(Rect area)`. But i have a feeling that creating a smaller texture and then rendering it on the big texture won't be faster.