### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+
+[*.{cpp,h}]
+indent_style = tab
+indent_size = 4
+
+[*.{md,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[CMakeLists.txt]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary

- Add a root `.editorconfig` consistent with the project's existing coding style
- C++ files: tabs (matching the existing source and `Codingstyle.txt`)
- Markdown/YAML/CMake: spaces
- Global: UTF-8, CRLF line endings, final newline

This is the same approach as the `.editorconfig` already accepted in flare-game.

## Testing

- Ran `git diff --check`
- Verified `.editorconfig` starts with `root = true`
- Verified CRLF rule and tab rule for C++ match existing source files
