### PR TITLE
Remove unnecessary #pragma once

### DIFF
--- a/src/CommonIncludes.h
+++ b/src/CommonIncludes.h
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License along with
 FLARE.  If not, see http://www.gnu.org/licenses/
 */
 
-#pragma once
 #ifndef COMMON_INCLUDES_H
 #define COMMON_INCLUDES_H
 


### PR DESCRIPTION
In the C and C++ programming languages, #pragma once is a non-standard but widely supported preprocessor directive designed to cause the current source file to be included only once in a single compilation. #pragma once is unnecessary due to the include guards.