### PR TITLE
docs: update OSX to macOS

### DIFF
--- a/Codingstyle.txt
+++ b/Codingstyle.txt
@@ -25,7 +25,7 @@ is all combined I have to reject the entire thing.
 
 ## Cross-platform considerations
 
-To the best of our ability, we want the code to work on Windows, OSX, Linux and more.
+To the best of our ability, we want the code to work on Windows, macOS, Linux and more.
 We try to isolate platform-specific code and use C preprocessor directives when necessary.
 
 ## OOP as a last resort

--- a/docs/code-conventions.html
+++ b/docs/code-conventions.html
@@ -58,7 +58,7 @@ code {
 
 <h2>Cross-platform considerations</h2>
 
-<p>To the best of our ability, we want the code to work on Windows, OSX, Linux and more. We try to isolate platform-specific code and use C preprocessor directives when necessary.</p>
+<p>To the best of our ability, we want the code to work on Windows, macOS, Linux and more. We try to isolate platform-specific code and use C preprocessor directives when necessary.</p>
 
 <h2>OOP as a last resort</h2>
 


### PR DESCRIPTION
## Summary

- Update "OSX" to "macOS" in `Codingstyle.txt` and `docs/code-conventions.html`

Apple rebranded OS X to macOS in 2016. The `flare-ios-project/README.md` reference to "MacOSX 10.9.5" is left as-is since it refers to a specific historical version.

## Testing

- Ran `git diff --check`
- Verified CRLF line endings preserved
