### PR TITLE
docs: use HTTPS for flare website link in generated docs

### DIFF
--- a/docs/attribute-reference.html
+++ b/docs/attribute-reference.html
@@ -2669,7 +2669,7 @@ code {
 <div class="footer">
 <hr/>
 <p>
-<a href="http://flarerpg.org/">FLARE Website</a>
+<a href="https://flarerpg.org/">FLARE Website</a>
 </p>
 </div>
 

--- a/docs/code-conventions.html
+++ b/docs/code-conventions.html
@@ -103,7 +103,7 @@ code {
 <div class="footer">
 <hr/>
 <p>
-<a href="http://flarerpg.org/">FLARE Website</a>
+<a href="https://flarerpg.org/">FLARE Website</a>
 </p>
 </div>
 

--- a/docs/gen/footer.txt
+++ b/docs/gen/footer.txt
@@ -4,7 +4,7 @@
 <div class="footer">
 <hr/>
 <p>
-<a href="http://flarerpg.org/">FLARE Website</a>
+<a href="https://flarerpg.org/">FLARE Website</a>
 </p>
 </div>
 

--- a/docs/translations.html
+++ b/docs/translations.html
@@ -131,7 +131,7 @@ msgstr "Felicitaciones, has alcanzado el nivel %d!"
 <div class="footer">
 <hr/>
 <p>
-<a href="http://flarerpg.org/">FLARE Website</a>
+<a href="https://flarerpg.org/">FLARE Website</a>
 </p>
 </div>
 


### PR DESCRIPTION
## Summary

- Update `http://flarerpg.org/` to `https://flarerpg.org/` in `docs/gen/footer.txt` (source template)
- Update the same link in the three generated HTML docs that use the template:
  - `docs/attribute-reference.html`
  - `docs/code-conventions.html`
  - `docs/translations.html`

No other links changed. W3C namespace/DTD URLs in `header.txt` are left as-is (they are identifiers, not navigational links).

## Testing

- Ran `git diff --check`
- Verified each file still uses CRLF line endings
- Verified `https://flarerpg.org/` returns HTTP 200
