### PR TITLE
docs: update translation tool links

### DIFF
--- a/docs/translations.html
+++ b/docs/translations.html
@@ -119,10 +119,10 @@ msgstr "Felicitaciones, has alcanzado el nivel %d!"
 <p>Here is a list of .po file editing tools, if you don't want to use a plain text editor.</p>
 
 <ul>
-<li><a href="http://www.poedit.net/">Poedit</a> - simple cross-platform editor of gettext catalogs.</li>
-<li><a href="http://translate.sourceforge.net/wiki/virtaal/index">Virtaal</a> - easy translation tool that supports many localization formats.</li>
-<li><a href="http://projects.gnome.org/gtranslator/">GTranslator</a> - powerful translation tool integrated with GNOME desktop.</li>
-<li><a href="http://www.kde.org/applications/development/lokalize/">Lokalize</a> - editor of gettext catalogs integrated with KDE desktop.</li>
+<li><a href="https://poedit.com/">Poedit</a> - simple cross-platform editor of gettext catalogs.</li>
+<li><a href="https://github.com/translate/virtaal">Virtaal</a> - easy translation tool that supports many localization formats.</li>
+<li><a href="https://wiki.gnome.org/Apps/Gtranslator">GTranslator</a> - powerful translation tool integrated with GNOME desktop.</li>
+<li><a href="https://apps.kde.org/lokalize/">Lokalize</a> - editor of gettext catalogs integrated with KDE desktop.</li>
 </ul>
 
 


### PR DESCRIPTION
## Summary

Update the translation tool links in `docs/translations.html` to their current HTTPS URLs:

| Tool | Old URL | New URL |
|------|---------|---------|
| Poedit | `http://www.poedit.net/` | `https://poedit.com/` |
| Virtaal | `http://translate.sourceforge.net/wiki/virtaal/index` (broken, returns 404) | `https://github.com/translate/virtaal` |
| GTranslator | `http://projects.gnome.org/gtranslator/` | `https://wiki.gnome.org/Apps/Gtranslator` |
| Lokalize | `http://www.kde.org/applications/development/lokalize/` | `https://apps.kde.org/lokalize/` |

The old Virtaal link was a dead page (301 to sourceforge.io, then 404). The GitHub repo is the active project home.

## Testing

- Ran `git diff --check`
- Verified each new URL returns HTTP 200
