### PR TITLE
docs: update OS X references to macOS

### DIFF
--- a/INSTALL.engine.md
+++ b/INSTALL.engine.md
@@ -93,7 +93,7 @@ There is also a flare build at the [openSUSE games repo][suse_repo].
 
 [suse_repo]: https://software.opensuse.org/package/flare
 
-### OS X
+### macOS
 
 Installing dependencies using [Homebrew]:
 

--- a/README.engine.md
+++ b/README.engine.md
@@ -62,7 +62,7 @@ Flare uses SDL2, SDL2\_image, SDL2\_mixer, and SDL2\_ttf. Please see the [INSTAL
 
 Settings are stored in one of these places:
 
-### Linux/Mac OS X/Unix
+### Linux/macOS/Unix
     $XDG_CONFIG_HOME/flare/
     $HOME/.config/flare/
     ./config
@@ -81,7 +81,7 @@ The settings files are created the first time you run Flare.
 
 Save files are stored in one of these places:
 
-### Linux/Mac OS X/Unix
+### Linux/macOS/Unix
     $XDG_DATA_HOME/flare/
     $HOME/.local/share/flare/
     ./userdata


### PR DESCRIPTION
## Summary

- Update "Mac OS X" to "macOS" in `README.engine.md` (2 occurrences in section headers)
- Update "OS X" to "macOS" in `INSTALL.engine.md` (1 section header)

Follows the naming already accepted in #1933.

## Testing

- Ran `git diff --check`
- Verified CRLF line endings preserved
