### PR TITLE
Mod selection dialogue when no core mod set

### DIFF
--- a/src/GameStateConfig.cpp
+++ b/src/GameStateConfig.cpp
@@ -160,3 +160,6 @@ void GameStateConfig::refreshFont() {
 	comb = new CombatText();
 }
 
+void GameStateConfig::setActiveTab(unsigned tab) {
+	menu_config->setActiveTab(tab);
+}

--- a/src/GameStateConfig.h
+++ b/src/GameStateConfig.h
@@ -45,6 +45,7 @@ public:
 	void logicAccept();
 	void logicCancel();
 	void refreshFont();
+	void setActiveTab(unsigned tab);
 
 	void render();
 };

--- a/src/GameStateTitle.cpp
+++ b/src/GameStateTitle.cpp
@@ -131,7 +131,8 @@ GameStateTitle::GameStateTitle()
 	// Core mod not selected dialogue
 	prompt_select_mods = new MenuConfirm();
 	prompt_select_mods->setTitle(msg->get("Enable a core mod to continue"));
-	prompt_select_mods->action_list->append(msg->get("Mods"), msg->get("You will be taken to the mod configuration"));
+	prompt_select_mods->action_list->append(msg->get("Edit Mods"), "");
+	prompt_select_mods->action_list->append(msg->get("Cancel"), "");
 
 	refreshWidgets();
 	force_refresh_background = true;
