### PR TITLE
chore: remove stale .travis.yml from gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,6 @@
 astyle_flare.sh export-ignore
 
 # related to coding and testing
-.travis.yml export-ignore
 qt.xml export-ignore
 
 # do not export the language recreation script


### PR DESCRIPTION
## Summary

- Remove the `.travis.yml export-ignore` line from `.gitattributes`

The `.travis.yml` file was removed in #1930. The `export-ignore` rule for a nonexistent file is dead config.

## Testing

- Ran `git diff --check`
- Verified CRLF line endings preserved
