### PR TITLE
docs: update dead MinGW link to MSYS2

### DIFF
--- a/INSTALL.engine.md
+++ b/INSTALL.engine.md
@@ -196,7 +196,7 @@ g++ -I /usr/include/SDL src/*.cpp -o flare -lSDL2 -lSDL2_image -lSDL2_mixer -lSD
 g++ -I C:\MinGW\include\SDL src\*.cpp -o flare.exe -lmingw32 -lSDLmain -lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf
 ```
 
-[MinGW]: http://www.mingw.org/
+[MinGW]: https://www.msys2.org/
 
 ## Optimizing your build
 


### PR DESCRIPTION
## Summary

- Update the `[MinGW]` link reference in `INSTALL.engine.md` from `http://www.mingw.org/` (dead, returns empty response) to `https://www.msys2.org/`

The project already recommends MSYS2 as the official Windows development environment. The old MinGW.org site is effectively dead.

## Testing

- Ran `git diff --check`
- Verified CRLF line endings preserved
- Verified `https://www.msys2.org/` returns HTTP 200
