### PR TITLE
chore: remove stale Travis CI reference in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ add_compile_options(
 )
 
 # Not supported by CMake 3.12!
-# Travis uses this version so we have to stick to modifying the strings...
+# Not supported by CMake < 3.13, so we have to stick to modifying the strings...
 # add_link_options(
 # 	"$<$<CONFIG:DEBUG>:-pg>"
 # )


### PR DESCRIPTION
## Summary

- Update the comment on line 47 of `CMakeLists.txt` that referenced Travis CI

The old comment said "Travis uses this version" when explaining why `add_link_options` is commented out. Since Travis was removed in #1930, the comment now just explains the CMake version constraint (< 3.13).

## Testing

- Ran `git diff --check`
- Verified CRLF line endings preserved