@@ -169,11 +170,16 @@ void GameStateTitle::logic() {
 	else if (prompt_select_mods && prompt_select_mods->visible) {
 		prompt_select_mods->logic();
 		if (prompt_select_mods->clicked_confirm) {
-			showLoading();
-			setRequestedGameState(new GameStateConfig());
+			if (prompt_select_mods->action_list->getSelected() == PROMPT_SELECT_MODS_OK) {
+				showLoading();
+				setRequestedGameState(new GameStateConfig());
 
-			prompt_select_mods->visible = false;
-			prompt_select_mods->clicked_confirm = false;
+				prompt_select_mods->visible = false;
+				prompt_select_mods->clicked_confirm = false;
+			} else if (prompt_select_mods->action_list->getSelected() == PROMPT_SELECT_MODS_CANCEL) {
+				prompt_select_mods->visible = false;
+			}
+
 		}
 	}
 	else {

--- a/src/GameStateTitle.cpp
+++ b/src/GameStateTitle.cpp
@@ -27,6 +27,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "GameStateTitle.h"
 #include "InputState.h"
 #include "MenuMovementType.h"
+#include "MenuConfig.h"
 #include "MenuConfirm.h"
 #include "MessageEngine.h"
 #include "Platform.h"
@@ -172,7 +173,9 @@ void GameStateTitle::logic() {
 		if (prompt_select_mods->clicked_confirm) {
 			if (prompt_select_mods->action_list->getSelected() == PROMPT_SELECT_MODS_OK) {
 				showLoading();
-				setRequestedGameState(new GameStateConfig());
+				GameStateConfig* config = new GameStateConfig();
+				config->setActiveTab(MenuConfig::MODS_TAB);
+				setRequestedGameState(config);
 
 				prompt_select_mods->visible = false;
 				prompt_select_mods->clicked_confirm = false;

--- a/src/GameStateTitle.cpp
+++ b/src/GameStateTitle.cpp
@@ -27,6 +27,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "GameStateTitle.h"
 #include "InputState.h"
 #include "MenuMovementType.h"
+#include "MenuConfirm.h"
 #include "MessageEngine.h"
 #include "Platform.h"
 #include "RenderDevice.h"
@@ -34,6 +35,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "SharedResources.h"
 #include "SoundManager.h"
 #include "WidgetButton.h"
+#include "WidgetHorizontalList.h"
 #include "WidgetLabel.h"
 #include "UtilsMath.h"
 #include "UtilsParsing.h"
@@ -104,10 +106,6 @@ GameStateTitle::GameStateTitle()
 	}
 
 	button_play->setLabel(msg->get("Play Game"));
-	if (!eset->gameplay.enable_playgame) {
-		button_play->enabled = false;
-		button_play->tooltip = msg->get("Enable a core mod to continue");
-	}
 	button_play->refresh();
 
 	button_cfg->setLabel(msg->get("Configuration"));
@@ -130,6 +128,11 @@ GameStateTitle::GameStateTitle()
 	tablist.add(button_credits);
 	tablist.add(button_exit);
 
+	// Core mod not selected dialogue
+	prompt_select_mods = new MenuConfirm();
+	prompt_select_mods->setTitle(msg->get("Enable a core mod to continue"));
+	prompt_select_mods->action_list->append(msg->get("Mods"), msg->get("You will be taken to the mod configuration"));
+
 	refreshWidgets();
 	force_refresh_background = true;
 
@@ -146,13 +149,12 @@ GameStateTitle::GameStateTitle()
 		menu_movement_type = new MenuMovementType();
 		menu_movement_type->visible = true;
 	}
+
 }
 
 void GameStateTitle::logic() {
 	if (inpt->window_resized)
 		refreshWidgets();
-
-	button_play->enabled = eset->gameplay.enable_playgame;
 
 	snd->logic(FPoint(0,0));
 
@@ -164,6 +166,16 @@ void GameStateTitle::logic() {
 	if (menu_movement_type && menu_movement_type->visible) {
 		menu_movement_type->logic();
 	}
+	else if (prompt_select_mods && prompt_select_mods->visible) {
+		prompt_select_mods->logic();
+		if (prompt_select_mods->clicked_confirm) {
+			showLoading();
+			setRequestedGameState(new GameStateConfig());
+
+			prompt_select_mods->visible = false;
+			prompt_select_mods->clicked_confirm = false;
+		}
+	}
 	else {
 		tablist.logic();
 
@@ -171,7 +183,10 @@ void GameStateTitle::logic() {
 			tablist.getNext(!TabList::GET_INNER, TabList::WIDGET_SELECT_AUTO);
 		}
 
-		if (button_play->checkClick()) {
+		if (button_play->checkClick() && !eset->gameplay.enable_playgame) {
+			prompt_select_mods->show();
+		}
+		else if (button_play->checkClick()) {
 			showLoading();
 			setRequestedGameState(new GameStateLoad());
 		}
@@ -196,6 +211,7 @@ void GameStateTitle::logic() {
 			exitRequested = true;
 		}
 	}
+
 }
 
 void GameStateTitle::refreshWidgets() {
@@ -218,6 +234,8 @@ void GameStateTitle::refreshWidgets() {
 
 	if (menu_movement_type)
 		menu_movement_type->align();
+	if (prompt_select_mods)
+		prompt_select_mods->align();
 }
 
 void GameStateTitle::render() {
@@ -229,6 +247,9 @@ void GameStateTitle::render() {
 		button_play->render();
 		button_cfg->render();
 		button_credits->render();
+
+		if (prompt_select_mods && prompt_select_mods->visible)
+			prompt_select_mods->render();
 
 		if (platform.has_exit_button)
 			button_exit->render();
@@ -249,4 +270,5 @@ GameStateTitle::~GameStateTitle() {
 	delete button_exit;
 	delete label_version;
 	delete menu_movement_type;
+	if (prompt_select_mods) delete prompt_select_mods;
 }

--- a/src/GameStateTitle.cpp
+++ b/src/GameStateTitle.cpp
@@ -179,14 +179,16 @@ void GameStateTitle::logic() {
 	else {
 		tablist.logic();
 
+		bool play_clicked = button_play->checkClick();
+
 		if (!inpt->usingMouse() && tablist.getCurrent() == -1) {
 			tablist.getNext(!TabList::GET_INNER, TabList::WIDGET_SELECT_AUTO);
 		}
 
-		if (button_play->checkClick() && !eset->gameplay.enable_playgame) {
+		if (play_clicked && !eset->gameplay.enable_playgame) {
 			prompt_select_mods->show();
 		}
-		else if (button_play->checkClick()) {
+		else if (play_clicked) {
 			showLoading();
 			setRequestedGameState(new GameStateLoad());
 		}

--- a/src/GameStateTitle.h
+++ b/src/GameStateTitle.h
@@ -26,6 +26,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 class MenuMovementType;
 class WidgetButton;
 class WidgetLabel;
+class MenuConfirm;
 
 class GameStateTitle : public GameState {
 private:
@@ -38,6 +39,7 @@ private:
 	WidgetButton *button_credits;
 	WidgetLabel *label_version;
 	MenuMovementType *menu_movement_type;
+	MenuConfirm *prompt_select_mods; // Nag dialogue when core mod is not selected
 
 	TabList tablist;
 

--- a/src/GameStateTitle.h
+++ b/src/GameStateTitle.h
@@ -30,6 +30,11 @@ class MenuConfirm;
 
 class GameStateTitle : public GameState {
 private:
+	enum {
+		PROMPT_SELECT_MODS_OK = 0,
+		PROMPT_SELECT_MODS_CANCEL = 1,
+	};
+
 	void refreshWidgets();
 
 	Sprite *logo;

--- a/src/MenuConfig.cpp
+++ b/src/MenuConfig.cpp
@@ -1733,6 +1733,14 @@ void MenuConfig::resetSelectedTab() {
 	keybind_tip_timer.reset(Timer::END);
 }
 
+int MenuConfig::getActiveTab() {
+	return tab_control->getActiveTab();
+}
+
+void MenuConfig::setActiveTab(unsigned tab) {
+	tab_control->setActiveTab(tab);
+}
+
 void MenuConfig::cleanup() {
 	if (background) {
 		delete background;

--- a/src/MenuConfig.h
+++ b/src/MenuConfig.h
@@ -165,6 +165,8 @@ public:
 	void setPauseExitText(bool enable_save);
 	void setPauseSaveEnabled(bool enable_save);
 	void resetSelectedTab();
+	int getActiveTab();
+	void setActiveTab(unsigned tab);
 
 	void confirmKey(int action);
 	void scanKey(int action);


### PR DESCRIPTION
#1828   When no core mods are selected the Play button will open a dialogue with option to go to mod selection.  MenuConfig and GameStateConfig now have public setters for the active tab.