### PR TITLE
Make controller aiming analog

### DIFF
--- a/src/MenuActionBar.cpp
+++ b/src/MenuActionBar.cpp
@@ -563,6 +563,7 @@ void MenuActionBar::checkAction(std::vector<ActionData> &action_queue) {
 	for (unsigned i = 0; i < slots_count; i++) {
 		ActionData action;
 		action.hotkey = i;
+		bool have_analog_aim = inpt->mode == InputState::MODE_JOYSTICK || inpt->usingMouse();
 		bool have_aim = false;
 		slot_activated[i] = false;
 
@@ -605,7 +606,7 @@ void MenuActionBar::checkAction(std::vector<ActionData> &action_queue) {
 		}
 
 		// joystick/keyboard action button
-		else if (!inpt->usingMouse() && slots[i]->checkClick() == WidgetSlot::ACTIVATE) {
+		else if (!have_analog_aim && slots[i]->checkClick() == WidgetSlot::ACTIVATE) {
 			have_aim = false;
 			slot_activated[i] = true;
 			action.power = hotkeys_mod[i];
@@ -614,17 +615,17 @@ void MenuActionBar::checkAction(std::vector<ActionData> &action_queue) {
 
 		// pressing hotkey
 		else if (i<10 && inpt->pressing[i + Input::BAR_1]) {
-			have_aim = inpt->usingMouse();
+			have_aim = have_analog_aim;
 			action.power = hotkeys_mod[i];
 			twostep_slot = -1;
 		}
 		else if (i==10 && inpt->pressing[Input::MAIN1] && !inpt->lock[Input::MAIN1] && !Utils::isWithinRect(window_area, inpt->mouse) && enable_main1) {
-			have_aim = inpt->usingMouse();
+			have_aim = have_analog_aim;
 			action.power = hotkeys_mod[10];
 			twostep_slot = -1;
 		}
 		else if (i==11 && inpt->pressing[Input::MAIN2] && !inpt->lock[Input::MAIN2] && !Utils::isWithinRect(window_area, inpt->mouse) && enable_main2) {
-			have_aim = inpt->usingMouse();
+			have_aim = have_analog_aim;
 			action.power = hotkeys_mod[11];
 			twostep_slot = -1;
 		}

--- a/src/SDLInputState.cpp
+++ b/src/SDLInputState.cpp
@@ -276,11 +276,6 @@ void SDLInputState::initBindings() {
 
 	setBind(Input::PAUSE, InputBind::GAMEPAD, SDL_CONTROLLER_BUTTON_START, NULL);
 
-	setBind(Input::AIM_RIGHT, InputBind::GAMEPAD_AXIS, (SDL_CONTROLLER_AXIS_RIGHTX*2), NULL);
-	setBind(Input::AIM_DOWN, InputBind::GAMEPAD_AXIS, (SDL_CONTROLLER_AXIS_RIGHTY*2), NULL);
-	setBind(Input::AIM_LEFT, InputBind::GAMEPAD_AXIS, (SDL_CONTROLLER_AXIS_RIGHTX*2) + 1, NULL);
-	setBind(Input::AIM_UP, InputBind::GAMEPAD_AXIS, (SDL_CONTROLLER_AXIS_RIGHTY*2) + 1, NULL);
-
 	// Not user-modifiable
 	setBind(Input::CTRL, InputBind::KEY, SDL_SCANCODE_LCTRL, NULL);
 	setBind(Input::CTRL, InputBind::KEY, SDL_SCANCODE_RCTRL, NULL);
@@ -511,6 +506,9 @@ void SDLInputState::handle() {
 
 					SDL_JoystickID joy_id = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(gamepad));
 					if (joy_id == event.jbutton.which) {
+						mouse.x = SDL_GameControllerGetAxis(gamepad, SDL_CONTROLLER_AXIS_RIGHTX) + settings->view_w_half;
+						mouse.y = SDL_GameControllerGetAxis(gamepad, SDL_CONTROLLER_AXIS_RIGHTY) + settings->view_h_half;
+
 						for (int key=0; key<KEY_COUNT; key++) {
 							for (size_t i = 0; i < binding[key].size(); ++i) {
 								int bind_axis = binding[key][i].bind / 2;


### PR DESCRIPTION
A few problems with this patch:

* UX for aiming stick customization must be changed entirely (to left/right options only)
* Aiming usually gets reset after the stick is released

The direction is also over-polling (updated on all controller analog events) but if restricted to just RIGHT{X,Y} it might not get updated at all.  Perhaps it could be reduced to just attacks inputs :thinking: