### PR TITLE
docs: update engine documentation links

### DIFF
--- a/INSTALL.engine.md
+++ b/INSTALL.engine.md
@@ -15,7 +15,7 @@ if you do not wish to [install Flare system-wide](#install_system_wide).
 ```sh
 git clone https://github.com/flareteam/flare-engine.git # clone the latest source code
 git clone https://github.com/flareteam/flare-game.git # and game data
-# remember your dependancies(see below)
+# remember your dependencies (see below)
 cd flare-engine
 cmake .
 make # build the executable
@@ -43,8 +43,8 @@ To build Flare you need the [2.0 Development Libraries for SDL][libsdl]:
 SDL\_image, SDL\_mixer, and SDL\_ttf, with the equivalent [2.0 Runtime Libraries][runtimesdl] to run the game;
 or follow the steps below for your Operating System of choice.
 
-[libsdl]: http://www.libsdl.org/download-2.0.php
-[runtimesdl]: http://www.libsdl.org/download-2.0.php
+[libsdl]: https://www.libsdl.org/download-2.0.php
+[runtimesdl]: https://www.libsdl.org/download-2.0.php
 
 ### Arch Linux
 
@@ -101,7 +101,7 @@ Installing dependencies using [Homebrew]:
 brew install cmake libvorbis sdl2 sdl2_image sdl2_mixer sdl2_ttf
 ```
 
-[Homebrew]: http://brew.sh/
+[Homebrew]: https://brew.sh/
 
 ### Windows
 

--- a/README.engine.md
+++ b/README.engine.md
@@ -13,7 +13,7 @@ The Flare engine, which is purely a runtime, is written in C++.
 
 Flare uses simple file formats (INI-style config files) for most of the game data,
 allowing anyone to easily modify game contents. Open formats are preferred (png, ogg).
-For creating maps, we also support [Tiled](http://www.mapeditor.org/) with the Flare plugin.
+For creating maps, we support [Tiled](https://www.mapeditor.org/) with the [Flare Tiled Tools](https://github.com/flareteam/flare-tiled-tools).
 
 Originally the first game to be developed using this engine was part of this
 repository. As the engine became mature, the game content was moved to an
@@ -44,7 +44,7 @@ The GNU Unifont font is released under GPL v2, with the exception that embedding
 
 The following links are specific to the engine
 
-* [Homepage](http://flarerpg.org)
+* [Homepage](https://flarerpg.org)
 * [Source](https://github.com/flareteam/flare-engine)
 * [Forums](https://github.com/flareteam/flare-game/discussions)
 * Email     clintbellanger@gmail.com


### PR DESCRIPTION
## Summary

- Update Tiled and project website links to HTTPS.
- Point the map editing note at the current `flare-tiled-tools` repository.
- Fix a small typo in the build instructions.

## Testing

- Ran `git diff --check`
- Checked the updated external links return HTTP 200
- Ran `cmake -S . -B /tmp/flare-engine-docs-verify`; configuration reached dependency detection and stopped because SDL2 development libraries are not installed in this environment
