### PR TITLE
Fixed minimap update when using fog of war  #1798

### DIFF
--- a/src/FogOfWar.cpp
+++ b/src/FogOfWar.cpp
@@ -230,20 +230,26 @@ void FogOfWar::updateTiles() {
 
 	calcBoundaries();
 	const unsigned short * mask = &def_mask[0];
+	unsigned short tile_old;
+	unsigned short tile_new;
+	Rect tile_sprite_old;
+	Rect tile_sprite_new;
+	Rect tile_sprite_zero = tset_dark.tiles[0].tile->getClip();
 
 	for (int x = bounds.x; x <= bounds.w; x++) {
 		for (int y = bounds.y; y <= bounds.h; y++) {
 			if (x>=0 && y>=0 && x < mapr->w && y < mapr->h) {
-				unsigned short prev_dark_tile = mapr->layers[dark_layer_id][x][y];
-				unsigned short prev_fog_tile = mapr->layers[fog_layer_id][x][y];
+				tile_old = mapr->layers[dark_layer_id][x][y];
+				tile_sprite_old = tset_dark.tiles[tile_old].tile->getClip();
+
 				mapr->layers[dark_layer_id][x][y] &= *mask;
 				mapr->layers[fog_layer_id][x][y] = *mask;
 
-				// TODO we check for a change in the fog layer here, which means we update the minimap every time the player moves
-				// It should be that the minimap only updates when the dark layer changes, but this results in the minimap failing to update sometimes when near the map edges
-				if (prev_dark_tile != mapr->layers[dark_layer_id][x][y] || prev_fog_tile != mapr->layers[fog_layer_id][x][y]) {
+				tile_new = mapr->layers[dark_layer_id][x][y];
+				tile_sprite_new = tset_dark.tiles[tile_new].tile->getClip();
+
+				if (tile_sprite_old != tile_sprite_zero && tile_sprite_new == tile_sprite_zero)
 					update_minimap = true;
-				}
 			}
 			mask++;
 		}

--- a/src/MenuMiniMap.cpp
+++ b/src/MenuMiniMap.cpp
@@ -420,8 +420,15 @@ void MenuMiniMap::updateOrtho(MapCollision *collider, Sprite** tile_surface, int
 			else if (tile_type == 2 || tile_type == 6) draw_color = color_obst;
 			else draw_tile = false;
 
+			// fog of war
 			tile_type = mapr->layers[fow->dark_layer_id][i][j];
-			if (tile_type != 0) draw_tile = false;
+
+			Rect tile_sprite_zero = fow->tset_dark.tiles[0].tile->getClip();
+			Rect tile_sprite_current = fow->tset_dark.tiles[tile_type].tile->getClip();
+
+			// if tile sprite is non "zero like"
+			if (tile_sprite_current != tile_sprite_zero)
+				draw_tile = false;
 
 			if (draw_tile && draw_color.a != 0) {
 				for (int l = 0; l < zoom; l++) {
@@ -532,16 +539,16 @@ void MenuMiniMap::updateIso(MapCollision *collider, Sprite** tile_surface, int z
 	Point ent_pos;
 	Image* target_img = (*tile_surface)->getGraphics();
 
-	Point hero(pc->stats.pos);
-	Point clipcenter;
+	FPoint hero(pc->stats.pos);
+	FPoint clipcenter;
 	Rect clip;
 
-	clipcenter.x = zoom*(hero.x - hero.y + std::max(map_size.x, map_size.y));
-	clipcenter.y = zoom*(hero.x + hero.y);
-	clip.x = static_cast<int>(std::floor(clipcenter.x)) - (fow->mask_radius)*zoom;
-	clip.y = static_cast<int>(std::floor(clipcenter.y)) - (fow->mask_radius)*zoom;
-	clip.w = static_cast<int>(std::ceil(clipcenter.x)) + (fow->mask_radius)*zoom - clip.x + 1;
-	clip.h = static_cast<int>(std::ceil(clipcenter.y)) + (fow->mask_radius)*zoom - clip.y + 1;
+	clipcenter.x = static_cast<float>(zoom)*(hero.x - hero.y + static_cast<float>(std::max(map_size.x, map_size.y)));
+	clipcenter.y = static_cast<float>(zoom)*(hero.x + hero.y);
+	clip.x = static_cast<int>(std::floor(clipcenter.x)) - fow->mask_radius*2*zoom;
+	clip.y = static_cast<int>(std::floor(clipcenter.y)) - fow->mask_radius*2*zoom;
+	clip.w = static_cast<int>(std::ceil(clipcenter.x)) + fow->mask_radius*2*zoom - clip.x;
+	clip.h = static_cast<int>(std::ceil(clipcenter.y)) + fow->mask_radius*2*zoom - clip.y;
 
 	if (clip.x<0) clip.x=0;
 	if (clip.y<0) clip.y=0;
@@ -561,7 +568,13 @@ void MenuMiniMap::updateIso(MapCollision *collider, Sprite** tile_surface, int z
 
 			// fog of war
 			tile_type = mapr->layers[fow->dark_layer_id][i][j];
-			if (tile_type != 0) draw_tile = false;
+
+			Rect tile_sprite_zero = fow->tset_dark.tiles[0].tile->getClip();
+			Rect tile_sprite_current = fow->tset_dark.tiles[tile_type].tile->getClip();
+
+			// if tile sprite is non "zero like"
+			if (tile_sprite_current != tile_sprite_zero)
+				draw_tile = false;
 
 			if (draw_tile) {
 				ent_pos.x = zoom*(i - j + std::max(map_size.x, map_size.y));

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -127,6 +127,18 @@ Rect::operator SDL_Rect() const {
 	return r;
 }
 
+bool Rect::operator == (const Rect& other) const {
+	if (x == other.x && y == other.y && w == other.w && h == other.h)
+		return true;
+	else
+		return false;
+}
+
+bool Rect::operator != (const Rect& other) const {
+	return !(*this == other);
+}
+
+
 /**
  * Color: RGBA color; defaults to 100% opaque black
  */

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -68,6 +68,8 @@ public:
 	Rect(int _x, int _y, int _w, int _h);
 	explicit Rect(const SDL_Rect& _r);
 	operator SDL_Rect() const;
+	bool operator == (const Rect& other) const;
+	bool operator != (const Rect& other) const;
 };
 
 class Color {


### PR DESCRIPTION
I have found that[ the "zero like" tiles problem ](https://github.com/flareteam/flare-engine/issues/1798#issuecomment-984065719)was also present in `FogOfWar::updateTiles()` function and was not setting `update_minimap = true` when 'zero like' tiles were updated.
Sometimes only 'zero like' tiles are update when the player moves and this change was not detected with the old `FogOfWar::updateTiles()` function. 

Now  `FogOfWar::updateTiles()` function checks if a non 'zero like' tile was changed to a 'zero like tile' in order to cover all scenarios.
The 'MenuMiniMap::update' functions checks it the tile is non 'zero like'  and set `draw_tile = false` accordingly.
Also multiplying `fow->mask_radius` by 2 helped include some missing pixels in the `Image::drawPixel()` function.

Please let me know if this works for you too and if the bug was fixed.